### PR TITLE
Specify explicit version for apache-rat-plugin

### DIFF
--- a/aurora4spark-parent/aurora4spark-sql-plugin/pom.xml
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/pom.xml
@@ -107,6 +107,7 @@
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
+                <version>0.13</version>
                 <configuration>
                     <excludes>
                         <exclude>dependency-reduced-pom.xml</exclude>


### PR DESCRIPTION
Due to being unable to import it IntelliJ without it.