### PR TITLE
Plugin version not set for Apache Rat Maven plugin

### DIFF
--- a/aurora4spark-parent/aurora4spark-sql-plugin/pom.xml
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/pom.xml
@@ -107,6 +107,7 @@
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
+                <version>0.13</version>
                 <configuration>
                     <excludes>
                         <exclude>dependency-reduced-pom.xml</exclude>


### PR DESCRIPTION
Hi, just noticed the first one was a merge commit , just for cleanliness sake let's try again

![2021-04-17 01_50_49-Window](https://user-images.githubusercontent.com/52247468/115096989-91920300-9f1f-11eb-9815-402502f0c1be.png)

Let's try this one again
![image](https://user-images.githubusercontent.com/52247468/115096996-9a82d480-9f1f-11eb-97ce-572110ac5bd9.png)

If the button is not enabled we need to ask Eduardo to enable it & possibly disable the Merge-commit button completely (possible in GH)