### PR TITLE
Integrate the Aurora4j API into the Spark plug-in.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ Spark Plugin development documentation: [aurora4spark-parent/README.md](aurora4s
 ### on `a6`
 
 ```
-/opt/spark/bin/spark-submit --name Example --jars /opt/aurora4spark/aurora4spark-sql-plugin.jar /opt/aurora4spark/example-avg.py
+$ source /opt/nec/ve/nlc/2.1.0/bin/nlcvars.sh
+$ export PATH=/opt/nec/ve/bin/:$PATH
+$ /opt/spark/bin/spark-submit \
+    --name Example \
+    --jars /opt/aurora4spark/aurora4spark-sql-plugin.jar \
+    /opt/aurora4spark/example-avg.py
 ```
-
-> The deployment instructions for these 2 files are in [aurora4spark-parent/aurora4spark-sql-plugin/README.md](aurora4spark-parent/aurora4spark-sql-plugin/README.md).

--- a/aurora4spark-parent/aurora4spark-sql-plugin/README.md
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/README.md
@@ -38,6 +38,12 @@ List of currently supported and tested queries can be found [in this file](../FE
 
 Will upload the `.jar` file and the example `.py` file.
 
+To deploy without running unit tests:
+
+```
+> ; set assembly / test := {}; deploy
+```
+
 ### Faster testing over SSH (around 40%) & general log-in to any SSH server
 
 https://docs.rackspace.com/blog/speeding-up-ssh-session-creation/

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/LocalVeoExtension.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/LocalVeoExtension.scala
@@ -1,11 +1,17 @@
 package com.nec.spark
 
-import com.nec.spark.agile.{AveragingPlanner, AveragingSparkPlan}
+import com.nec.VeDirectApp.compile_c
+import com.nec.spark.LocalVeoExtension.ve_so_name
+import com.nec.spark.agile.AveragingSparkPlanOffHeap.OffHeapDoubleAverager
+import com.nec.spark.agile.{AveragingPlanner, AveragingSparkPlanOffHeap}
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
+import org.apache.spark.sql.execution.{ColumnarRule, RowToColumnarExec, SparkPlan}
 
+object LocalVeoExtension {
+  lazy val ve_so_name = compile_c()
+}
 final class LocalVeoExtension extends (SparkSessionExtensions => Unit) with Logging {
   override def apply(sparkSessionExtensions: SparkSessionExtensions): Unit = {
     sparkSessionExtensions.injectColumnar({ sparkSession =>
@@ -15,7 +21,10 @@ final class LocalVeoExtension extends (SparkSessionExtensions => Unit) with Logg
             AveragingPlanner
               .matchPlan(sparkPlan)
               .map { childPlan =>
-                AveragingSparkPlan(childPlan.sparkPlan, AveragingSparkPlan.averageLocalScala)
+                AveragingSparkPlanOffHeap(
+                  RowToColumnarExec(childPlan.sparkPlan),
+                  OffHeapDoubleAverager.VeoBased(ve_so_name)
+                )
               }
               .getOrElse(sparkPlan)
       }

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/AveragingSparkPlanOffHeap.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/AveragingSparkPlanOffHeap.scala
@@ -1,0 +1,97 @@
+package com.nec.spark.agile
+
+import com.nec.VeDirectApp.compile_c
+import com.nec.aurora.Aurora
+import com.nec.{AvgSimple, VeJavaContext}
+import com.nec.spark.agile.AveragingSparkPlanOffHeap.OffHeapDoubleAverager
+import com.nec.spark.agile.SingleValueStubPlan.SparkDefaultColumnName
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.execution.vectorized.{OffHeapColumnVector, OnHeapColumnVector}
+import org.apache.spark.sql.execution.{RowToColumnarExec, SparkPlan}
+import org.apache.spark.sql.types.DoubleType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import sun.misc.Unsafe
+
+object AveragingSparkPlanOffHeap {
+
+  trait OffHeapDoubleAverager extends Serializable {
+    def average(memoryLocation: Long, count: Int): Double
+  }
+
+  object OffHeapDoubleAverager {
+    object UnsafeBased extends OffHeapDoubleAverager {
+      private def getUnsafe: Unsafe = {
+        val theUnsafe = classOf[Unsafe].getDeclaredField("theUnsafe")
+        theUnsafe.setAccessible(true)
+        theUnsafe.get(null).asInstanceOf[Unsafe]
+      }
+      override def average(memoryLocation: Long, count: ColumnIndex): Double = {
+        (0 until count)
+          .map { i =>
+            getUnsafe.getDouble(memoryLocation + i * 8)
+          }
+          .toList
+          .sum / count
+      }
+    }
+
+    case class VeoBased(ve_so_name: String) extends OffHeapDoubleAverager {
+      override def average(memoryLocation: Long, count: ColumnIndex): Double = {
+        println(s"SO name: ${ve_so_name}")
+        val proc = Aurora.veo_proc_create(0)
+        println(s"Created proc = ${proc}")
+        try {
+          val ctx: Aurora.veo_thr_ctxt = Aurora.veo_context_open(proc)
+          println(s"Created ctx = ${ctx}")
+          try {
+            val lib: Long = Aurora.veo_load_library(proc, ve_so_name)
+            val vej = new VeJavaContext(ctx, lib)
+            AvgSimple.avg_doubles_mem(vej, memoryLocation, count)
+          } finally Aurora.veo_context_close(ctx)
+        } finally Aurora.veo_proc_destroy(proc)
+      }
+    }
+  }
+
+}
+
+case class AveragingSparkPlanOffHeap(child: RowToColumnarExec, averager: OffHeapDoubleAverager)
+  extends SparkPlan {
+
+  override def supportsColumnar: Boolean = true
+
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    child
+      .doExecuteColumnar()
+      .map { columnarBatch =>
+        val theCol = columnarBatch.column(0).asInstanceOf[OffHeapColumnVector]
+        (
+          averager.average(theCol.valuesNativeAddress(), columnarBatch.numRows()),
+          columnarBatch.numRows()
+        )
+      }
+      .coalesce(1)
+      .mapPartitions { nums =>
+        Iterator {
+          val nl = nums.toList
+          val totalSize = nl.map(_._2).sum
+          nl.map { case (avgs, gs) => avgs * (gs.toDouble / totalSize) }.sum
+        }
+      }
+      .map { double =>
+        val vector = new OnHeapColumnVector(1, DoubleType)
+        vector.putDouble(0, double)
+        new ColumnarBatch(Array(vector), 1)
+      }
+  }
+
+  override def output: Seq[Attribute] = Seq(
+    AttributeReference(name = SparkDefaultColumnName, dataType = DoubleType, nullable = false)()
+  )
+
+  override def children: Seq[SparkPlan] = Seq(child)
+
+  override protected def doExecute(): RDD[InternalRow] = sys.error("Row production not supported")
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/ve-direct/src/main/scala/com/nec/SumMultipleColumns.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/ve-direct/src/main/scala/com/nec/SumMultipleColumns.scala
@@ -31,8 +31,10 @@ object SumMultipleColumns {
     ret_type = None
   )
 
-  def sum_multiple_doubles(veJavaContext: VeJavaContext,
-                           inputs: List[List[Double]]): List[Double] = {
+  def sum_multiple_doubles(
+    veJavaContext: VeJavaContext,
+    inputs: List[List[Double]]
+  ): List[Double] = {
     import veJavaContext._
     val our_args = Aurora.veo_args_alloc()
     val inputFlattened = inputs.flatten
@@ -41,7 +43,13 @@ object SumMultipleColumns {
     val dataDoublePointerOut = new DoublePointer(inputs.map(_ => 0: Double): _*)
 
     Aurora.veo_args_set_stack(our_args, 0, 0, inputData.asByteBuffer(), 8 * inputFlattened.size)
-    Aurora.veo_args_set_stack(our_args, 1, 1, dataDoublePointerOut.asByteBuffer(), 8 * inputs.length)
+    Aurora.veo_args_set_stack(
+      our_args,
+      1,
+      1,
+      dataDoublePointerOut.asByteBuffer(),
+      8 * inputs.length
+    )
     Aurora.veo_args_set_i64(our_args, 2, inputs.length)
     Aurora.veo_args_set_i64(our_args, 3, inputs.head.length)
 

--- a/aurora4spark-parent/aurora4spark-sql-plugin/ve-direct/src/main/scala/com/nec/VeDirectApp.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/ve-direct/src/main/scala/com/nec/VeDirectApp.scala
@@ -3,15 +3,8 @@ package com.nec
 import com.nec.aurora.Aurora
 
 import java.nio.file.{Files, Paths}
-import sun.misc.Unsafe
 
 object VeDirectApp {
-
-  private def getUnsafe: Unsafe = {
-    val theUnsafe = classOf[Unsafe].getDeclaredField("theUnsafe")
-    theUnsafe.setAccessible(true)
-    theUnsafe.get(null).asInstanceOf[Unsafe]
-  }
 
   def compile_c(): String = {
     val buildDir = Paths.get("_ve_build").toAbsolutePath
@@ -59,22 +52,18 @@ object VeDirectApp {
         val vej = new VeJavaContext(ctx, lib)
         println(SumSimple.sum_doubles(vej, List(1, 2, 3, 4)))
         println(AvgSimple.avg_doubles(vej, List(1, 2, 3, 10)))
-        val multiColumnSumResult = SumMultipleColumns.sum_multiple_doubles(vej, List(
-          List(1,2,3),
-          List(2,3,4),
-          List(5,4,3),
-          List(10,10,10)
-        ))
+        val multiColumnSumResult = SumMultipleColumns.sum_multiple_doubles(
+          vej,
+          List(List(1, 2, 3), List(2, 3, 4), List(5, 4, 3), List(10, 10, 10))
+        )
         println(multiColumnSumResult)
         assert(multiColumnSumResult == List(6.0, 9.0, 12.0, 30.0))
-        val multiColumnAvgResult = AvgMultipleColumns.avg_multiple_doubles(vej, List(
-          List(5, 10, 15),
-          List(3, 27, 30),
-          List(100, 200, 300),
-          List(1000, 2000, 3000)
-        ))
+        val multiColumnAvgResult = AvgMultipleColumns.avg_multiple_doubles(
+          vej,
+          List(List(5, 10, 15), List(3, 27, 30), List(100, 200, 300), List(1000, 2000, 3000))
+        )
         println(multiColumnAvgResult)
-        assert(multiColumnAvgResult== List(10.0, 20.0 , 200.0 ,2000.0))
+        assert(multiColumnAvgResult == List(10.0, 20.0, 200.0, 2000.0))
         println(
           SumPairwise.pairwise_sum_doubles(vej, List[(Double, Double)]((1, 1), (1, 2), (2, 9)))
         )

--- a/examples/example-avg.py
+++ b/examples/example-avg.py
@@ -19,6 +19,7 @@ if __name__ == "__main__":
         .builder \
         .appName("aurora4spark example") \
         .config("spark.sql.extensions", "com.nec.spark.LocalVeoExtension") \
+        .config("spark.sql.columnVector.offheap.enabled", "true") \
         .getOrCreate()
 
     basic_df_example(spark)


### PR DESCRIPTION
Updated `/README.md` for usage instructions.

Here, we compile with `ncc` once at the level of the driver.
Then, for each partition we call into the vector engine using the pre-compiled kernel. To that kernel we pass batches of data, compute the average, and then coalesce these batches into one final result.

We need to explicitly specify that we want 'offheap' to be used for columnar data - however we'll be able to use other approaches later.