### PR TITLE
Enable multi-column summing for Parquet (or any other) file input.

### DIFF
--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/Aurora4SparkExecutorPlugin.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/Aurora4SparkExecutorPlugin.scala
@@ -5,7 +5,8 @@ import com.nec.aurora.Aurora.veo_proc_handle
 
 import java.util
 import scala.collection.JavaConverters.mapAsScalaMapConverter
-import com.nec.spark.Aurora4SparkExecutorPlugin.{_veo_proc, launched, params}
+import com.nec.spark.Aurora4SparkExecutorPlugin.{_veo_ctx, _veo_proc, launched, params}
+import com.nec.spark.LocalVeoExtension.ve_so_name
 import org.apache.spark.api.plugin.{ExecutorPlugin, PluginContext}
 import org.apache.spark.internal.Logging
 
@@ -17,18 +18,23 @@ object Aurora4SparkExecutorPlugin {
   /** For assumption testing purposes only for now */
   private[spark] var launched: Boolean = false
   var _veo_proc: veo_proc_handle = _
+  var _veo_ctx: Aurora.veo_thr_ctxt = _
+  var lib: Long = -1
 }
 
 class Aurora4SparkExecutorPlugin extends ExecutorPlugin with Logging {
 
   override def init(ctx: PluginContext, extraConf: util.Map[String, String]): Unit = {
     _veo_proc = Aurora.veo_proc_create(0)
+    _veo_ctx = Aurora.veo_context_open(_veo_proc)
+    Aurora4SparkExecutorPlugin.lib = Aurora.veo_load_library(_veo_proc, ve_so_name)
     logInfo("Initializing Aurora4SparkExecutorPlugin.")
     params = params ++ extraConf.asScala
     launched = true
   }
 
   override def shutdown(): Unit = {
+    Aurora.veo_context_close(_veo_ctx)
     Aurora.veo_proc_destroy(_veo_proc)
     super.shutdown()
   }

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/LocalVeoExtension.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/LocalVeoExtension.scala
@@ -33,9 +33,9 @@ final class LocalVeoExtension extends (SparkSessionExtensions => Unit) with Logg
                   .matchPlan(sparkPlan)
                   .map { childPlan =>
                     MultipleColumnsSummingPlanOffHeap(
-                      RowToColumnarExec(childPlan.sparkPlan),
-                      MultipleColumnsSummingPlanOffHeap.MultipleColumnsOffHeapSummer
-                        .VeoBased(ve_so_name),
+                      if (childPlan.sparkPlan.supportsColumnar) childPlan.sparkPlan
+                      else RowToColumnarExec(childPlan.sparkPlan),
+                      MultipleColumnsSummingPlanOffHeap.MultipleColumnsOffHeapSummer.VeoBased,
                       childPlan.attributes
                     )
                   }

--- a/aurora4spark-parent/aurora4spark-sql-plugin/ve-direct/src/main/scala/com/nec/SumSimple.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/ve-direct/src/main/scala/com/nec/SumSimple.scala
@@ -34,12 +34,15 @@ object SumSimple {
       veJavaContext,
       dataDoublePointer.asByteBuffer().asInstanceOf[DirectBuffer].address(),
       doubles.length
-    ) finally dataDoublePointer.close()
+    )
+    finally dataDoublePointer.close()
   }
 
-  def sum_doubles_memory(veJavaContext: VeJavaContext,
-                         numbersMemoryAddress: Long,
-                         count: Int): Double = {
+  def sum_doubles_memory(
+    veJavaContext: VeJavaContext,
+    numbersMemoryAddress: Long,
+    count: Int
+  ): Double = {
     val our_args = Aurora.veo_args_alloc()
 
     import veJavaContext._
@@ -57,8 +60,12 @@ object SumSimple {
     try {
       val req_id = Aurora.veo_call_async_by_name(ctx, lib, "sum", our_args)
       val longPointer = new LongPointer(8)
-      Aurora.veo_call_wait_result(ctx, req_id, longPointer)
-      longPointer.asByteBuffer().getDouble(0)
-    } finally our_args.close()
+      try {
+        Aurora.veo_call_wait_result(ctx, req_id, longPointer)
+        longPointer.asByteBuffer().getDouble(0)
+      } finally longPointer.close()
+    } finally {
+      Aurora.veo_args_free(our_args)
+    }
   }
 }


### PR DESCRIPTION
- Whole-codegen interferes with its optimizations so has to be disabled.
- Extracted out VE process and context creation to Executor top level, for performance
- Added some clean-ups, as they were leaking memory in the real world Parquet test.
- Match plans other than local in-memory table.

The DAG currently looks like this, thus losing a huge benefit of how Parquet is read. For Spark GPU projects, a separate Parquet stage is created and this is what we would also need to do to benefit from columnar performance.

![image](https://user-images.githubusercontent.com/52247468/118195478-35999c00-b443-11eb-8862-70e29872736c.png)
It also runs in just 1 task, in the executor, we need to check why, if it's to do with how we do VEO or with the Plan:
![image](https://user-images.githubusercontent.com/52247468/118195787-c8d2d180-b443-11eb-95d2-81dfc17fdb5c.png)
Running a raw spark query shows multiple tasks running in parallel:
![image](https://user-images.githubusercontent.com/52247468/118195874-f61f7f80-b443-11eb-876c-abbb9985582c.png)

More work to be done; this gets us one step further in the right direction.