### PR TITLE
Invoke the pure-Python script as well

### DIFF
--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/BigDecimalSummer.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/BigDecimalSummer.scala
@@ -37,4 +37,9 @@ object BigDecimalSummer {
       BundleExecutor.returningBigDecimal.executeBundle(Bundle.sumBigDecimals(nums))
   }
 
+  object BundleNecSSHSummerPurePython extends BigDecimalSummer {
+    override def sum(nums: List[BigDecimal]): BigDecimal =
+      BundleExecutor.returningBigDecimal.executeBundle(Bundle.sumBigDecimalsPurePython(nums))
+  }
+
 }

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/Bundle.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/Bundle.scala
@@ -7,6 +7,45 @@ trait Bundle {
 }
 
 object Bundle {
+  val envVars = List(
+    "ASL_HOME" -> "/opt/nec/ve/nlc/2.1.0",
+    "ASL_LIB_I64" -> "0",
+    "ASL_LIB_MPI" -> "0",
+    "LD_LIBRARY_PATH" -> "/opt/nec/ve/nlc/2.1.0/lib",
+    "NCC_INCLUDE_PATH" -> "/opt/nec/ve/nlc/2.1.0/include/inc:/opt/nec/ve/nlc/2.1.0/include",
+    "NFORT_INCLUDE_PATH" -> "/opt/nec/ve/nlc/2.1.0/include/mod:/opt/nec/ve/nlc/2.1.0/include",
+    "NLC_HOME" -> "/opt/nec/ve/nlc/2.1.0",
+    "NLC_LIB_I64" -> "0",
+    "NLC_LIB_MPI" -> "0",
+    "NLC_VERSION" -> "2.1.0",
+    "VE_LD_LIBRARY_PATH" -> "/opt/nec/ve/nlc/2.1.0/lib",
+    "VE_LIBRARY_PATH" -> "/opt/nec/ve/nlc/2.1.0/lib",
+    "VE_NLC_STATIC_LIBRARY_PATH" -> "/opt/nec/ve/nlc/2.1.0/lib"
+  )
+
+  def envs: String = envVars
+    .map { case (k, v) =>
+      s"""os.environ["${k}"] = "${v}""""
+    }
+    .toList
+    .mkString("\n")
+
+  def sumBigDecimalsPurePython(nums: List[BigDecimal]): Bundle = new Bundle {
+    override def asPythonScript: String = {
+      s"""
+         |
+         |import os
+         |
+         |${envs}
+         |
+         |import nlcpy
+         |import sys
+         |numbers = [${nums.map(_.toBigInt().toString()).mkString(", ")}]
+         |print(int(nlcpy.sum(numbers)))
+         |""".stripMargin
+    }
+  }
+
   def sumBigDecimals(numbers: List[BigDecimal]): Bundle = new Bundle {
     // todo use actual numbers
     def asPythonScript: String = new String(

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/BundleExecutorSpec.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/BundleExecutorSpec.scala
@@ -25,4 +25,11 @@ final class BundleExecutorSpec extends AnyFreeSpec {
         .executeBundle(Bundle.sumBigDecimals(List(1, 2, 3, 4))) == BigDecimal(10)
     )
   }
+
+  "We can run our bundle of sums in pure Python and it returns the expected output" taggedAs AcceptanceTest in {
+    assert(
+      BundleExecutor.returningBigDecimal
+        .executeBundle(Bundle.sumBigDecimalsPurePython(List(1, 2, 3, 4))) == BigDecimal(10)
+    )
+  }
 }


### PR DESCRIPTION
We are using the env vars from the sourced script; later we can get these values dynamically by diffing the output of `export` directly from the server.