### PR TITLE
Add possibility to print plans via implicit class.

### DIFF
--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/debugging/Debugging.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/debugging/Debugging.scala
@@ -7,14 +7,14 @@ import org.apache.spark.sql.execution.SparkPlan
 
 object Debugging {
   implicit class SprarkSessionImplicit(val sparkSession: SparkSession) {
-    def debugSql(sqlQuery: String): DataFrame = {
+    def debugSql(sqlQuery: String, name: String): DataFrame = {
       val plansDir = Paths.get("target", "plans")
       if(!plansDir.toFile.exists()) {
         Files.createDirectory(plansDir)
       }
       val frame = sparkSession.sql(sqlQuery)
       Files.write(
-        Paths.get(plansDir.toString, sqlQuery),
+        Paths.get("target", "plans", name),
         frame.queryExecution.sparkPlan.toString().getBytes("UTF-8"),
         StandardOpenOption.CREATE
       )

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/SparkSanityTests.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/SparkSanityTests.scala
@@ -1,5 +1,6 @@
 package com.nec.spark.agile
 
+import com.nec.debugging.Debugging.SprarkSessionImplicit
 import com.nec.spark.Aurora4SparkDriver
 import com.nec.spark.Aurora4SparkExecutorPlugin
 import com.nec.spark.SparkAdditions
@@ -7,6 +8,7 @@ import com.nec.spark.planning.SingleColumnSumPlanExtractor
 import org.scalatest.BeforeAndAfter
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
+
 import org.apache.spark.sql.internal.SQLConf.WHOLESTAGE_CODEGEN_ENABLED
 
 /**
@@ -41,7 +43,7 @@ final class SparkSanityTests
       .createOrReplaceTempView("nums")
 
     val executionPlan =
-      sparkSession.sql("SELECT SUM(value) FROM nums").as[Double].executionPlan
+      sparkSession.debugSql("SELECT SUM(value) FROM nums", "SUM(value)").as[Double].executionPlan
 
     assert(
       executionPlan.getClass.getCanonicalName
@@ -56,5 +58,4 @@ final class SparkSanityTests
         .map(_.map(_.getDouble(0)).toList) == Some(List(1, 2, 3))
     )
   }
-
 }

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/planning/AveragingSparkPlanSpec.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/planning/AveragingSparkPlanSpec.scala
@@ -22,7 +22,7 @@ final class AveragingSparkPlanSpec
       .createOrReplaceTempView("nums")
 
     val executionPlan =
-      sparkSession.debugSql("SELECT AVG(value)  FROM nums").as[(Double)].executionPlan
+      sparkSession.debugSql("SELECT AVG(value)  FROM nums", "SUM(value)").as[(Double)].executionPlan
 
     assert(
       SingleColumnAvgPlanExtractor.matchPlan(executionPlan).isDefined,

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/VEWordCountSpec.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/VEWordCountSpec.scala
@@ -1,10 +1,10 @@
 package com.nec.ve
 
-import com.nec.spark.SparkAdditions
-import com.nec.spark.AuroraSqlPlugin
+import com.nec.spark.{Aurora4SparkExecutorPlugin, AuroraSqlPlugin, SparkAdditions}
 import com.nec.spark.planning.WordCountPlanner
 import com.nec.spark.planning.WordCountPlanner.WordCounter
 import com.nec.ve.VEWordCountSpec.WordCountQuery
+
 import org.apache.spark.sql.execution.PlanExtractor.DatasetPlanExtractor
 import org.apache.spark.sql.internal.SQLConf.COLUMN_VECTOR_OFFHEAP_ENABLED
 import org.apache.spark.sql.internal.SQLConf.WHOLESTAGE_CODEGEN_ENABLED
@@ -23,6 +23,8 @@ final class VEWordCountSpec extends AnyFreeSpec with BeforeAndAfter with SparkAd
       .set(COLUMN_VECTOR_OFFHEAP_ENABLED.key, "true")
   ) { sparkSession =>
     import sparkSession.implicits._
+
+    Aurora4SparkExecutorPlugin.closeAutomatically = true
 
     List("a", "ab", "bc", "ab")
       .toDS()

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/VeBenchmarkOffheapVsArrowApp.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/VeBenchmarkOffheapVsArrowApp.scala
@@ -1,7 +1,6 @@
 package com.nec.ve
 
 import com.nec.spark._
-import com.nec.ve.VEWordCountSpec.WordCountQuery
 
 import org.apache.spark.sql.execution.VeBasedBenchmark
 


### PR DESCRIPTION
So, basically here we use the implicit class to extent the original `SparkSession` to add `debugSql` method which will allow us to write the plans of selected queries to the file.