### PR TITLE
added python test generator support for json and parquet

### DIFF
--- a/tests/python/generate_data.py
+++ b/tests/python/generate_data.py
@@ -1,0 +1,60 @@
+from pyspark.sql import SparkSession
+import pyspark.sql.functions as Function
+import pyspark.sql.types as Type
+
+import argparse
+import sys
+import uuid
+
+def arguments():
+    args = argparse.ArgumentParser(description='Generates sample data in CSV / JSON / Parquet for PySpark Benchmark')
+    args.add_argument('outfile', type=str, metavar='file_url', help='Output file URL')
+    args.add_argument('-r','--rows', type=int, default=100, help='Number of rows')
+    args.add_argument('-p','--partitions', type=int, default=100, help='Number of partitions')
+    args.add_argument('-n','--name', type=str, default='Generete test data', help='PySpark job name')
+    args.add_argument('-ft','--filetype', type=str, default='csv', help='Output file type. Supports csv, json, parquet')
+    
+    return args.parse_args()
+
+def get_uuid():
+    return uuid.uuid4().hex
+
+def main(args):
+
+    spark = SparkSession.builder.appName(args.name).getOrCreate()
+
+    Logger = spark._jvm.org.apache.log4j.Logger
+    log = Logger.getLogger(__name__)
+    log.info('='*64)
+    log.info('')
+    log.info('Generating data with {0} rows, {1} partitions at {2}'.format(args.rows, args.partitions, args.outfile))
+    log.info('')
+    log.info('='*64)
+
+    udfUUID = Function.udf(get_uuid, Type.StringType())
+
+    df = (spark.range(0, args.rows, numPartitions=args.partitions)
+        .withColumn('value', udfUUID())
+        .withColumn('prefix2', Function.substring(Function.col('value'),1,2))
+        .withColumn('prefix4', Function.substring(Function.col('value'),1,4))
+        .withColumn('prefix8', Function.substring(Function.col('value'),1,8))
+        .withColumn('float_val', Function.rand(seed=8675309)*1000000)
+        .withColumn('integer_val', Function.col('float_val').cast(Type.LongType()))
+        .drop('id'))
+
+
+    output_folder =  args.outfile + "_R" + str(args.rows) + "_P" + str(args.partitions) + "_" + args.filetype 
+
+    if args.filetype == "csv":
+        df.write.csv(output_folder, mode='overwrite', header=True)
+    elif args.filetype == "json":
+        df.write.json(output_folder, mode='overwrite')
+    elif args.filetype == "parquet":
+        df.write.parquet(output_folder, mode='overwrite')
+
+    log.info('Saved at {0}'.format(output_folder))
+
+if __name__ == '__main__':
+    args = arguments()
+    main(args)
+    

--- a/tests/python/shuffle_benchmark.py
+++ b/tests/python/shuffle_benchmark.py
@@ -9,11 +9,11 @@ import sys
 from timeit import default_timer as timer
 
 def arguments():
-    args = argparse.ArgumentParser(description='Shuffle Benchmark. Please generate dataset using generate_csv.py first.')
-    args.add_argument('inputfile', type=str, metavar='file_url', help='Input CSV file URL')
+    args = argparse.ArgumentParser(description='Shuffle Benchmark. Please generate dataset using generate_data.py first.')
+    args.add_argument('inputfile', type=str, metavar='file_url', help='Input file URL')
     args.add_argument('-n','--name', type=str, default='shuffle_benchmark', help='PySpark job name')
     args.add_argument('-r','--repartitions', type=int, default=200, help='Number of partitions')
-    args.add_argument('-o','--outputfile', type=str, default=None, help='Output file name (CSV')
+    args.add_argument('-o','--outputfile', type=str, default=None, help='Output file name (CSV)')
     args.add_argument('-x','--executor', type=str, default='18g', help='Set Executor Memory')
     args.add_argument('-d','--driver', type=str, default='3g', help='Set Driver Memory')
     args.add_argument('-sl','--storageLevel', type=str, default='11001', help='Set Storage Level')
@@ -21,9 +21,9 @@ def arguments():
 
     return args.parse_args()
 
-def groupByAggBenchmark(df, Log):
-    Log.info("="*64)
-    Log.info('Starting Benchmark for GroupBy & Agg')
+def groupByAggBenchmark(df, log):
+    log.info("="*64)
+    log.info('Starting Benchmark for GroupBy & Agg')
 
     start_time = timer()
     res = (df.groupBy('prefix2').agg(
@@ -36,28 +36,28 @@ def groupByAggBenchmark(df, Log):
 
     count = res.rdd.count()
 
-    Log.info('Count value for groupByAggBenchmark() = {0}'.format(count))
-    Log.info("="*64)
+    log.info('Count value for groupByAggBenchmark() = {0}'.format(count))
+    log.info("="*64)
     return timer() - start_time
 
-def repartitionBenchmark(df, partitions, Log):
-    Log.info("="*64)
-    Log.info('Starting Benchmark for Repartition')
+def repartitionBenchmark(df, partitions, log):
+    log.info("="*64)
+    log.info('Starting Benchmark for Repartition')
 
     start_time = timer()
     res = (df.repartition(partitions,'prefix4'))
 
     count = res.rdd.count()
 
-    Log.info('Count value repartitionBenchmark() = {0}'.format(count))
-    Log.info('Number of partition after repartitionBenchmark() = {0}'.format(res.rdd.getNumPartitions()))
-    Log.info("="*64)
+    log.info('Count value repartitionBenchmark() = {0}'.format(count))
+    log.info('Number of partition after repartitionBenchmark() = {0}'.format(res.rdd.getNumPartitions()))
+    log.info("="*64)
 
     return timer() - start_time
 
-def innerJoinBenchmark(df, Log):
-    Log.info("="*64)
-    Log.info('Starting Benchmark for Inner Join')
+def innerJoinBenchmark(df, log):
+    log.info("="*64)
+    log.info('Starting Benchmark for Inner Join')
 
     start_time = timer()
 
@@ -66,14 +66,14 @@ def innerJoinBenchmark(df, Log):
 
     count = res.rdd.count()
 
-    Log.info('Count value for innerJoinBenchmark() = {0}'.format(count))
-    Log.info("="*64)
+    log.info('Count value for innerJoinBenchmark() = {0}'.format(count))
+    log.info("="*64)
 
     return timer() - start_time
 
-def broadcastInnerJoinBenchmark(df, Log):
-    Log.info("="*64)
-    Log.info('Starting Benchmark for Broadcast Inner Join')
+def broadcastInnerJoinBenchmark(df, log):
+    log.info("="*64)
+    log.info('Starting Benchmark for Broadcast Inner Join')
 
     start_time = timer()
 
@@ -82,23 +82,22 @@ def broadcastInnerJoinBenchmark(df, Log):
 
     count = res.rdd.count()
 
-    Log.info('Count value for broadcastInnerJoinBenchmark() = {0}'.format(count))
-    Log.info("="*64)
+    log.info('Count value for broadcastInnerJoinBenchmark() = {0}'.format(count))
+    log.info("="*64)
 
     return timer() - start_time
 
-def main():
-    args = arguments()
+def main(args):
 
     conf = SparkConf().setAll([('spark.executor.memory', args.executor), ('spark.driver.memory',args.driver)]) 
     spark = SparkSession.builder.appName(args.name).config(conf=conf).getOrCreate()
 
     Logger = spark._jvm.org.apache.log4j.Logger
-    Log = Logger.getLogger(__name__)
+    log = Logger.getLogger(__name__)
 
-    Log.info("="*64)
-    Log.info('Shuffle Benchmark using input file = {0} with storage level = {1}'.format(args.inputfile, args.storageLevel))
-    Log.info("="*64)
+    log.info("="*64)
+    log.info('Shuffle Benchmark using input file = {0} with storage level = {1}'.format(args.inputfile, args.storageLevel))
+    log.info("="*64)
 
     callSiteShortOrig = spark.sparkContext.getLocalProperty('callSite.short')
     callSiteLongOrig = spark.sparkContext.getLocalProperty('callSite.long')
@@ -116,7 +115,19 @@ def main():
     for i in range(4):
         level[i] = bool(int(level[i]))
     level[4] = int(level[4])
-    df = spark.read.csv(args.inputfile, header=True, schema=schema).persist(StorageLevel(*tuple(level)))
+
+
+    # initialize df
+    df = None
+    
+    if "csv" in args.inputfile:
+        df = spark.read.csv(args.inputfile, header=True, schema=schema).persist(StorageLevel(*tuple(level)))
+    elif "json" in args.inputfile:
+        df = spark.read.json(args.inputfile, schema=schema).persist(StorageLevel(*tuple(level)))
+    elif "parquet" in args.inputfile:
+        df = spark.read.parquet(args.inputfile, schema=schema).persist(StorageLevel(*tuple(level)))
+
+    assert df, (f"Filetype not found in {args.inputfile}! Ensure that the path dir is correct.")
 
     TEST = 5
     result = []
@@ -124,45 +135,45 @@ def main():
         if(args.type == 'groupbyagg'):
             spark.sparkContext.setLocalProperty('callSite.short', f'groupByAggBenchmark()_test_{i}')
             spark.sparkContext.setLocalProperty('callSite.long', f'Benchmark for performing groupByAggBenchmark() on a dataframe for test {i}')
-            groupByAggBenchmark_time = groupByAggBenchmark(df, Log)
+            groupByAggBenchmark_time = groupByAggBenchmark(df, log)
             result.append(groupByAggBenchmark_time)
 
         elif(args.type == 'repart'):
             spark.sparkContext.setLocalProperty('callSite.short', f'repartitionBenchmark()_test_{i}')
             spark.sparkContext.setLocalProperty('callSite.long', f'Benchmark for repartitionBenchmark() a dataframe for test {i}')
-            repartitionBenchmark_time = repartitionBenchmark(df, args.repartitions, Log)
+            repartitionBenchmark_time = repartitionBenchmark(df, args.repartitions, log)
             result.append(repartitionBenchmark_time)
 
         elif(args.type == 'innerjoin'):
             spark.sparkContext.setLocalProperty('callSite.short', f'innerJoinBenchmark()_test_{i}')
             spark.sparkContext.setLocalProperty('callSite.long', f'Benchmark for performing innerJoinBenchmark() for test {i}')
-            innerJoinBenchmark_time = innerJoinBenchmark(df, Log)
+            innerJoinBenchmark_time = innerJoinBenchmark(df, log)
             result.append(innerJoinBenchmark_time)
 
         elif(args.type == 'broadinnerjoin'):
             spark.sparkContext.setLocalProperty('callSite.short', f'broadcastInnerJoinBenchmark()_test_{i}')
             spark.sparkContext.setLocalProperty('callSite.long', f'Benchmark for performing broadcastInnerJoinBenchmark() for test {i}')
-            broadcastInnerJoinBenchmark_time = broadcastInnerJoinBenchmark(df, Log)
+            broadcastInnerJoinBenchmark_time = broadcastInnerJoinBenchmark(df, log)
             result.append(broadcastInnerJoinBenchmark_time)
 
     spark.sparkContext.setLocalProperty('callSite.short', callSiteShortOrig)
     spark.sparkContext.setLocalProperty('callSite.long', callSiteLongOrig)
     
     average = 0
-    Log.info("="*64)
-    Log.info('RESULTS')
-    Log.info('Test Run = {0}, StorageLevel = {1}, Operation = {2}.'.format(args.name, args.storageLevel, args.type))
+    log.info("="*64)
+    log.info('RESULTS')
+    log.info('Test Run = {0}, StorageLevel = {1}, Operation = {2}.'.format(args.name, args.storageLevel, args.type))
     
     for i in range(TEST):
-        Log.info(f'TEST {i} test time : {result[i]} s')
+        log.info(f'TEST {i} test time : {result[i]} s')
         if i > 0 and i < 4:
             average += result[i]
 
-    Log.info(f'Average for TEST 1:3 : {average/3} s')
-    Log.info("="*64)
+    log.info(f'Average for TEST 1:3 : {average/3} s')
+    log.info("="*64)
 
     if args.outputfile is not None:
-        Log.info(f'Writing results to {args.outputfile}_{args.storageLevel}_{args.type}')
+        log.info(f'Writing results to {args.outputfile}_{args.storageLevel}_{args.type}')
         
         result.insert(0, args.type)
         result.insert(len(result), average/3)
@@ -185,4 +196,6 @@ def main():
         )
 
 if __name__ == '__main__':
-    main()
+    args = arguments()
+    main(args)
+    


### PR DESCRIPTION
Added support for json and parquet file types using Laziem's python tests. 

Sample Usage:

**To generate benchmark dataset:**
spark-submit --master spark://spark-benchmark-link:port generate_data.py DatasetFolderName -r 3000 -ft parquet
**To perform benchmarking:**
spark-submit --master spark://spark-benchmark-link:port shuffle_benchmark.py DatasetFolderName -r 3000 -o output/OutputDatasetFolderName  -sl 11001 -t groupbyagg