### PR TITLE
Evaluate Spark expressions as C code

### DIFF
--- a/aurora4spark-parent/aurora4spark-sql-plugin/build.sbt
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/build.sbt
@@ -35,6 +35,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % sparkVersion % "test,ve" classifier ("tests"),
   "org.apache.spark" %% "spark-catalyst" % sparkVersion,
   "org.scalatest" %% "scalatest" % "3.2.9" % "test,acc,cmake,ve",
+  "com.eed3si9n.expecty" %% "expecty" % "0.15.4" % "test,acc,cmake,ve",
   "frovedis" %% "frovedis-client" % "0.1.0-SNAPSHOT" % "test,acc",
   "frovedis" %% "frovedis-client-test" % "0.1.0-SNAPSHOT" % "test,acc",
   "com.nec" % "aveo4j" % "0.0.1",

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/CExpressionEvaluation.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/agile/CExpressionEvaluation.scala
@@ -1,0 +1,80 @@
+package com.nec.spark.agile
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.expressions.Alias
+import org.apache.spark.sql.catalyst.expressions.aggregate.Sum
+import org.apache.spark.sql.types.DoubleType
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.aggregate.Average
+import org.apache.spark.sql.catalyst.expressions.Subtract
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.expressions.Add
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.Multiply
+
+object CExpressionEvaluation {
+
+  final case class AggregateDescription(
+    init: List[String],
+    iter: List[String],
+    result: List[String]
+  )
+
+  def evaluateSub(expression: Expression): String = {
+    expression match {
+      case AttributeReference(_, _, _, _) =>
+        // todo support multiple columns - not yet though!
+        "input->data[i]"
+      case Subtract(left, right, _)             => s"${evaluateSub(left)} - ${evaluateSub(right)}"
+      case Multiply(left, right, _)             => s"${evaluateSub(left)} * ${evaluateSub(right)}"
+      case Add(left, right, _)                  => s"${evaluateSub(left)} + ${evaluateSub(right)}"
+      case Literal(v, DoubleType | IntegerType) => s"$v"
+    }
+  }
+
+  def process(
+    cleanName: String,
+    aggregateExpression: AggregateExpression
+  ): Option[AggregateDescription] = {
+    PartialFunction.condOpt(aggregateExpression.aggregateFunction) {
+      case Sum(sub) =>
+        AggregateDescription(
+          init = List(s"double ${cleanName}_accumulated = 0;"),
+          iter = List(s"${cleanName}_accumulated += ${evaluateSub(sub)};"),
+          result = List(
+            s"double ${cleanName}_result = ${cleanName}_accumulated;",
+            s"output->data[0] = ${cleanName}_result;"
+          )
+        )
+      case Average(sub) =>
+        AggregateDescription(
+          init = List(s"double ${cleanName}_accumulated = 0;", s"int ${cleanName}_counted = 0;"),
+          iter = List(
+            s"${cleanName}_accumulated += ${evaluateSub(sub)};",
+            s"${cleanName}_counted += 1;"
+          ),
+          result = List(
+            s"double ${cleanName}_result = ${cleanName}_accumulated / ${cleanName}_counted;",
+            s"output->data[0] = ${cleanName}_result;"
+          )
+        )
+    }
+  }
+
+  def cGen(alias: Alias, aggregateExpression: AggregateExpression): List[String] = {
+    // todo a better clean up - this can clash
+    val cleanName = alias.name.replaceAll("[^A-Z_a-z0-9]", "")
+    val ad =
+      process(cleanName, aggregateExpression).getOrElse(
+        sys.error(s"Unknown: ${aggregateExpression}")
+      )
+
+    List[List[String]](
+      ad.init,
+      List("for (int i = 0; i < input->count; i++) {"),
+      ad.iter,
+      List("}"),
+      ad.result
+    ).flatten
+  }
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/planning/CEvaluationPlan.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/main/scala/com/nec/spark/planning/CEvaluationPlan.scala
@@ -1,0 +1,75 @@
+package com.nec.spark.planning
+import com.nec.arrow.ArrowNativeInterfaceNumeric
+import com.nec.arrow.ArrowNativeInterfaceNumeric.SupportedVectorWrapper.Float8VectorWrapper
+import com.nec.spark.planning.CEvaluationPlan.NativeEvaluator
+import org.apache.arrow.vector.Float8Vector
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter
+import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.UnaryExecNode
+import org.apache.spark.sql.execution.arrow.ArrowWriter
+import org.apache.spark.sql.types.DoubleType
+import org.apache.spark.sql.util.ArrowUtilsExposed
+
+object CEvaluationPlan {
+  trait NativeEvaluator extends Serializable {
+    def forCode(code: String): ArrowNativeInterfaceNumeric
+  }
+}
+final case class CEvaluationPlan(
+  lines: List[String],
+  child: SparkPlan,
+  nativeEvaluator: NativeEvaluator
+) extends SparkPlan
+  with UnaryExecNode {
+  protected def inputAttributes: Seq[Attribute] = child.output
+  override def output: Seq[Attribute] = Seq(
+    AttributeReference(name = "value", dataType = DoubleType, nullable = false)()
+  )
+  override def outputPartitioning: Partitioning = SinglePartition
+  override protected def doExecute(): RDD[InternalRow] = {
+    val evaluator = nativeEvaluator.forCode(lines.mkString("\n", "\n", "\n"))
+    child
+      .execute()
+      .coalesce(numPartitions = 1)
+      .mapPartitions { rows =>
+        Iterator {
+          val timeZoneId = conf.sessionLocalTimeZone
+          val allocator = ArrowUtilsExposed.rootAllocator.newChildAllocator(
+            s"writer for word count",
+            0,
+            Long.MaxValue
+          )
+          val arrowSchema = ArrowUtilsExposed.toArrowSchema(schema, timeZoneId)
+          val root = VectorSchemaRoot.create(arrowSchema, allocator)
+          val arrowWriter = ArrowWriter.create(root)
+          rows.foreach(row => arrowWriter.write(row))
+          arrowWriter.finish()
+          val vector = root.getVector(0).asInstanceOf[Float8Vector]
+          arrowWriter.finish()
+
+          val outputVector = new Float8Vector("count", allocator)
+          outputVector.allocateNew(1)
+          outputVector.setValueCount(1)
+          evaluator.callFunction(
+            name = "f",
+            inputArguments = List(Some(Float8VectorWrapper(vector)), None),
+            outputArguments = List(None, Some(outputVector), None)
+          )
+
+          (0 until outputVector.getValueCount).iterator.map { idx =>
+            val writer = new UnsafeRowWriter(1)
+            writer.reset()
+            writer.write(0, outputVector.getValueAsDouble(idx))
+            writer.getRow
+          }
+        }.take(1).flatten
+      }
+  }
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/cmake/DynamicCSqlExpressionEvaluationSpec.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/cmake/DynamicCSqlExpressionEvaluationSpec.scala
@@ -1,0 +1,102 @@
+package com.nec.cmake
+
+import com.nec.arrow.CArrowNativeInterfaceNumeric
+import com.nec.arrow.TransferDefinitions
+import com.nec.cmake.DynamicCSqlExpressionEvaluationSpec.configuration
+import com.nec.spark.SparkAdditions
+import com.nec.spark.agile.CExpressionEvaluation
+import com.nec.spark.planning.CEvaluationPlan
+import com.nec.spark.planning.CEvaluationPlan.NativeEvaluator
+import com.nec.spark.planning.simplesum.SimpleSumPlanTest.Source
+import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.Strategy
+import org.apache.spark.sql.catalyst.expressions.Alias
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.plans.logical
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.internal.SQLConf.CODEGEN_FALLBACK
+import org.scalatest.BeforeAndAfter
+import org.scalatest.freespec.AnyFreeSpec
+
+object DynamicCSqlExpressionEvaluationSpec {
+
+  val cNativeEvaluator: NativeEvaluator = { code =>
+    val cLib = CMakeBuilder.buildC(
+      List(TransferDefinitions.TransferDefinitionsSourceCode, code)
+        .mkString("\n\n")
+    )
+    System.err.println(s"Generated: ${cLib.toAbsolutePath.toString}")
+    new CArrowNativeInterfaceNumeric(cLib.toAbsolutePath.toString)
+  }
+
+  def configuration(sql: String): SparkSession.Builder => SparkSession.Builder = {
+    _.config(CODEGEN_FALLBACK.key, value = false)
+      .config("spark.sql.codegen.comments", value = true)
+      .withExtensions(sse =>
+        sse.injectPlannerStrategy(sparkSession =>
+          new Strategy {
+            override def apply(plan: LogicalPlan): Seq[SparkPlan] =
+              plan match {
+                case logical.Aggregate(groupingExpressions, resultExpressions, child) =>
+                  List(
+                    CEvaluationPlan(
+                      List(
+                        List(
+                          "long f(non_null_double_vector* input, non_null_double_vector* output) {",
+                          "output->data = malloc(1 * sizeof(double));"
+                        ),
+                        CExpressionEvaluation.cGen(
+                          resultExpressions.head.asInstanceOf[Alias],
+                          resultExpressions.head
+                            .asInstanceOf[Alias]
+                            .child
+                            .asInstanceOf[AggregateExpression]
+                        ),
+                        List("}")
+                      ).flatten,
+                      planLater(child),
+                      cNativeEvaluator
+                    )
+                  )
+                case _ => Nil
+              }
+          }
+        )
+      )
+  }
+
+}
+
+final class DynamicCSqlExpressionEvaluationSpec
+  extends AnyFreeSpec
+  with BeforeAndAfter
+  with SparkAdditions {
+
+  "Different expressions can be evaluated" - {
+    List(
+      "SELECT SUM(value) FROM nums" -> 62.0d,
+      "SELECT SUM(value - 1) FROM nums" -> 57.0d,
+      /** The below are ignored for now */
+      "SELECT AVG(value) FROM nums" -> 24.8d,
+      "SELECT AVG(2 * value) FROM nums" -> 24.8d,
+      "SELECT AVG(2 * value), SUM(value) FROM nums" -> 0.0d,
+      "SELECT AVG(2 * value), SUM(value - 1), value / 2 FROM nums GROUP BY (value / 2)" -> 0.0d
+    ).take(2).foreach { case (sql, expectation) =>
+      s"${sql}" in withSparkSession2(configuration(sql)) { sparkSession =>
+        Source.CSV.generate(sparkSession)
+        import sparkSession.implicits._
+        assert(sparkSession.sql(sql).debugSqlHere.as[Double].collect().toList == List(expectation))
+      }
+    }
+  }
+
+  implicit class RichDataSet[T](val dataSet: Dataset[T]) {
+    def debugSqlHere: Dataset[T] = {
+      info(dataSet.queryExecution.executedPlan.toString())
+      dataSet
+    }
+  }
+
+}

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/ExpressionGenerationSpec.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/ExpressionGenerationSpec.scala
@@ -1,0 +1,171 @@
+package com.nec.spark.agile
+import com.nec.spark.SparkAdditions
+import com.nec.spark.planning.simplesum.SimpleSumPlanTest.Source
+import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.Strategy
+import org.apache.spark.sql.catalyst.expressions.Add
+import org.apache.spark.sql.catalyst.expressions.Alias
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.Subtract
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.expressions.aggregate.Average
+import org.apache.spark.sql.catalyst.expressions.aggregate.Complete
+import org.apache.spark.sql.catalyst.expressions.aggregate.Sum
+import org.apache.spark.sql.catalyst.plans.logical
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.internal.SQLConf.CODEGEN_FALLBACK
+import org.apache.spark.sql.types.DoubleType
+import org.apache.spark.sql.types.Metadata
+import org.scalatest.BeforeAndAfter
+import org.scalatest.freespec.AnyFreeSpec
+import CExpressionEvaluation._
+object ExpressionGenerationSpec {
+
+}
+
+final class ExpressionGenerationSpec extends AnyFreeSpec with BeforeAndAfter with SparkAdditions {
+  import com.eed3si9n.expecty.Expecty.assert
+  "SUM((value#14 - 1.0)) is evaluated" in {
+    val expr = AggregateExpression(
+      aggregateFunction = Sum(
+        Subtract(
+          AttributeReference(
+            name = "abcd",
+            dataType = DoubleType,
+            nullable = false,
+            metadata = Metadata.empty
+          )(),
+          Literal(1.0, DoubleType)
+        )
+      ),
+      mode = Complete,
+      isDistinct = false,
+      filter = None
+    )
+
+    assert(
+      cGen(Alias(null, "summy")(), expr) ==
+        List(
+          "double summy_accumulated = 0;",
+          "for (int i = 0; i < input->count; i++) {",
+          "summy_accumulated += input->data[i] - 1.0;",
+          "}",
+          "double summy_result = summy_accumulated;"
+        )
+    )
+
+  }
+
+  "AVG((value#14 - 1.0)) is evaluated" in {
+    val expr = AggregateExpression(
+      aggregateFunction = Average(
+        Subtract(
+          AttributeReference(
+            name = "abcd",
+            dataType = DoubleType,
+            nullable = false,
+            metadata = Metadata.empty
+          )(),
+          Literal(1.0, DoubleType)
+        )
+      ),
+      mode = Complete,
+      isDistinct = false,
+      filter = None
+    )
+
+    assert(
+      cGen(Alias(null, "avy#123 + 51")(), expr) == List(
+        "double avy12351_accumulated = 0;",
+        "int avy12351_counted = 0;",
+        "for (int i = 0; i < input->count; i++) {",
+        "avy12351_accumulated += input->data[i] - 1.0;",
+        "avy12351_counted += 1;",
+        "}",
+        "double avy12351_result = avy12351_accumulated / avy12351_counted;"
+      )
+    )
+
+  }
+  "AVG((value#14 + 2.0)) is evaluated" in {
+    val expr = AggregateExpression(
+      aggregateFunction = Average(
+        Add(
+          AttributeReference(
+            name = "abcd",
+            dataType = DoubleType,
+            nullable = false,
+            metadata = Metadata.empty
+          )(),
+          Literal(2.0, DoubleType)
+        )
+      ),
+      mode = Complete,
+      isDistinct = false,
+      filter = None
+    )
+
+    assert(
+      cGen(Alias(null, "avy#123 + 2")(), expr) ==
+        List(
+          "double avy1232_accumulated = 0;",
+          "int avy1232_counted = 0;",
+          "for (int i = 0; i < input->count; i++) {",
+          "avy1232_accumulated += input->data[i] + 2.0;",
+          "avy1232_counted += 1;",
+          "}",
+          "double avy1232_result = avy1232_accumulated / avy1232_counted;"
+        )
+    )
+
+  }
+
+  "Different expressions are found" - {
+    List(
+      "SELECT SUM(value) FROM nums",
+      "SELECT SUM(value - 1) FROM nums",
+      "SELECT AVG(2 * value) FROM nums",
+      "SELECT AVG(2 * value), SUM(value) FROM nums",
+      "SELECT AVG(2 * value), SUM(value - 1), value / 2 FROM nums GROUP BY (value / 2)"
+    ).take(2).foreach { sql =>
+      s"${sql}" in withSparkSession2(
+        _.config(CODEGEN_FALLBACK.key, value = false)
+          .config("spark.sql.codegen.comments", value = true)
+          .withExtensions(sse =>
+            sse.injectPlannerStrategy(sparkSession =>
+              new Strategy {
+                override def apply(plan: LogicalPlan): Seq[SparkPlan] =
+                  plan match {
+                    case logical.Aggregate(groupingExpressions, resultExpressions, child) =>
+                      info(s"Grouping ==> ${groupingExpressions.mkString}")
+                      info(s"Result ==> ${resultExpressions.mkString}")
+                      info(s"Result ==> ${resultExpressions.collect {
+                        case Alias(ae @ AggregateExpression(Sum(sth), mode, isDistinct, filter, resultId), name) =>
+                          info(sth.toString)
+                          info(sth.getClass.getCanonicalName)
+                          ae.productIterator.mkString("|")
+                      }.mkString}")
+                      Nil
+                    case _ => Nil
+                  }
+              }
+            )
+          )
+      ) { sparkSession =>
+        Source.CSV.generate(sparkSession)
+        import sparkSession.implicits._
+        sparkSession.sql(sql).debugSqlHere
+      }
+    }
+  }
+
+  implicit class RichDataSet[T](val dataSet: Dataset[T]) {
+    def debugSqlHere: Dataset[T] = {
+      info(dataSet.queryExecution.executedPlan.toString())
+      dataSet
+    }
+  }
+
+}


### PR DESCRIPTION
We will create a weider-ranging plan that incorporates the combination of Hash, Join, and these expressions, as well as codegen, to combine everything.

The impact of this is that we are closer to supporting a real-world Taxi data-set.

Here's an example of simple evaluated code for sum. It already supports Avg and eg SUM(1+value):

```c
long f(non_null_double_vector* input, non_null_double_vector* output) {
output->data = malloc(1 * sizeof(double));
double sumvalue_accumulated = 0;
for (int i = 0; i < input->count; i++) {
sumvalue_accumulated += input->data[i];
}
double sumvalue_result = sumvalue_accumulated;
output->data[0] = sumvalue_result;
}
```