### PR TITLE
Prepare a base interface for supporting CSV on VE

### DIFF
--- a/src/main/java/com/nec/arrow/ArrowTransferStructures.java
+++ b/src/main/java/com/nec/arrow/ArrowTransferStructures.java
@@ -4,8 +4,6 @@ import com.sun.jna.Library;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 
-import java.nio.ByteBuffer;
-
 public interface ArrowTransferStructures extends Library {
     @Structure.FieldOrder({"data", "offsets", "count"})
     class varchar_vector extends Structure {
@@ -21,9 +19,14 @@ public interface ArrowTransferStructures extends Library {
             super(p);
             read();
         }
+
         public static class ByReference extends varchar_vector implements Structure.ByReference {
-            public ByReference() { }
-            public ByReference(Pointer p) { super(p); }
+            public ByReference() {
+            }
+
+            public ByReference(Pointer p) {
+                super(p);
+            }
         }
     }
 
@@ -41,9 +44,14 @@ public interface ArrowTransferStructures extends Library {
             super(p);
             read();
         }
+
         public static class ByReference extends varchar_vector_raw implements Structure.ByReference {
-            public ByReference() { }
-            public ByReference(Pointer p) { super(p); }
+            public ByReference() {
+            }
+
+            public ByReference(Pointer p) {
+                super(p);
+            }
         }
     }
 
@@ -60,11 +68,17 @@ public interface ArrowTransferStructures extends Library {
             super(p);
             read();
         }
+
         public static class ByReference extends non_null_int_vector implements Structure.ByReference {
-            public ByReference() { }
-            public ByReference(Pointer p) { super(p); }
+            public ByReference() {
+            }
+
+            public ByReference(Pointer p) {
+                super(p);
+            }
         }
     }
+
     @Structure.FieldOrder({"data", "count"})
     class non_null_int2_vector extends Structure {
         public long data;
@@ -78,9 +92,14 @@ public interface ArrowTransferStructures extends Library {
             super(p);
             read();
         }
+
         public static class ByReference extends non_null_int2_vector implements Structure.ByReference {
-            public ByReference() { }
-            public ByReference(Pointer p) { super(p); }
+            public ByReference() {
+            }
+
+            public ByReference(Pointer p) {
+                super(p);
+            }
         }
     }
 
@@ -106,9 +125,38 @@ public interface ArrowTransferStructures extends Library {
             super(p);
             read();
         }
+
         public static class ByReference extends non_null_double_vector implements Structure.ByReference {
-            public ByReference() { }
-            public ByReference(Pointer p) { super(p); }
+            public ByReference() {
+            }
+
+            public ByReference(Pointer p) {
+                super(p);
+            }
+        }
+    }
+
+    @Structure.FieldOrder({"data", "length"})
+    class non_null_c_bounded_string extends Structure {
+        public long data;
+        public Integer length;
+
+        public non_null_c_bounded_string() {
+            super();
+        }
+
+        public non_null_c_bounded_string(Pointer p) {
+            super(p);
+            read();
+        }
+
+        public static class ByReference extends non_null_c_bounded_string implements Structure.ByReference {
+            public ByReference() {
+            }
+
+            public ByReference(Pointer p) {
+                super(p);
+            }
         }
     }
 }

--- a/src/main/resources/com/nec/arrow/functions/cpp/transfer-definitions.h
+++ b/src/main/resources/com/nec/arrow/functions/cpp/transfer-definitions.h
@@ -28,6 +28,12 @@ typedef struct
     long count;
 } non_null_double_vector;
 
+typedef struct
+{
+    char *data;
+    int length;
+} non_null_c_bounded_string;
+
 #define VE_TD_DEFS 1
 #endif
 

--- a/src/main/resources/com/nec/arrow/functions/csv.cpp
+++ b/src/main/resources/com/nec/arrow/functions/csv.cpp
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <sstream>
+#include <vector>
+
+extern "C" long parse_csv(  non_null_c_bounded_string* csv_data,
+                            non_null_double_vector* output_a,
+                            non_null_double_vector* output_b,
+                            non_null_double_vector* output_c)
+{
+    std::string x(csv_data->data, csv_data->length);
+    std::istringstream input2;
+    input2.str(x);
+    std::string line;
+    std::vector<double> a_values = {};
+    std::vector<double> b_values = {};
+    std::vector<double> c_values = {};
+    
+
+    int line_idx = 0;
+    int output_idx = -1;
+    
+    while(getline(input2, line, '\n')) {
+        if ( !line.empty()) {
+            if ( !(output_idx < 0) ) {
+                std::stringstream ss(line);
+                std::string part;
+                getline(ss, part, ',');
+                double val_a = std::stod(part);
+                getline(ss, part, ',');
+                double val_b = std::stod(part);
+                getline(ss, part, ',');
+                double val_c = std::stod(part);
+                a_values.push_back(val_a);
+                b_values.push_back(val_b);
+                c_values.push_back(val_c);
+            }
+            line_idx++;
+            output_idx++;
+        }
+    }
+
+    int count = output_idx;
+
+    size_t mem_len = sizeof (double) * count;
+
+    output_a->data = (double *)malloc (mem_len);
+    memcpy(output_a->data, a_values.data(), mem_len),
+    output_a->count = count;
+
+    output_b->data = (double *)malloc (mem_len);
+    memcpy(output_b->data, b_values.data(), mem_len),
+    output_b->count = count;
+
+    output_c->data = (double *)malloc (mem_len);
+    memcpy(output_c->data, c_values.data(), mem_len),
+    output_c->count = count;
+
+
+    return 0;
+}

--- a/src/main/scala/com/nec/arrow/ArrowInterfaces.scala
+++ b/src/main/scala/com/nec/arrow/ArrowInterfaces.scala
@@ -11,6 +11,8 @@ import sun.nio.ch.DirectBuffer
 import org.apache.arrow.vector.IntVector
 import com.nec.arrow.ArrowTransferStructures._
 
+import java.nio.ByteBuffer
+
 object ArrowInterfaces {
 
   def non_null_int_vector_to_IntVector(input: non_null_int_vector, output: IntVector): Unit = {
@@ -34,6 +36,17 @@ object ArrowInterfaces {
     vc.data = float8Vector.getDataBuffer.nioBuffer().asInstanceOf[DirectBuffer].address()
 
     vc.count = float8Vector.getValueCount
+    vc
+  }
+
+  def c_bounded_string(string: String): non_null_c_bounded_string = {
+    val vc = new non_null_c_bounded_string()
+    vc.data = ByteBuffer
+      .allocateDirect(string.length)
+      .put(string.getBytes())
+      .asInstanceOf[DirectBuffer]
+      .address()
+    vc.length = string.length
     vc
   }
 

--- a/src/main/scala/com/nec/arrow/ArrowNativeInterfaceNumeric.scala
+++ b/src/main/scala/com/nec/arrow/ArrowNativeInterfaceNumeric.scala
@@ -34,8 +34,8 @@ trait ArrowNativeInterfaceNumeric extends Serializable {
 object ArrowNativeInterfaceNumeric {
   sealed trait SupportedVectorWrapper {}
   object SupportedVectorWrapper {
+    final case class StringWrapper(string: String) extends SupportedVectorWrapper
     final case class Float8VectorWrapper(float8Vector: Float8Vector) extends SupportedVectorWrapper
     final case class IntVectorWrapper(intVector: IntVector) extends SupportedVectorWrapper
-
   }
 }

--- a/src/main/scala/com/nec/arrow/CArrowNativeInterfaceNumeric.scala
+++ b/src/main/scala/com/nec/arrow/CArrowNativeInterfaceNumeric.scala
@@ -1,13 +1,13 @@
 package com.nec.arrow
 
-import java.nio.file.Path
-
-import com.nec.arrow.ArrowTransferStructures.{non_null_double_vector, non_null_int2_vector}
-import com.nec.arrow.ArrowInterfaces.{c_double_vector, c_int2_vector, non_null_double_vector_to_float8Vector}
+import com.nec.arrow.ArrowTransferStructures.non_null_double_vector
+import com.nec.arrow.ArrowInterfaces.c_double_vector
+import com.nec.arrow.ArrowInterfaces.c_int2_vector
+import com.nec.arrow.ArrowInterfaces.non_null_double_vector_to_float8Vector
 import com.sun.jna.Library
-import org.apache.arrow.vector.Float8Vector
-import ArrowNativeInterfaceNumeric._
-import SupportedVectorWrapper._
+import com.nec.arrow.ArrowNativeInterfaceNumeric._
+import com.nec.arrow.ArrowNativeInterfaceNumeric.SupportedVectorWrapper._
+import com.nec.arrow.ArrowInterfaces.c_bounded_string
 
 final class CArrowNativeInterfaceNumeric(libPath: String) extends ArrowNativeInterfaceNumeric {
   override def callFunctionGen(
@@ -36,22 +36,21 @@ object CArrowNativeInterfaceNumeric {
     val nl = nativeLibraryHandler.getNativeLibrary
     val fn = nl.getFunction(functionName)
 
-    val outputStructs = outputArguments.map(_.map{
-      case Float8VectorWrapper(doubleVector) =>
-        new non_null_double_vector(doubleVector.getValueCount)
+    val outputStructs = outputArguments.map(_.map { case Float8VectorWrapper(doubleVector) =>
+      new non_null_double_vector(doubleVector.getValueCount)
     })
 
     val invokeArgs: Array[java.lang.Object] = inputArguments
       .zip(outputStructs)
       .map {
+        case ((Some(StringWrapper(str)), _)) =>
+          c_bounded_string(str)
         case ((Some(Float8VectorWrapper(vcv)), _)) =>
           c_double_vector(vcv)
         case ((Some(IntVectorWrapper(vcv)), _)) =>
           c_int2_vector(vcv)
         case ((_, Some(structVector))) =>
           structVector
-        case other =>
-          sys.error(s"Unexpected state: $other")
       }
       .toArray
 

--- a/src/main/scala/com/nec/arrow/functions/CsvParse.scala
+++ b/src/main/scala/com/nec/arrow/functions/CsvParse.scala
@@ -1,0 +1,24 @@
+package com.nec.arrow.functions
+
+import com.nec.arrow.ArrowNativeInterfaceNumeric
+import com.nec.arrow.ArrowNativeInterfaceNumeric.SupportedVectorWrapper.StringWrapper
+import org.apache.arrow.vector.Float8Vector
+
+object CsvParse {
+
+  val CsvParseCode: String = {
+    val source = scala.io.Source.fromInputStream(getClass.getResourceAsStream("csv.cpp"))
+    try source.mkString
+    finally source.close()
+  }
+
+  def runOn(
+    nativeInterface: ArrowNativeInterfaceNumeric
+  )(input: String, a: Float8Vector, b: Float8Vector, c: Float8Vector): Unit = {
+    nativeInterface.callFunction(
+      name = "parse_csv",
+      inputArguments = List(Some(StringWrapper(input)), None, None, None),
+      outputArguments = List(None, Some(a), Some(b), Some(c))
+    )
+  }
+}

--- a/src/test/scala/com/nec/cmake/functions/ParseCSVSpec.scala
+++ b/src/test/scala/com/nec/cmake/functions/ParseCSVSpec.scala
@@ -1,0 +1,54 @@
+package com.nec.cmake.functions
+
+import com.eed3si9n.expecty.Expecty.expect
+import com.eed3si9n.expecty.Expecty.assert
+import com.nec.arrow.ArrowNativeInterfaceNumeric
+import com.nec.arrow.CArrowNativeInterfaceNumeric
+import com.nec.arrow.TransferDefinitions
+import com.nec.arrow.functions.CsvParse
+import com.nec.cmake.CMakeBuilder
+import com.nec.cmake.functions.ParseCSVSpec.verifyOn
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.Float8Vector
+import org.scalatest.freespec.AnyFreeSpec
+
+object ParseCSVSpec {
+  implicit class RichFloat8(float8Vector: Float8Vector) {
+    def toList: List[Double] = (0 until float8Vector.getValueCount).map(float8Vector.get).toList
+  }
+
+  def verifyOn(arrowInterfaceNumeric: ArrowNativeInterfaceNumeric): Unit = {
+
+    val inputColumns = List[(Double, Double, Double)]((1, 2, 3), (4, 5, 6), (7, 8, 9))
+    val inputStr = inputColumns
+      .map { case (a, b, c) => List(a, b, c).mkString(",") }
+      .mkString(start = "a,b,c\n", sep = "\n", end = "\n\n")
+    val alloc = new RootAllocator(Integer.MAX_VALUE)
+    val a = new Float8Vector("a", alloc)
+    val b = new Float8Vector("b", alloc)
+    val c = new Float8Vector("c", alloc)
+    CsvParse.runOn(arrowInterfaceNumeric)(inputStr, a, b, c)
+
+    expect(
+      a.toList == inputColumns.map(_._1),
+      b.toList == inputColumns.map(_._2),
+      c.toList == inputColumns.map(_._3)
+    )
+
+    CsvParse.runOn(arrowInterfaceNumeric)(inputStr + "\n5,43,1.2\n", a, b, c)
+
+    assert(a.getValueCount == 4)
+  }
+}
+
+final class ParseCSVSpec extends AnyFreeSpec {
+
+  "Through Arrow, it works" in {
+    val cLib = CMakeBuilder.buildC(
+      List(TransferDefinitions.TransferDefinitionsSourceCode, CsvParse.CsvParseCode)
+        .mkString("\n\n")
+    )
+    verifyOn(new CArrowNativeInterfaceNumeric(cLib.toString))
+  }
+
+}

--- a/src/test/scala/com/nec/ve/ParseVECSVSpec.scala
+++ b/src/test/scala/com/nec/ve/ParseVECSVSpec.scala
@@ -1,0 +1,44 @@
+package com.nec.ve
+
+import com.nec.arrow.TransferDefinitions
+import com.nec.arrow.VeArrowNativeInterfaceNumeric
+import com.nec.arrow.functions.CsvParse
+import com.nec.aurora.Aurora
+import com.nec.cmake.CMakeBuilder
+import com.nec.cmake.functions.ParseCSVSpec.verifyOn
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.Float8Vector
+import org.scalatest.freespec.AnyFreeSpec
+
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.time.Instant
+
+final class ParseVECSVSpec extends AnyFreeSpec {
+  "We can sort a list of ints" in {
+    val veBuildPath = Paths.get("target", "ve", s"${Instant.now().toEpochMilli}").toAbsolutePath
+    Files.createDirectory(veBuildPath)
+    val soPath = VeKernelCompiler("csv", veBuildPath).compile_c(
+      List(TransferDefinitions.TransferDefinitionsSourceCode, CsvParse.CsvParseCode)
+        .mkString("\n\n")
+    )
+
+    val proc = Aurora.veo_proc_create(0)
+    try {
+      val ctx: Aurora.veo_thr_ctxt = Aurora.veo_context_open(proc)
+      try {
+        val alloc = new RootAllocator(Integer.MAX_VALUE)
+        val outVector = new Float8Vector("value", alloc)
+        val data: Seq[Double] = Seq(5, 1, 2, 34, 6)
+        val lib: Long = Aurora.veo_load_library(proc, soPath.toString)
+        verifyOn(new VeArrowNativeInterfaceNumeric(proc, ctx, lib))
+      } finally Aurora.veo_context_close(ctx)
+    } finally Aurora.veo_proc_destroy(proc)
+  }
+  "Through Arrow, it works" in {
+    val cLib = CMakeBuilder.buildC(
+      List(TransferDefinitions.TransferDefinitionsSourceCode, CsvParse.CsvParseCode)
+        .mkString("\n\n")
+    )
+  }
+}


### PR DESCRIPTION
Run the tests using: ` ~ CMake / testOnly *ParseCSV*` and `~ VectorEngine / testOnly *ParseVECSV*`.

The code `csv.cpp` is to be replaced by efficient C++.