### PR TITLE
Support AVG()

### DIFF
--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/AveragingPlanner.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/AveragingPlanner.scala
@@ -1,0 +1,41 @@
+package com.nec.spark.agile
+
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Average}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.aggregate.HashAggregateExec
+
+/**
+ * Basic SparkPlan matcher that will match a plan that averages a bunch of numbers.
+ */
+object AveragingPlanner {
+  def matchPlan(sparkPlan: SparkPlan): Option[SparkPlan] = {
+    PartialFunction
+      .condOpt(sparkPlan) {
+        case first @ HashAggregateExec(
+              requiredChildDistributionExpressions,
+              groupingExpressions,
+              List(AggregateExpression(Average(_), _, _, _, _)),
+              aggregateAttributes,
+              initialInputBufferOffset,
+              resultExpressions,
+              org.apache.spark.sql.execution.exchange
+                .ShuffleExchangeExec(
+                  outputPartitioning,
+                  org.apache.spark.sql.execution.aggregate
+                    .HashAggregateExec(
+                      _requiredChildDistributionExpressions,
+                      _groupingExpressions,
+                      _aggregateExpressions,
+                      _aggregateAttributes,
+                      _initialInputBufferOffset,
+                      _resultExpressions,
+                      fourth
+                    ),
+                  shuffleOrigin
+                )
+            ) =>
+          fourth
+      }
+  }
+
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/AveragingSparkPlan.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/AveragingSparkPlan.scala
@@ -1,0 +1,52 @@
+package com.nec.spark.agile
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.SparkPlan
+
+object AveragingSparkPlan {
+
+  val averageRemote: List[Double] => Double = l =>
+    BundleExecutor.returningBigDecimal
+      .executeBundle(Bundle.avgBigDecimals(l.map(double => BigDecimal(double))))
+      .toDouble
+
+  val averageLocal: List[Double] => Double = l => if (l.nonEmpty) l.sum / l.size else 0
+
+  /** Coalesces all the data into one partition, and then averages it lazily */
+  def averagingRdd(parentRdd: RDD[Double], f: List[Double] => Double): RDD[Double] =
+    parentRdd
+      .coalesce(1)
+      .mapPartitions(its => Iterator(f(its.toList)))
+}
+
+final case class AveragingSparkPlan(child: SparkPlan, f: List[Double] => Double) extends SparkPlan {
+
+  def computeBD(): RDD[Double] = AveragingSparkPlan
+    .averagingRdd(
+      child
+        .execute()
+        .map(_.getDouble(0)),
+      f
+    )
+
+  /**
+   * Extracts the first element, passes through our RDD and then creates another InternalRow RDD in
+   * return.
+   */
+  override protected def doExecute(): RDD[InternalRow] =
+    computeBD()
+      .map(bd =>
+        ExpressionEncoder[Double]
+          .createSerializer()
+          .apply(bd)
+      )
+
+  private[agile] def compute(): RDD[InternalRow] = doExecute()
+
+  override def output: Seq[Attribute] = Seq(child.output.head)
+
+  override def children: Seq[SparkPlan] = Seq(child)
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/Bundle.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/Bundle.scala
@@ -54,4 +54,13 @@ object Bundle {
       full
     }
   }
+
+  def avgBigDecimals(numbers: List[BigDecimal]): Bundle = new Bundle {
+    def asPythonScript: String = {
+      val script = new String(Files.readAllBytes(Paths.get(getClass.getResource("/avg.py").toURI)))
+
+      val numbersDeclaration = s"numbers = [${numbers.map(_.toFloat.toString).mkString(", ")}] \n"
+      numbersDeclaration ++ script
+    }
+  }
 }

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/SingleValueStubPlan.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/SingleValueStubPlan.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.execution.{LocalTableScanExec, SparkPlan}
 import org.apache.spark.sql.types.DecimalType
 
 object SingleValueStubPlan {
-  private val SparkDefaultColumnName = "value"
+  val SparkDefaultColumnName = "value"
 
   val NumDecimalType = DecimalType.SYSTEM_DEFAULT
 

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/SumPlanExtractor.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/SumPlanExtractor.scala
@@ -1,6 +1,7 @@
 package com.nec.spark.agile
 
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Sum}
 import org.apache.spark.sql.execution.{LocalTableScanExec, SparkPlan}
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.types.{Decimal, DecimalType}
@@ -33,7 +34,7 @@ object SumPlanExtractor {
       case first @ HashAggregateExec(
             requiredChildDistributionExpressions,
             groupingExpressions,
-            aggregateExpressions,
+            Seq(AggregateExpression(Sum(_), _, _, _, _)),
             aggregateAttributes,
             initialInputBufferOffset,
             resultExpressions,

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/resources/avg.py
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/resources/avg.py
@@ -1,0 +1,41 @@
+from nlcpy import veo
+import os
+import sys
+
+nodeid = os.environ.get("VE_NODE_NUMBER", 0)
+bld = veo.VeBuild()
+bld.set_build_dir("_ve_build")
+bld.set_c_src("_sum", r"""
+
+double avg(double *a, int n)
+{
+    int i;
+    if ( n == 0 ) {
+        return 0;
+    }
+    double sum = 0;
+    for (i = 0; i < n; i++) {
+        sum += a[i] / n;
+    }
+    return sum;
+}""")
+
+ve_so_name = bld.build_so()
+
+proc = veo.VeoAlloc().proc
+ctxt = proc.open_context()
+lib = proc.load_library((os.getcwd() + "/" + ve_so_name).encode("UTF-8"))
+lib.avg.args_type(b"double*", "int")
+lib.avg.ret_type("double")
+np = veo.np
+
+np_numbers = np.array(numbers)
+a_ve = proc.alloc_mem(len(numbers) * 8)
+proc.write_mem(a_ve, np_numbers, len(numbers) * 8)
+req = lib.avg(ctxt, a_ve, len(numbers))
+avg = req.wait_result()
+
+print(avg)
+
+proc.free_mem(a_ve)
+del proc

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/AveragingSparkPlanSpec.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/AveragingSparkPlanSpec.scala
@@ -1,0 +1,24 @@
+package com.nec.spark.agile
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+
+final class AveragingSparkPlanSpec extends AnyFreeSpec {
+  "We can average a general RDD" in {
+    val conf = new SparkConf()
+    conf.setMaster("local")
+    conf.set("spark.ui.enabled", "false")
+    conf.setAppName("local-test")
+    val sparkSession = SparkSession.builder().config(conf).getOrCreate()
+    try {
+      import sparkSession.implicits._
+      val result =
+        AveragingSparkPlan
+          .averagingRdd(Seq[Double](100, 200).toDS().rdd, AveragingSparkPlan.averageLocal)
+          .collect()
+          .head
+      assert(result == 150d)
+    } finally sparkSession.close()
+  }
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/BundleExecutorSpec.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/BundleExecutorSpec.scala
@@ -35,4 +35,21 @@ final class BundleExecutorSpec extends AnyFreeSpec {
           .executeBundle(Bundle.sumBigDecimalsPurePython(List(1, 2, 3, 4))) == BigDecimal(10)
       )
     }
+
+  "We can average some numbers" taggedAs
+    AcceptanceTest in {
+      assert(
+        BundleExecutor.returningBigDecimal
+          .executeBundle(Bundle.avgBigDecimals(List(1, 2, 5, 200))) == (BigDecimal(208) / 4)
+      )
+    }
+
+  "Putting no data in gives 0 when averaging" taggedAs
+    AcceptanceTest in {
+      assert(
+        BundleExecutor.returningBigDecimal
+          .executeBundle(Bundle.avgBigDecimals(List.empty)) == BigDecimal(0)
+      )
+    }
+
 }

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/SparkSqlPlanExtension.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/SparkSqlPlanExtension.scala
@@ -1,0 +1,35 @@
+package com.nec.spark.agile
+
+import com.nec.spark.agile.SparkSqlPlanExtension.rulesToApply
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
+
+import scala.collection.mutable
+
+object SparkSqlPlanExtension {
+  val rulesToApply = mutable.Buffer.empty[Rule[SparkPlan]]
+}
+final class SparkSqlPlanExtension extends (SparkSessionExtensions => Unit) with Logging {
+  override def apply(sparkSessionExtensions: SparkSessionExtensions): Unit = {
+    sparkSessionExtensions.injectColumnar({ sparkSession =>
+      new ColumnarRule {
+        override def preColumnarTransitions: Rule[SparkPlan] =
+          sparkPlan =>
+            if (rulesToApply.isEmpty) {
+              sparkPlan
+            } else {
+              val resultingPlan = rulesToApply.foldLeft(sparkPlan) { case (plan, rule) =>
+                rule.apply(plan)
+              }
+              assert(
+                resultingPlan != sparkPlan,
+                sys.error(s"Expected some plan transformations at ${sparkPlan}")
+              )
+              resultingPlan
+            }
+      }
+    })
+  }
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/StaticNumberPlan.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/StaticNumberPlan.scala
@@ -1,0 +1,28 @@
+package com.nec.spark.agile
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.LeafExecNode
+
+final case class StaticNumberPlan(n: BigDecimal) extends LeafExecNode {
+  override protected def doExecute(): RDD[InternalRow] = {
+    rdd
+  }
+
+  override def output: Seq[Attribute] = Seq(SingleValueStubPlan.DefaultNumericAttribute)
+
+  @transient private lazy val unsafeRows: Array[InternalRow] = {
+    Array(
+      ExpressionEncoder[BigDecimal]
+        .createSerializer()
+        .apply(n)
+    )
+  }
+
+  @transient private lazy val rdd: RDD[InternalRow] = {
+    val numSlices = math.min(unsafeRows.length, sqlContext.sparkContext.defaultParallelism)
+    sqlContext.sparkContext.parallelize(unsafeRows, numSlices)
+  }
+}


### PR DESCRIPTION
This one was interesting: if you use decimal types for avg(), then the returned schema will have different scale than sum(), which caused lots of funky issues. However, it is easier to use Double type instead. I encoded the weird behaviour in unit tests so it is clear what is happening, rather than getting funny surprises.

Ensure that sum() does not conflict with avg() in terms of pattern matching.

Ensure the csv read works on Windows due to path changes.

Create `SparkSqlPlanExtension`, a more generic way to do an extension for our use cases, where we update the rules outside the extension. We are not abstracting this right now with the SumPlugin because we are not certain what the future holds in terms of the shape (it is less painful to copy & refactor later, than it is to try to fit something into a shape that is not appropriate).

Implement the avg() kernel.

Implement a pattern matcher for Avg()

Implemented also a `StaticNumberPlan` for testing and identifying any output issues.

Thanks Dominik for finding the exact issue ;-)

We will abstract probably after 4-5 datapoints of trying various things -- then we can come up with a more appropriate architecture. Please merge #13 before proceeding with this one.