### PR TITLE
Create an Arrow summing Codegen processor

### DIFF
--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/arrow/functions/Sum.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/arrow/functions/Sum.scala
@@ -16,7 +16,7 @@ object Sum {
     nativeInterface: ArrowNativeInterfaceNumeric
   )(float8Vector: Float8Vector, columnsCount: Int): Seq[Double] = {
     val ra = new RootAllocator()
-    val  outputVector = new Float8Vector("count", ra)
+    val outputVector = new Float8Vector("count", ra)
     outputVector.allocateNew(columnsCount)
     outputVector.setValueCount(columnsCount)
     nativeInterface.callFunction(
@@ -31,16 +31,19 @@ object Sum {
   }
 
   def sumJVM(float8Vector: Float8Vector, columnsCount: Int): Seq[Double] = {
-    (0 until float8Vector.getValueCount)
-      .map(idx => float8Vector.getValueAsDouble(idx))
-      .zipWithIndex
-      .groupBy { case (elem, idx) =>
-        idx % columnsCount
-      }
-      .map { case (idx, seq) =>
-        seq.map(_._1).sum
-      }
-      .toSeq
+    if (float8Vector.getValueCount < 1) Seq.fill(columnsCount)(0)
+    else
+      (0 until float8Vector.getValueCount)
+        .view
+        .map(idx => float8Vector.getValueAsDouble(idx))
+        .zipWithIndex
+        .groupBy { case (elem, idx) =>
+          idx % columnsCount
+        }
+        .map { case (idx, seq) =>
+          seq.map(_._1).sum
+        }
+        .toSeq
   }
 
 }

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/ArrowSummingCodegenPlan.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/ArrowSummingCodegenPlan.scala
@@ -1,0 +1,74 @@
+package com.nec.spark.agile
+
+import com.nec.spark.agile.ArrowSummingCodegenPlan.UnsafeArrowSummingContainer
+import com.nec.spark.planning.ArrowSummingPlan.ArrowSummer
+import org.apache.arrow.vector.Float8Vector
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.types.pojo.Schema
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter
+import org.apache.spark.sql.execution.BlockingOperatorWithCodegen
+import org.apache.spark.sql.execution.CodegenSupport
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.util.ArrowUtilsExposed
+
+object ArrowSummingCodegenPlan {
+
+  /** Container to aggregate all the data coming in and place it in the right spots */
+  /** Will probably be MUCH faster if we put somewhere other than Arrow. */
+  /** We can also batch the inputs and process asynchronously based on memory limitations */
+  /** There're many variations we can do here */
+  final class UnsafeArrowSummingContainer(summer: ArrowSummer, vectorSchemaRoot: VectorSchemaRoot)
+    extends UnsafeBatchProcessor {
+    private val theVector = vectorSchemaRoot.getVector(0).asInstanceOf[Float8Vector]
+    private var counter: Int = 0
+    override def insertRow(unsafeRow: UnsafeRow): Unit = {
+      val vl = unsafeRow.getDouble(0)
+
+      /**
+       * This is bound to be quite slow, allocating memory for each record;
+       * TODO find a better strategy
+       */
+      theVector.setValueCount(counter + 1)
+      theVector.setSafe(counter, vl)
+      counter = counter + 1
+    }
+    override def execute(): Iterator[InternalRow] = {
+      val result = summer.sum(theVector, 1)
+      val writer = new UnsafeRowWriter(1)
+      writer.reset()
+      writer.write(0, result)
+      Iterator(writer.getRow)
+    }
+  }
+}
+
+final case class ArrowSummingCodegenPlan(child: SparkPlan, summer: ArrowSummer)
+  extends SparkPlan
+  with BlockingOperatorWithCodegen
+  with UnsafeExternalProcessorBase {
+  override def output: Seq[Attribute] = child.output
+  override def children: Seq[SparkPlan] = Seq(child)
+
+  require(child.isInstanceOf[CodegenSupport], "Required to support Codegen")
+
+  override type ContainerType = UnsafeArrowSummingContainer
+
+  def createContainer(): UnsafeArrowSummingContainer = {
+    val timeZoneId = conf.sessionLocalTimeZone
+    val arrowSchema: Schema = ArrowUtilsExposed.toArrowSchema(schema, timeZoneId)
+    val allocator =
+      ArrowUtilsExposed.rootAllocator.newChildAllocator(
+        s"writer for a summing plan",
+        0,
+        Long.MaxValue
+      )
+    val root: VectorSchemaRoot = VectorSchemaRoot.create(arrowSchema, allocator)
+    new UnsafeArrowSummingContainer(summer, root)
+  }
+
+  override def containerClass: Class[UnsafeArrowSummingContainer] =
+    classOf[UnsafeArrowSummingContainer]
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/ArrowSummingCodegenPlanSpec.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/ArrowSummingCodegenPlanSpec.scala
@@ -1,0 +1,85 @@
+package com.nec.spark.agile
+
+import com.nec.debugging.Debugging.RichDataSet
+import com.nec.spark.SparkAdditions
+import com.nec.spark.planning.ArrowSummingPlan.ArrowSummer
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.expressions.aggregate.Sum
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.ColumnarRule
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.aggregate.HashAggregateExec
+import org.apache.spark.sql.internal.SQLConf.CODEGEN_FALLBACK
+import org.scalatest.BeforeAndAfter
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+
+final class ArrowSummingCodegenPlanSpec
+  extends AnyFreeSpec
+  with BeforeAndAfter
+  with SparkAdditions
+  with Matchers {
+  "Execute Identity WSCG for a SUM() VeSummingCodegenPlan" in withSparkSession2(
+    _.config(CODEGEN_FALLBACK.key, value = false)
+      .config("spark.sql.codegen.comments", value = true)
+      .withExtensions(sse =>
+        sse.injectColumnar(ss =>
+          new ColumnarRule {
+            override def postColumnarTransitions: Rule[SparkPlan] = { sparkPlan =>
+              PartialFunction
+                .condOpt(sparkPlan) {
+                  case first @ HashAggregateExec(
+                        requiredChildDistributionExpressions,
+                        groupingExpressions,
+                        Seq(
+                          AggregateExpression(avg @ Sum(exr), mode, isDistinct, filter, resultId)
+                        ),
+                        aggregateAttributes,
+                        initialInputBufferOffset,
+                        resultExpressions,
+                        see @ org.apache.spark.sql.execution.exchange
+                          .ShuffleExchangeExec(
+                            outputPartitioning,
+                            org.apache.spark.sql.execution.aggregate
+                              .HashAggregateExec(
+                                _requiredChildDistributionExpressions,
+                                _groupingExpressions,
+                                _aggregateExpressions,
+                                _aggregateAttributes,
+                                _initialInputBufferOffset,
+                                _resultExpressions,
+                                fourth
+                              ),
+                            shuffleOrigin
+                          )
+                      ) if (avg.references.size == 1) => {
+                    println(fourth)
+                    println(fourth.getClass.getCanonicalName())
+                    println(fourth.supportsColumnar)
+                    val indices = fourth.output.map(_.name).zipWithIndex.toMap
+                    val colName = avg.references.head.name
+
+                    first.copy(child =
+                      see.copy(child = ArrowSummingCodegenPlan(fourth, ArrowSummer.JVMBased))
+                    )
+                  }
+                }
+                .getOrElse(sparkPlan)
+            }
+          }
+        )
+      )
+  ) { sparkSession =>
+    import sparkSession.implicits._
+    Seq(1d, 2d, 3d)
+      .toDS()
+      .createOrReplaceTempView("nums")
+
+    val executionPlan = sparkSession
+      .sql("SELECT SUM(value) FROM nums")
+      .debugSqlAndShow(name = "arrow-sum-codegen")
+      .as[Double]
+    val result = executionPlan.collect().toList
+    assert(result == List(6d))
+  }
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/IdentityCodegenBatchPlan.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/IdentityCodegenBatchPlan.scala
@@ -1,64 +1,16 @@
 package com.nec.spark.agile
 
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator
-import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
-import org.apache.spark.sql.catalyst.expressions.codegen.ExprCode
 import org.apache.spark.sql.execution.BlockingOperatorWithCodegen
-import org.apache.spark.sql.execution.CodegenSupport
 import org.apache.spark.sql.execution.SparkPlan
 
 final case class IdentityCodegenBatchPlan(child: SparkPlan)
   extends SparkPlan
-  with BlockingOperatorWithCodegen {
-  override protected def doExecute(): RDD[InternalRow] = sys.error("This should not be called if in WSCG")
+  with BlockingOperatorWithCodegen
+  with UnsafeExternalProcessorBase {
+  type ContainerType = UnsafeExternalDuplicator
+  def createContainer(): UnsafeExternalDuplicator = new UnsafeExternalDuplicator
+  override def containerClass: Class[UnsafeExternalDuplicator] = classOf[UnsafeExternalDuplicator]
   override def output: Seq[Attribute] = child.output
   override def children: Seq[SparkPlan] = Seq(child)
-  override def inputRDDs(): Seq[RDD[InternalRow]] = Seq(child.execute())
-
-  def createContainer(): UnsafeExternalDuplicator = new UnsafeExternalDuplicator
-
-  override protected def doProduce(ctx: CodegenContext): String = {
-    val excecuted = ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "excecuted")
-    val outputRow = ctx.freshName("outputRow")
-    val thisPlan = ctx.addReferenceObj("plan", this)
-    containerVariable = ctx.addMutableState(
-      classOf[UnsafeExternalDuplicator].getName,
-      "batchProcessor",
-      v => s"$v = $thisPlan.createContainer();",
-      forceInline = true
-    )
-    ctx.INPUT_ROW = null
-    val resultIterator = ctx.addMutableState(
-      "scala.collection.Iterator<UnsafeRow>",
-      "resultsIterator",
-      forceInline = true
-    )
-    s"""
-  if(!$excecuted) {
-    $excecuted = true;
-    ${child.asInstanceOf[CodegenSupport].produce(ctx, this)}
-   $resultIterator = $containerVariable.execute();
-   }
-
- while ($limitNotReachedCond $resultIterator.hasNext()) {
-   UnsafeRow $outputRow = (UnsafeRow)$resultIterator.next();
-   ${consume(ctx, null, outputRow)}
-   if (shouldStop()) return;
-}
-   """
-  }
-
-  private var containerVariable: String = _
-
-  override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
-
-    s"""
-       |${row.code}
-       |$containerVariable.insertRow((UnsafeRow)${row.value});
-     """.stripMargin
-  }
-
 }

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/UnsafeExternalProcessorBase.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/UnsafeExternalProcessorBase.scala
@@ -1,0 +1,65 @@
+package com.nec.spark.agile
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+import org.apache.spark.sql.catalyst.expressions.codegen.ExprCode
+import org.apache.spark.sql.execution.BlockingOperatorWithCodegen
+import org.apache.spark.sql.execution.CodegenSupport
+import org.apache.spark.sql.execution.SparkPlan
+
+trait UnsafeExternalProcessorBase { this: SparkPlan with BlockingOperatorWithCodegen =>
+
+  def child: SparkPlan
+
+  override protected def doExecute(): RDD[InternalRow] = sys.error("This should not be called if in WSCG")
+  override def inputRDDs(): Seq[RDD[InternalRow]] = Seq(child.execute())
+
+  type ContainerType <: UnsafeBatchProcessor
+
+  def containerClass: Class[ContainerType]
+
+  def createContainer(): ContainerType
+
+  override protected def doProduce(ctx: CodegenContext): String = {
+    val excecuted = ctx.addMutableState(CodeGenerator.JAVA_BOOLEAN, "executed")
+    val outputRow = ctx.freshName("outputRow")
+    val thisPlan = ctx.addReferenceObj("plan", this)
+    containerVariable = ctx.addMutableState(
+      containerClass.getName,
+      "batchProcessor",
+      v => s"$v = $thisPlan.createContainer();",
+      forceInline = true
+    )
+    ctx.INPUT_ROW = null
+    val resultIterator = ctx.addMutableState(
+      "scala.collection.Iterator<UnsafeRow>",
+      "resultsIterator",
+      forceInline = true
+    )
+    s"""
+  if(!$excecuted) {
+    $excecuted = true;
+    ${child.asInstanceOf[CodegenSupport].produce(ctx, this)}
+   $resultIterator = $containerVariable.execute();
+   }
+
+ while ($limitNotReachedCond $resultIterator.hasNext()) {
+   UnsafeRow $outputRow = (UnsafeRow)$resultIterator.next();
+   ${consume(ctx, null, outputRow)}
+   if (shouldStop()) return;
+}
+   """
+  }
+
+  private var containerVariable: String = _
+
+  override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
+
+    s"""
+       |${row.code}
+       |$containerVariable.insertRow((UnsafeRow)${row.value});
+     """.stripMargin
+  }
+}


### PR DESCRIPTION
This gives us the possibility to hook into hyper-fast code paths generated by the JVM

Here we could really beat Spark's/JVM's performance :-)

Eg we can pass data to a ring buffer at 0-delays, and collect that in a separate thread very easily, before passing it onto the VE. Many possibilities including MPI and DMA and other things!

Updated `Sum` to work with 0 input data (called was using `.head`)

Extracted out `UnsafeExternalProcessorBase`