### PR TITLE
Update READMEs & set up SBT in the sub-directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,5 @@ target
 # Intelij gitignore things
 .idea
 *.iml
+.bsp
+/hadoop-*

--- a/README.md
+++ b/README.md
@@ -1,20 +1,4 @@
 # aurora4spark
 
-Requirements:
-- Maven
-- Hadoop
-- JDK 8+
+Spark Plugin documentation: [aurora4spark-parent/README.md](aurora4spark-parent/README.md).
 
-## Development workflow
-
-- Unit test: `mvn test`
-- Unit test + scalastyle: `mvn verify`
-- Integration/Acceptance test + unit test: `mvn verify -DskipIntegrationTests=false`
-- Integration/Acceptance test w/o unit tests: `mvn verify -DskipUnitTests=true -DskipIntegrationTests=false`
-- Run specific integration test: `mvn integration-test '-DwildcardSuites=com.nec.spark.agile.BigDecimalSummerSpec' '-DskipIntegrationTests=false'`
-- Scalafmt auto-formatting: `mvn mvn-scalafmt_2.12:format`
-
-### Collaboration
-
-- Make a PR -> Reviewer approves & if happy, merges with rebase
-- Aim for 1 commit per distinct feature

--- a/aurora4spark-parent/README.md
+++ b/aurora4spark-parent/README.md
@@ -1,0 +1,28 @@
+# aurora4spark
+
+Requirements:
+- Maven
+- Hadoop
+- JDK 8
+
+## Development workflow
+
+Like Spark, we separate development workflow from general building.
+
+For development workflow with SBT, go to: [aurora4spark-sql-plugin/README.md](aurora4spark-sql-plugin/README.md). SBT is used because of faster turnaround times in TDD.
+
+Nonetheless, these are the relevant options in Maven:
+
+- Unit test: `mvn test`
+- Unit test + scalastyle: `mvn verify`
+- Integration/Acceptance test + unit test: `mvn verify -DskipIntegrationTests=false`
+- Integration/Acceptance test w/o unit tests: `mvn verify -DskipUnitTests=true -DskipIntegrationTests=false`
+- Run specific integration test: `mvn integration-test '-DwildcardSuites=com.nec.spark.agile.BigDecimalSummerSpec' '-DskipIntegrationTests=false'`
+- Scalafmt auto-formatting: `mvn mvn-scalafmt_2.12:format`
+
+
+### Collaboration
+
+- Make a PR -> Reviewer approves & if happy, merges with rebase
+- Aim for 1 commit per distinct feature
+

--- a/aurora4spark-parent/aurora4spark-sql-plugin/.scalafmt.conf
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/.scalafmt.conf
@@ -1,0 +1,19 @@
+version = "2.7.5"
+
+preset=IntelliJ
+maxColumn=100
+# If true, the margin character | is aligned with the opening triple quote string literals
+assumeStandardLibraryStripMargin = true
+
+continuationIndent {
+  callSite = 2
+  defnSite = 2
+  extendSite = 2
+}
+spaces.afterKeywordBeforeParen = true
+newlines.avoidForSimpleOverflow = []
+importSelectors = "noBinPack"
+rewrite.rules = [SortImports]
+docstrings.style = Asterisk
+comments.wrap = trailing
+docstrings.wrap = yes

--- a/aurora4spark-parent/aurora4spark-sql-plugin/README.md
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/README.md
@@ -1,0 +1,22 @@
+# aurora4spark-sql-plugin
+
+Requirements:
+- SBT
+- Hadoop
+- JDK 8
+
+## Development workflow
+
+Within sbt:
+
+- Unit tests: `~testQuick`
+- Acceptance tests: `~ AcceptanceTest / testQuick` (or `Acc`)
+- Run once: `Acc/test`
+- Run a specific unit test suite: `~ testOnly *SuiteName*`
+- Scalafmt format: `fmt`
+- Check before committing: `check` (checks scalafmt and runs any outstanding unit tests)
+
+### Faster testing over SSH (around 40%) & general log-in to any SSH server
+
+https://docs.rackspace.com/blog/speeding-up-ssh-session-creation/
+

--- a/aurora4spark-parent/aurora4spark-sql-plugin/build.sbt
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/build.sbt
@@ -1,0 +1,38 @@
+/**
+ * For fast development purposes, similar to how Spark project does it. Maven's compilation cycles
+ * are very slow
+ */
+val sparkVersion = "3.1.1"
+ThisBuild / scalaVersion := "2.12.13"
+val orcVversion = "1.5.8"
+val slf4jVersion = "1.7.30"
+libraryDependencies ++= Seq(
+  "org.slf4j" % "jul-to-slf4j" % slf4jVersion,
+  "org.slf4j" % "jcl-over-slf4j" % slf4jVersion,
+  "org.apache.spark" %% "spark-hive" % sparkVersion,
+  "org.apache.spark" %% "spark-sql" % sparkVersion,
+  "org.apache.spark" %% "spark-catalyst" % sparkVersion,
+  "org.scalatest" %% "scalatest" % "3.2.7" % "test,acc"
+)
+Test / parallelExecution := false
+
+lazy val AcceptanceTest = config("acc") extend Test
+configs(AcceptanceTest)
+inConfig(AcceptanceTest)(Defaults.testTasks)
+
+/** Acceptance tests basically run against external/SSH/etc */
+val AcceptanceTestTag = "com.nec.spark.AcceptanceTest"
+val excludeAcceptanceTestOption = Tests.Argument("-l", AcceptanceTestTag)
+val includeAcceptanceTestOption = Tests.Argument("-n", AcceptanceTestTag)
+Test / testOptions += excludeAcceptanceTestOption
+AcceptanceTest / testOptions := (AcceptanceTest / testOptions).value.map {
+  case `excludeAcceptanceTestOption` => includeAcceptanceTestOption
+  case other                         => other
+}
+
+/** in SBT, run: AcceptanceTest / test; Test / test * */
+
+Global / onChangedBuildSource := ReloadOnSourceChanges
+
+addCommandAlias("check", ";scalafmtCheck;scalafmtSbtCheck;testQuick")
+addCommandAlias("fmt", ";scalafmtSbt;scalafmtAll")

--- a/aurora4spark-parent/aurora4spark-sql-plugin/project/build.properties
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.0

--- a/aurora4spark-parent/aurora4spark-sql-plugin/project/plugins.sbt
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/Bundle.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/Bundle.scala
@@ -46,7 +46,6 @@ object Bundle {
   }
 
   def sumBigDecimals(numbers: List[BigDecimal]): Bundle = new Bundle {
-    // todo use actual numbers
     def asPythonScript: String = {
       val script = new String(Files.readAllBytes(Paths.get(getClass.getResource("/sum.py").toURI)))
 
@@ -55,4 +54,4 @@ object Bundle {
       full
     }
   }
-}8
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/resources/sum.py
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/resources/sum.py
@@ -27,16 +27,6 @@ lib.sum.args_type(b"double*", "int")
 lib.sum.ret_type("double")
 np = veo.np
 
-numbers = []
-
-for arg in sys.argv[1:]:
-    try:
-        number = float(arg)
-        numbers.append(number)
-    except:
-        print("Provided argument is not a number {}".format(arg))
-        exit(1)
-
 np_numbers = np.array(numbers)
 a_ve = proc.alloc_mem(len(numbers) * 8)
 proc.write_mem(a_ve, np_numbers, len(numbers) * 8)


### PR DESCRIPTION
Maven vs SBT for me is a difference of around 2-3x development speed because of TDD and compile times.

Isolating it to the very specific subproject; we will still continue to use Maven for the outer layer for ease of access.

READMEs: better to segregate to avoid noise from different places.

Also saw a test failure from Py script, fixed it