### PR TITLE
Include SimpleSum in the test framework

### DIFF
--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/BenchTestingPossibilities.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/BenchTestingPossibilities.scala
@@ -1,12 +1,26 @@
 package com.nec.spark
+import com.nec.spark.BenchTestingPossibilities.BenchTestAdditions
 import com.nec.spark.BenchTestingPossibilities.Testing.DataSize
+import com.nec.spark.planning.simplesum.SimpleSumPlanTest
 import com.nec.spark.planning.simplesum.SimpleSumPlanTest.Source
 import org.apache.spark.sql.SparkSession
 import org.scalatest.freespec.AnyFreeSpec
+import com.eed3si9n.expecty.Expecty.assert
 
 object BenchTestingPossibilities {
+  /** Compiler-friendly name that we can use as part of class an method names. */
+  final case class CleanName(value: String) {
+    override def toString: String = value
+  }
+  object CleanName {
+
+    implicit class RichStringClean(string: String) {
+      def clean: CleanName = fromString(string)
+    }
+    def fromString(value: String): CleanName = CleanName(value.replaceAll("[^a-zA-Z_0-9]", ""))
+  }
   abstract class Testing {
-    def name: String
+    def name: CleanName
     def verify(sparkSession: SparkSession): Unit
     def benchmark(sparkSession: SparkSession): Unit
     def prepareSession(dataSize: DataSize = DataSize.BenchmarkSize): SparkSession
@@ -30,7 +44,7 @@ object BenchTestingPossibilities {
 
   /** You can generate variations of these as well as well, including CSV and so forth */
   def testSql(sql: String, expectedResult: Double, source: Source): Testing = new Testing {
-    override def name: String = s"${source.title}${sql.replaceAll("[^a-zA-Z_0-9]", "")}"
+    override def name: CleanName = CleanName.fromString(s"${source.title}${sql}")
     override def benchmark(sparkSession: SparkSession): Unit = {
       sparkSession.sql(sql)
     }
@@ -38,7 +52,7 @@ object BenchTestingPossibilities {
       val sess = SparkSession
         .builder()
         .master("local[4]")
-        .appName(name)
+        .appName(name.value)
         .config(key = "spark.ui.enabled", value = false)
         .getOrCreate()
 
@@ -50,33 +64,39 @@ object BenchTestingPossibilities {
     override def cleanUp(sparkSession: SparkSession): Unit = sparkSession.close()
     override def verify(sparkSession: SparkSession): Unit = {
       import sparkSession.implicits._
-      sparkSession.sql(sql).as[Double].collect().toList == List(expectedResult)
+      assert(sparkSession.sql(sql).as[Double].collect().toList == List(expectedResult))
     }
     override def requiresVe: Boolean = false
   }
 
   /** Proof of generating any variation of things */
-  val possibilities: List[Testing] = {
+  val SampleTests: List[Testing] = {
     for {
       num <- 2 to 4
       source <- List(Source.CSV, Source.Parquet)
     } yield testSql(
       sql = s"SELECT SUM(value + $num) FROM nums",
-      expectedResult = num + 2,
+      expectedResult = 62 + 5 * num,
       source = source
     )
   }.toList
 
-}
+  val possibilities: List[Testing] = List(SampleTests, SimpleSumPlanTest.OurTesting).flatten
 
-final class BenchTestingPossibilities extends AnyFreeSpec {
-
-  /** TODO We could also generate Spark plan details from here for easy cross-referencing, as well as codegen */
-  BenchTestingPossibilities.possibilities.filterNot(_.requiresVe).foreach { testing =>
-    testing.name in {
-      val sparkSession = testing.prepareSession(dataSize = DataSize.SanityCheckSize)
-      try testing.verify(sparkSession)
-      finally testing.cleanUp(sparkSession)
+  trait BenchTestAdditions { this: AnyFreeSpec =>
+    def runTestCase(testing: Testing): Unit = {
+      testing.name.value in {
+        val sparkSession = testing.prepareSession(dataSize = DataSize.SanityCheckSize)
+        try testing.verify(sparkSession)
+        finally testing.cleanUp(sparkSession)
+      }
     }
   }
+}
+
+final class BenchTestingPossibilities extends AnyFreeSpec with BenchTestAdditions {
+
+  /** TODO We could also generate Spark plan details from here for easy cross-referencing, as well as codegen */
+  BenchTestingPossibilities.SampleTests.filterNot(_.requiresVe).foreach(runTestCase)
+
 }

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/SparkAdditions.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/SparkAdditions.scala
@@ -13,6 +13,8 @@ import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.sql.execution.PlanExtractor.DatasetPlanExtractor
 import org.apache.spark.sql.execution.SparkPlan
 
+object  SparkAdditions {
+}
 trait SparkAdditions extends BeforeAndAfterAllConfigMap {
   this: TestSuite with Informing with BeforeAndAfter =>
 

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/ExpressionGenerationSpec.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/agile/ExpressionGenerationSpec.scala
@@ -20,10 +20,8 @@ import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.sql.types.Metadata
 import org.scalatest.BeforeAndAfter
 import org.scalatest.freespec.AnyFreeSpec
-import CExpressionEvaluation._
-object ExpressionGenerationSpec {
-
-}
+import com.nec.spark.agile.CExpressionEvaluation._
+object ExpressionGenerationSpec {}
 
 final class ExpressionGenerationSpec extends AnyFreeSpec with BeforeAndAfter with SparkAdditions {
   import com.eed3si9n.expecty.Expecty.assert
@@ -52,7 +50,8 @@ final class ExpressionGenerationSpec extends AnyFreeSpec with BeforeAndAfter wit
           "for (int i = 0; i < input->count; i++) {",
           "summy_accumulated += input->data[i] - 1.0;",
           "}",
-          "double summy_result = summy_accumulated;"
+          "double summy_result = summy_accumulated;",
+          "output->data[0] = summy_result;"
         )
     )
 
@@ -84,7 +83,8 @@ final class ExpressionGenerationSpec extends AnyFreeSpec with BeforeAndAfter wit
         "avy12351_accumulated += input->data[i] - 1.0;",
         "avy12351_counted += 1;",
         "}",
-        "double avy12351_result = avy12351_accumulated / avy12351_counted;"
+        "double avy12351_result = avy12351_accumulated / avy12351_counted;",
+        "output->data[0] = avy12351_result;"
       )
     )
 
@@ -116,7 +116,8 @@ final class ExpressionGenerationSpec extends AnyFreeSpec with BeforeAndAfter wit
           "avy1232_accumulated += input->data[i] + 2.0;",
           "avy1232_counted += 1;",
           "}",
-          "double avy1232_result = avy1232_accumulated / avy1232_counted;"
+          "double avy1232_result = avy1232_accumulated / avy1232_counted;",
+          "output->data[0] = avy1232_result;"
         )
     )
 

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/planning/simplesum/SimpleSumPlanTest.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/spark/planning/simplesum/SimpleSumPlanTest.scala
@@ -1,12 +1,14 @@
 package com.nec.spark.planning.simplesum
-import com.nec.spark.SparkAdditions
+import com.nec.spark.BenchTestingPossibilities.BenchTestAdditions
+import com.nec.spark.BenchTestingPossibilities.CleanName
+import com.nec.spark.BenchTestingPossibilities.CleanName.RichStringClean
+import com.nec.spark.BenchTestingPossibilities.Testing
 import com.nec.spark.cgescape.CodegenEscapeSpec.makeCsvNums
 import com.nec.spark.cgescape.CodegenEscapeSpec.makeMemoryNums
 import com.nec.spark.cgescape.CodegenEscapeSpec.makeParquetNums
 import com.nec.spark.planning.ArrowSummingPlan.ArrowSummer
 import com.nec.spark.planning.simplesum.SimpleSumPlan.SumMethod
-import com.nec.spark.planning.simplesum.SimpleSumPlanTest.PureJvmBasedModes
-import com.nec.spark.planning.simplesum.SimpleSumPlanTest.Source
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.Strategy
@@ -14,8 +16,8 @@ import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.internal.SQLConf.CODEGEN_FALLBACK
-import org.scalatest.BeforeAndAfter
 import org.scalatest.freespec.AnyFreeSpec
+import com.eed3si9n.expecty.Expecty.assert
 
 object SimpleSumPlanTest {
   val PureJvmBasedModes: List[SumMethod] = List(
@@ -57,45 +59,71 @@ object SimpleSumPlanTest {
 
     val All: List[Source] = List(CSV, Parquet, InMemory)
   }
-}
 
-final class SimpleSumPlanTest extends AnyFreeSpec with BeforeAndAfter with SparkAdditions {
-
-  PureJvmBasedModes.foreach { sumMethod =>
-    s"${sumMethod.title}" - {
-      Source.All.foreach { source =>
-        s"${source.title}" in withSparkSession2(
-          _.config(CODEGEN_FALLBACK.key, value = false)
-            .config("spark.sql.codegen.comments", value = true)
-            .withExtensions(sse =>
-              sse.injectPlannerStrategy(sparkSession =>
-                new Strategy {
-                  override def apply(plan: LogicalPlan): Seq[SparkPlan] =
-                    plan match {
-                      case logical.Aggregate(groupingExpressions, resultExpressions, child) =>
-                        List(SimpleSumPlan(planLater(child), sumMethod))
-                      case _ => Nil
-                    }
-                }
-              )
-            )
-        ) { sparkSession =>
-          source.generate(sparkSession)
-          val sql = "SELECT SUM(value) FROM nums"
-          import sparkSession.implicits._
-          val ds = sparkSession.sql(sql).debugSqlHere.as[Double]
-          val result = ds.collect().toList
-          assert(result == List[Double](62))
-        }
-      }
-    }
-  }
+  // not used, need to reincorporate back somehow
 
   implicit class RichDataSet[T](val dataSet: Dataset[T]) {
     def debugSqlHere: Dataset[T] = {
-      info(dataSet.queryExecution.executedPlan.toString())
+      System.err.println(dataSet.queryExecution.executedPlan.toString())
       dataSet
     }
   }
+
+  val OurTesting: List[Testing] = {
+    for {
+      sumMethod <- PureJvmBasedModes
+      source <- Source.All
+      sql = "SELECT SUM(value) FROM nums"
+    } yield new Testing {
+      override def name: CleanName = s"SimpleSum_${sumMethod.title}_${source}".clean
+      override def verify(sparkSession: SparkSession): Unit = {
+
+        import sparkSession.implicits._
+        val ds = sparkSession.sql(sql).debugSqlHere.as[Double]
+        val result = ds.collect().toList
+        assert(result == List[Double](62))
+      }
+      override def benchmark(sparkSession: SparkSession): Unit = {
+        import sparkSession.implicits._
+        val ds = sparkSession.sql(sql).as[Double]
+        ds.collect().toList
+      }
+      override def prepareSession(dataSize: Testing.DataSize): SparkSession = {
+        val conf = new SparkConf()
+        conf.setMaster("local")
+        conf.setAppName("local-test")
+        conf.set("spark.ui.enabled", "false")
+        val ss = SparkSession
+          .builder()
+          .config(conf)
+          .config(CODEGEN_FALLBACK.key, value = false)
+          .config("spark.sql.codegen.comments", value = true)
+          .withExtensions(sse =>
+            sse.injectPlannerStrategy(sparkSession =>
+              new Strategy {
+                override def apply(plan: LogicalPlan): Seq[SparkPlan] =
+                  plan match {
+                    case logical.Aggregate(groupingExpressions, resultExpressions, child) =>
+                      List(SimpleSumPlan(planLater(child), sumMethod))
+                    case _ => Nil
+                  }
+              }
+            )
+          )
+          .getOrCreate()
+
+        source.generate(ss)
+
+        ss
+      }
+      override def cleanUp(sparkSession: SparkSession): Unit = sparkSession.close()
+      override def requiresVe: Boolean = false
+    }
+  }
+}
+
+final class SimpleSumPlanTest extends AnyFreeSpec with BenchTestAdditions {
+
+  SimpleSumPlanTest.OurTesting.foreach(runTestCase)
 
 }

--- a/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/DynamicBenchmarkVeCheck.scala
+++ b/aurora4spark-parent/aurora4spark-sql-plugin/src/test/scala/com/nec/ve/DynamicBenchmarkVeCheck.scala
@@ -8,7 +8,7 @@ final class DynamicBenchmarkVeCheck extends AnyFreeSpec {
 
   /** TODO We could also generate Spark plan details from here for easy cross-referencing, as well as codegen */
   BenchTestingPossibilities.possibilities.filter(_.requiresVe).foreach { testing =>
-    testing.name in {
+    testing.name.value in {
       val sparkSession = testing.prepareSession(dataSize = DataSize.SanityCheckSize)
       try testing.verify(sparkSession)
       finally testing.cleanUp(sparkSession)


### PR DESCRIPTION
Lots of benchmarks auto-generated!

Next, need to look at generating for multiple input columns in C. Then, multiple output columns in C.

Also changed to use `CleanName` for the name of each `Testing`, to avoid weird mistakes and speed up dev.

These benchmarks will also expose any memory leakage issues - and these can have a big impact on performance meaning we could by error discard certain possibilities simply due to unnecessary memory pressures.

Now we can spot outliers and things that do really well, visually, based on the auto-generated benchmarks. For example here:
![image](https://user-images.githubusercontent.com/52247468/123880972-a76a6e00-d93b-11eb-9d04-43e1706d6f47.png)

We're looking at making most simple SQL statements work to support more variations, and from those variations, find out weaknesses/strengths, as well as where slowdowns happen so we can improve them quickly.