### PR TITLE
Create a Batch processor, which just duplicates input data.

### DIFF
--- a/aurora4spark-parent/aurora4spark-sql-plugin/example-plans/identity-codegen-batch.txt
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/example-plans/identity-codegen-batch.txt
@@ -1,0 +1,66 @@
+Found 1 WholeStageCodegen subtrees.
+== Subtree 1 / 1 (maxMethodCodeSize:118; maxConstantPoolSize:96(0.15% used); numInnerClasses:0) ==
+*(1) IdentityCodegenBatchPlan
++- *(1) LocalTableScan [value#1]
+
+Generated code:
+/* 001 */ public Object generate(Object[] references) {
+/* 002 */   return new GeneratedIteratorForCodegenStage1(references);
+/* 003 */ }
+/* 004 */
+/* 005 */ /**
+/* 006 */  * Codegened pipeline for stage (id=1)
+/* 007 */  * *(1) IdentityCodegenBatchPlan
+/* 008 */  * +- *(1) LocalTableScan [value#1]
+/* 009 */  */
+/* 010 */ // codegenStageId=1
+/* 011 */ final class GeneratedIteratorForCodegenStage1 extends org.apache.spark.sql.execution.BufferedRowIterator {
+/* 012 */   private Object[] references;
+/* 013 */   private scala.collection.Iterator[] inputs;
+/* 014 */   private boolean identitycodegenbatchplan_excecuted_0;
+/* 015 */   private com.nec.spark.agile.UnsafeExternalDuplicator identitycodegenbatchplan_batchProcessor_0;
+/* 016 */   private scala.collection.Iterator<UnsafeRow> identitycodegenbatchplan_resultsIterator_0;
+/* 017 */   private scala.collection.Iterator localtablescan_input_0;
+/* 018 */
+/* 019 */   public GeneratedIteratorForCodegenStage1(Object[] references) {
+/* 020 */     this.references = references;
+/* 021 */   }
+/* 022 */
+/* 023 */   public void init(int index, scala.collection.Iterator[] inputs) {
+/* 024 */     partitionIndex = index;
+/* 025 */     this.inputs = inputs;
+/* 026 */
+/* 027 */     identitycodegenbatchplan_batchProcessor_0 = ((com.nec.spark.agile.IdentityCodegenBatchPlan) references[0] /* plan */).createContainer();
+/* 028 */     localtablescan_input_0 = inputs[0];
+/* 029 */
+/* 030 */   }
+/* 031 */
+/* 032 */   protected void processNext() throws java.io.IOException {
+/* 033 */     // PRODUCE: IdentityCodegenBatchPlan
+/* 034 */     if(!identitycodegenbatchplan_excecuted_0) {
+/* 035 */       identitycodegenbatchplan_excecuted_0 = true;
+/* 036 */
+/* 037 */       // PRODUCE: LocalTableScan [value#1]
+/* 038 */       while ( localtablescan_input_0.hasNext()) {
+/* 039 */         InternalRow localtablescan_row_0 = (InternalRow) localtablescan_input_0.next();
+/* 040 */         ((org.apache.spark.sql.execution.metric.SQLMetric) references[1] /* numOutputRows */).add(1);
+/* 041 */         // CONSUME: IdentityCodegenBatchPlan
+/* 042 */         identitycodegenbatchplan_batchProcessor_0.insertRow((UnsafeRow)localtablescan_row_0);
+/* 043 */         // shouldStop check is eliminated
+/* 044 */       }
+/* 045 */
+/* 046 */       identitycodegenbatchplan_resultsIterator_0 = identitycodegenbatchplan_batchProcessor_0.execute();
+/* 047 */     }
+/* 048 */
+/* 049 */     while ( identitycodegenbatchplan_resultsIterator_0.hasNext()) {
+/* 050 */       UnsafeRow identitycodegenbatchplan_outputRow_0 = (UnsafeRow)identitycodegenbatchplan_resultsIterator_0.next();
+/* 051 */
+/* 052 */       // CONSUME: WholeStageCodegen (1)
+/* 053 */       append(identitycodegenbatchplan_outputRow_0);
+/* 054 */
+/* 055 */       if (shouldStop()) return;
+/* 056 */     }
+/* 057 */   }
+/* 058 */
+/* 059 */ }
+

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/IdentityCodegenBatchPlan.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/IdentityCodegenBatchPlan.scala
@@ -1,0 +1,64 @@
+package com.nec.spark.agile
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+import org.apache.spark.sql.catalyst.expressions.codegen.ExprCode
+import org.apache.spark.sql.execution.BlockingOperatorWithCodegen
+import org.apache.spark.sql.execution.CodegenSupport
+import org.apache.spark.sql.execution.SparkPlan
+
+final case class IdentityCodegenBatchPlan(child: SparkPlan)
+  extends SparkPlan
+  with BlockingOperatorWithCodegen {
+  override protected def doExecute(): RDD[InternalRow] = sys.error("This should not be called if in WSCG")
+  override def output: Seq[Attribute] = child.output
+  override def children: Seq[SparkPlan] = Seq(child)
+  override def inputRDDs(): Seq[RDD[InternalRow]] = Seq(child.execute())
+
+  def createContainer(): UnsafeExternalDuplicator = new UnsafeExternalDuplicator
+
+  override protected def doProduce(ctx: CodegenContext): String = {
+    val excecuted = ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "excecuted")
+    val outputRow = ctx.freshName("outputRow")
+    val thisPlan = ctx.addReferenceObj("plan", this)
+    containerVariable = ctx.addMutableState(
+      classOf[UnsafeExternalDuplicator].getName,
+      "batchProcessor",
+      v => s"$v = $thisPlan.createContainer();",
+      forceInline = true
+    )
+    ctx.INPUT_ROW = null
+    val resultIterator = ctx.addMutableState(
+      "scala.collection.Iterator<UnsafeRow>",
+      "resultsIterator",
+      forceInline = true
+    )
+    s"""
+  if(!$excecuted) {
+    $excecuted = true;
+    ${child.asInstanceOf[CodegenSupport].produce(ctx, this)}
+   $resultIterator = $containerVariable.execute();
+   }
+
+ while ($limitNotReachedCond $resultIterator.hasNext()) {
+   UnsafeRow $outputRow = (UnsafeRow)$resultIterator.next();
+   ${consume(ctx, null, outputRow)}
+   if (shouldStop()) return;
+}
+   """
+  }
+
+  private var containerVariable: String = _
+
+  override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
+
+    s"""
+       |${row.code}
+       |$containerVariable.insertRow((UnsafeRow)${row.value});
+     """.stripMargin
+  }
+
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/IdentityCodegenPlan.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/IdentityCodegenPlan.scala
@@ -19,6 +19,7 @@ final case class IdentityCodegenPlan(child: SparkPlan) extends SparkPlan with Co
     val resultVars = input.zipWithIndex.map { case (ev, i) => ev }
     s"""
        |do {
+       | // here we have the doConsume
        |  ${consume(ctx, resultVars)}
        |} while(false);
      """.stripMargin

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/IdentityWholeStageCodegenSpec.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/IdentityWholeStageCodegenSpec.scala
@@ -36,7 +36,7 @@ final class IdentityWholeStageCodegenSpec
   }
 
   "Execute Identity WSCE for a LocalTableScan, and get the original input back" in withSparkSession2(
-    _.config(CODEGEN_FALLBACK.key, value = false)
+    _.config(CODEGEN_FALLBACK.key, value = false).config("spark.sql.codegen.comments", value = true)
   ) { sparkSession =>
     import sparkSession.implicits._
     Seq(1d, 2d, 3d)
@@ -50,6 +50,26 @@ final class IdentityWholeStageCodegenSpec
     info(codegened.toString())
     codegened
       .debugCodegen(name = "identity-codegen")
+    val result = codegened.executeCollectPublic().map(row => row.getDouble(0))
+    assert(result.toList == List(1d, 2d, 3d))
+  }
+
+  "Execute Identity WSCE for a LocalTableScan, and get the original input back, using IdentityCodegenBatchPlan" in withSparkSession2(
+    _.config(CODEGEN_FALLBACK.key, value = false)
+      .config("spark.sql.codegen.comments", value = true)
+  ) { sparkSession =>
+    import sparkSession.implicits._
+    Seq(1d, 2d, 3d)
+      .toDS()
+      .createOrReplaceTempView("nums")
+
+    val executionPlan = sparkSession
+      .sql("SELECT value FROM nums")
+      .executionPlan
+    val codegened = WholeStageCodegenExec(IdentityCodegenBatchPlan(executionPlan))(1)
+    info(codegened.toString())
+    codegened
+      .debugCodegen(name = "identity-codegen-batch")
     val result = codegened.executeCollectPublic().map(row => row.getDouble(0))
     assert(result.toList == List(1d, 2d, 3d))
   }

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/UnsafeBatchProcessor.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/UnsafeBatchProcessor.scala
@@ -1,0 +1,8 @@
+package com.nec.spark.agile
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+
+trait UnsafeBatchProcessor {
+  def insertRow(unsafeRow: UnsafeRow): Unit
+  def execute(): Iterator[InternalRow]
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/UnsafeExternalDuplicator.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/UnsafeExternalDuplicator.scala
@@ -1,0 +1,10 @@
+package com.nec.spark.agile
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+
+/** Collect UnsafeRows, and then emit UnsafeRows */
+final class UnsafeExternalDuplicator extends UnsafeBatchProcessor {
+  private val rows = scala.collection.mutable.Buffer.empty[UnsafeRow]
+  def insertRow(unsafeRow: UnsafeRow): Unit = rows.append(unsafeRow)
+  def execute(): Iterator[InternalRow] = rows.iterator
+}


### PR DESCRIPTION
Our VE based plans will follow more or less this line of execution, because we cannot run 'execute' until we had loaded in all the data.

Nonetheless, we could load the data in incrementally onto the VE, or even asynchronously.

This specific implementation will not necessarily work on large data sets because UnsafeRow might get deallocated.