### PR TITLE
D wholestage codegen renchmark

### DIFF
--- a/aurora4spark-parent/aurora4spark-sql-plugin/project/plugins.sbt
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.0")

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/SparkRapidsSession.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/SparkRapidsSession.scala
@@ -28,6 +28,12 @@ class SparkRapidsSession {
       .format("parquet")
       .load("/home/william/large-sample-parquet-10_9/")
       .createOrReplaceTempView("nums")
+
+    sparkSession.sqlContext.read
+      .format("csv")
+      .option("header", true)
+      .load("/home/dominik/large-sample-csv-10_9/")
+      .createOrReplaceTempView("nums_csv")
   }
 
   @TearDown

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/SparkVeSession.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/SparkVeSession.scala
@@ -29,6 +29,12 @@ class SparkVeSession {
       .format("parquet")
       .load("/home/william/large-sample-parquet-10_9/")
       .createOrReplaceTempView("nums")
+
+    sparkSession.sqlContext.read
+      .format("csv")
+      .option("header", true)
+      .load("/home/dominik/large-sample-csv-10_9/")
+      .createOrReplaceTempView("nums_csv")
   }
 
   @TearDown

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/SparkWholestageSession.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/SparkWholestageSession.scala
@@ -26,6 +26,12 @@ class SparkWholestageSession {
       .format("parquet")
       .load("/home/william/large-sample-parquet-10_9/")
       .createOrReplaceTempView("nums")
+
+    sparkSession.sqlContext.read
+      .format("csv")
+      .option("header", true)
+      .load("/home/dominik/large-sample-csv-10_9/")
+      .createOrReplaceTempView("nums_csv")
   }
 
   @TearDown

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/VEJMHBenchmarkCSV.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/VEJMHBenchmarkCSV.scala
@@ -1,0 +1,32 @@
+package com.nec.ve
+
+import com.nec.spark._
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Benchmark)
+class VEJMHBenchmarkCSV {
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  def test2JVMRunNoWholestageCodegen(sparkVeSession: SparkVeSession): Unit = {
+    LocalVeoExtension._enabled = false
+    val query = sparkVeSession.sparkSession.sql("SELECT SUM(a) FROM nums_csv")
+    println(s"JVM result = ${query.collect().toList}")
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  def test2JVMRunWithWholestageCodegen(sparkWholestageSession: SparkWholestageSession): Unit = {
+    val query = sparkWholestageSession.sparkSession.sql("SELECT SUM(a) FROM nums_csv")
+    println(s"JVM result = ${query.collect().toList}")
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  def testRapidsRun(rapidsSession: SparkRapidsSession): Unit = {
+    LocalVeoExtension._enabled = false
+    val query = rapidsSession.sparkSession.sql("SELECT SUM(a) FROM nums_csv")
+    println(query.queryExecution.executedPlan)
+    println(s"JVM result = ${query.collect().toList}")
+  }
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/VEJMHBenchmarkParquet.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/VEJMHBenchmarkParquet.scala
@@ -1,13 +1,10 @@
 package com.nec.ve
 
 import com.nec.spark._
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.execution.debug.DebugQuery
-import org.apache.spark.sql.internal.SQLConf
 import org.openjdk.jmh.annotations._
 
 @State(Scope.Benchmark)
-class VEJMHBenchmark {
+class VEJMHBenchmarkParquet {
 
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))


### PR DESCRIPTION
This PR introduces the CSV benchmarks for JVM with and without wholestage codegen and for rapids. Benchmark for VE will be added in a separate PR.  The results  show that processing CSV file with the same data as parquet are much less performant and much harder to optimize by spark itself:
```
[info] Benchmark                                           Mode  Cnt    Score    Error  Units
[info] VEJMHBenchmarkCSV.test2JVMRunNoWholestageCodegen      ss    5  323,441 ± 27,143   s/op
[info] VEJMHBenchmarkCSV.test2JVMRunWithWholestageCodegen    ss    5  312,278 ± 31,970   s/op
[info] VEJMHBenchmarkCSV.testRapidsRun                       ss    5  154,353 ± 10,068   s/op
```
