### PR TITLE
WIP // Add one more identity plan for Parquet

### DIFF
--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/IdentityCodegenPlan.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/IdentityCodegenPlan.scala
@@ -8,10 +8,15 @@ import org.apache.spark.sql.execution.CodegenSupport
 import org.apache.spark.sql.execution.SparkPlan
 
 final case class IdentityCodegenPlan(child: SparkPlan) extends SparkPlan with CodegenSupport {
+
   override protected def doExecute(): RDD[InternalRow] = sys.error("This should not be called.")
+
   override def output: Seq[Attribute] = child.output
+
   override def children: Seq[SparkPlan] = Seq(child)
+
   override def inputRDDs(): Seq[RDD[InternalRow]] = Seq(child.execute())
+
   override protected def doProduce(ctx: CodegenContext): String =
     child.asInstanceOf[CodegenSupport].produce(ctx, this)
 

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/IdentityWholeStageCodegenSpec.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/IdentityWholeStageCodegenSpec.scala
@@ -1,9 +1,15 @@
 package com.nec.spark.agile
 
+import com.nec.debugging.Debugging.RichDataSet
 import com.nec.debugging.Debugging.RichSparkPlan
+import com.nec.spark.SampleTestData.SampleCSV
+import com.nec.spark.SampleTestData.SampleTwoColumnParquet
 import com.nec.spark.SparkAdditions
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.internal.SQLConf.CODEGEN_FALLBACK
+import org.apache.spark.sql.types.DoubleType
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.StructType
 import org.scalatest.BeforeAndAfter
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
@@ -52,6 +58,29 @@ final class IdentityWholeStageCodegenSpec
       .debugCodegen(name = "identity-codegen")
     val result = codegened.executeCollectPublic().map(row => row.getDouble(0))
     assert(result.toList == List(1d, 2d, 3d))
+  }
+  "Execute Identity WSCE for a Parquet read, and get the original input back" in withSparkSession2(
+    _.config(CODEGEN_FALLBACK.key, value = false).config("spark.sql.codegen.comments", value = true)
+  ) { sparkSession =>
+    import sparkSession.implicits._
+
+    val schema = StructType(Array(StructField("a", DoubleType)))
+
+    sparkSession.sqlContext.read
+      .format("parquet")
+      .load(SampleTwoColumnParquet.toAbsolutePath.toString)
+      .createOrReplaceTempView("nums")
+
+    val executionPlan = sparkSession
+      .sql("SELECT a FROM nums")
+      .executionPlan
+
+    val codegened = WholeStageCodegenExec(IdentityCodegenPlan(executionPlan))(1)
+    info(codegened.toString())
+    codegened
+      .debugCodegen(name = "identity-codegen-parquet")
+    val result = codegened.executeCollectPublic().map(row => row.getDouble(0))
+    assert(result.toList == List(1d, 2d, 3d, 4d, 52.0d))
   }
 
   "Execute Identity WSCE for a LocalTableScan, and get the original input back, using IdentityCodegenBatchPlan" in withSparkSession2(


### PR DESCRIPTION
Since it worked for LocalTableScan, expected it to work for other cases however it is not the case.

```
[info]   java.lang.UnsupportedOperationException:
[info]   at org.apache.spark.sql.execution.WholeStageCodegenExec.doProduce(WholeStageCodegenExec.scala:789)
[info]   at org.apache.spark.sql.execution.CodegenSupport.$anonfun$produce$1(WholeStageCodegenExec.scala:95)
[info]   at org.apache.spark.sql.execution.SparkPlan.$anonfun$executeQuery$1(SparkPlan.scala:218)
[info]   at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
[info]   at org.apache.spark.sql.execution.SparkPlan.executeQuery(SparkPlan.scala:215)
[info]   at org.apache.spark.sql.execution.CodegenSupport.produce(WholeStageCodegenExec.scala:90)
[info]   at org.apache.spark.sql.execution.CodegenSupport.produce$(WholeStageCodegenExec.scala:90)
[info]   at org.apache.spark.sql.execution.WholeStageCodegenExec.produce(WholeStageCodegenExec.scala:622)
[info]   at com.nec.spark.agile.IdentityCodegenPlan.doProduce(IdentityCodegenPlan.scala:21)
[info]   at org.apache.spark.sql.execution.CodegenSupport.$anonfun$produce$1(WholeStageCodegenExec.scala:95)
[info]   at org.apache.spark.sql.execution.SparkPlan.$anonfun$executeQuery$1(SparkPlan.scala:218)
[info]   at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
[info]   at org.apache.spark.sql.execution.SparkPlan.executeQuery(SparkPlan.scala:215)
[info]   at org.apache.spark.sql.execution.CodegenSupport.produce(WholeStageCodegenExec.scala:90)
[info]   at org.apache.spark.sql.execution.CodegenSupport.produce$(WholeStageCodegenExec.scala:90)
[info]   at com.nec.spark.agile.IdentityCodegenPlan.produce(IdentityCodegenPlan.scala:10)
[info]   at org.apache.spark.sql.execution.WholeStageCodegenExec.doCodeGen(WholeStageCodegenExec.scala:655)
[info]   at org.apache.spark.sql.execution.debug.package$.$anonfun$codegenStringSeq$4(package.scala:122)
[info]   at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
[info]   at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
[info]   at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
[info]   at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
[info]   at scala.collection.TraversableLike.map(TraversableLike.scala:286)
[info]   at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
[info]   at scala.collection.AbstractTraversable.map(Traversable.scala:108)
[info]   at org.apache.spark.sql.execution.debug.package$.codegenStringSeq(package.scala:121)
[info]   at org.apache.spark.sql.execution.debug.package$.writeCodegen(package.scala:83)
[info]   at org.apache.spark.sql.execution.debug.package$.codegenString(package.scala:78)
[info]   at com.nec.debugging.Debugging$RichSparkPlan.debugCodegen(Debugging.scala:47)
[info]   at com.nec.spark.agile.IdentityWholeStageCodegenSpec.$anonfun$new$11(IdentityWholeStageCodegenSpec.scala:81)
[info]   at com.nec.spark.SparkAdditions.withSparkSession2(SparkAdditions.scala:49)
[info]   at com.nec.spark.SparkAdditions.withSparkSession2$(SparkAdditions.scala:41)
[info]   at com.nec.spark.agile.IdentityWholeStageCodegenSpec.withSparkSession2(IdentityWholeStageCodegenSpec.scala:21)
[info]   at com.nec.spark.agile.IdentityWholeStageCodegenSpec.$anonfun$new$9(IdentityWholeStageCodegenSpec.scala:64)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]   at org.scalatest.freespec.AnyFreeSpecLike$$anon$1.apply(AnyFreeSpecLike.scala:430)
[info]   at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
[info]   at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
[info]   at org.scalatest.freespec.AnyFreeSpec.withFixture(AnyFreeSpec.scala:1739)
[info]   at org.scalatest.freespec.AnyFreeSpecLike.invokeWithFixture$1(AnyFreeSpecLike.scala:428)
[info]   at org.scalatest.freespec.AnyFreeSpecLike.$anonfun$runTest$1(AnyFreeSpecLike.scala:440)
[info]   at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
[info]   at org.scalatest.freespec.AnyFreeSpecLike.runTest(AnyFreeSpecLike.scala:440)
[info]   at org.scalatest.freespec.AnyFreeSpecLike.runTest$(AnyFreeSpecLike.scala:422)
[info]   at com.nec.spark.agile.IdentityWholeStageCodegenSpec.org$scalatest$BeforeAndAfter$$super$runTest(IdentityWholeStageCodegenSpec.scala:21)
[info]   at org.scalatest.BeforeAndAfter.runTest(BeforeAndAfter.scala:213)
[info]   at org.scalatest.BeforeAndAfter.runTest$(BeforeAndAfter.scala:203)
[info]   at com.nec.spark.agile.IdentityWholeStageCodegenSpec.runTest(IdentityWholeStageCodegenSpec.scala:21)
[info]   at org.scalatest.freespec.AnyFreeSpecLike.$anonfun$runTests$1(AnyFreeSpecLike.scala:499)
[info]   at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
[info]   at scala.collection.immutable.List.foreach(List.scala:431)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
[info]   at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
[info]   at org.scalatest.freespec.AnyFreeSpecLike.runTests(AnyFreeSpecLike.scala:499)
[info]   at org.scalatest.freespec.AnyFreeSpecLike.runTests$(AnyFreeSpecLike.scala:498)
[info]   at org.scalatest.freespec.AnyFreeSpec.runTests(AnyFreeSpec.scala:1739)
[info]   at org.scalatest.Suite.run(Suite.scala:1112)
[info]   at org.scalatest.Suite.run$(Suite.scala:1094)
[info]   at org.scalatest.freespec.AnyFreeSpec.org$scalatest$freespec$AnyFreeSpecLike$$super$run(AnyFreeSpec.scala:1739)
[info]   at org.scalatest.freespec.AnyFreeSpecLike.$anonfun$run$1(AnyFreeSpecLike.scala:543)
[info]   at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
[info]   at org.scalatest.freespec.AnyFreeSpecLike.run(AnyFreeSpecLike.scala:543)
[info]   at org.scalatest.freespec.AnyFreeSpecLike.run$(AnyFreeSpecLike.scala:542)
[info]   at com.nec.spark.agile.IdentityWholeStageCodegenSpec.org$scalatest$BeforeAndAfter$$super$run(IdentityWholeStageCodegenSpec.scala:21)
[info]   at org.scalatest.BeforeAndAfter.run(BeforeAndAfter.scala:273)
[info]   at org.scalatest.BeforeAndAfter.run$(BeforeAndAfter.scala:271)
[info]   at com.nec.spark.agile.IdentityWholeStageCodegenSpec.org$scalatest$BeforeAndAfterAllConfigMap$$super$run(IdentityWholeStageCodegenSpec.scala:21)
[info]   at org.scalatest.BeforeAndAfterAllConfigMap.liftedTree1$1(BeforeAndAfterAllConfigMap.scala:248)
[info]   at org.scalatest.BeforeAndAfterAllConfigMap.run(BeforeAndAfterAllConfigMap.scala:245)
[info]   at org.scalatest.BeforeAndAfterAllConfigMap.run$(BeforeAndAfterAllConfigMap.scala:242)
[info]   at com.nec.spark.agile.IdentityWholeStageCodegenSpec.run(IdentityWholeStageCodegenSpec.scala:21)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:318)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:513)
[info]   at sbt.TestRunner.runTest$1(TestFramework.scala:140)
[info]   at sbt.TestRunner.run(TestFramework.scala:155)
[info]   at sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.$anonfun$apply$1(TestFramework.scala:318)
[info]   at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:278)
[info]   at sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply(TestFramework.scala:318)
[info]   at sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply(TestFramework.scala:318)
[info]   at sbt.TestFunction.apply(TestFramework.scala:330)
[info]   at sbt.Tests$.processRunnable$1(Tests.scala:474)
[info]   at sbt.Tests$.$anonfun$makeSerial$1(Tests.scala:480)
[info]   at sbt.std.Transform$$anon$3.$anonfun$apply$2(Transform.scala:46)
[info]   at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[info]   at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[info]   at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[info]   at sbt.Execute.work(Execute.scala:291)
[info]   at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[info]   at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[info]   at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[info]   at java.base/java.lang.Thread.run(Thread.java:834)

```