### PR TITLE
Test reading of whole-CSV files

### DIFF
--- a/SBT.md
+++ b/SBT.md
@@ -8,14 +8,16 @@ Requirements:
 
 ## Hadoop set up on Windows
 
-For Windows, make sure you configure Hadoop as per [Hadoop on Windows](https://wiki.apache.org/hadoop/WindowsProblems) and set the appropriate `HADOOP_HOME`. Binaries [here](https://github.com/steveloughran/winutils/releases/tag/tag_2017-08-29-hadoop-2.8.1-native).
+For Windows, make sure you configure Hadoop as per [Hadoop on Windows](https://wiki.apache.org/hadoop/WindowsProblems) and set the appropriate `HADOOP_HOME` (download winutils)
 
 Then the files should look like this:
 
 ```
-C:/hadoop-2.8.1/bin/hadoop.dll
+C:/hadoop-3.2.1/bin/hadoop.dll
 ...
 ```
+
+Also add the bin directory to `PATH`.
 
 ## VE configuration options
 

--- a/src/test/scala/com/nec/spark/ReadFullCSVSpec.scala
+++ b/src/test/scala/com/nec/spark/ReadFullCSVSpec.scala
@@ -1,0 +1,47 @@
+package com.nec.spark
+
+import com.eed3si9n.expecty.Expecty.expect
+import com.nec.spark.ReadFullCSVSpec.SampleRow
+import org.scalatest.BeforeAndAfter
+import org.scalatest.freespec.AnyFreeSpec
+
+import java.nio.file.Paths
+
+object ReadFullCSVSpec {
+  final case class SampleRow(a: Double, b: Double, c: Double)
+}
+
+final class ReadFullCSVSpec extends AnyFreeSpec with BeforeAndAfter with SparkAdditions {
+  "We can write and read back a .csv.gz collection via Hadoop" in withSparkSession2(identity) {
+    sparkSession =>
+      info(
+        "This shows that we can read these files from hdfs, and then should be able to read them as a whole and push to the VE."
+      )
+      info(
+        "Currently we get a String however to make a Byte array is very straightforward, and will bring good performance gains."
+      )
+      import sparkSession.sqlContext.implicits._
+      val targetPath = Paths.get("target").toAbsolutePath
+      val samplePartedCsv = targetPath.resolve("sample.csv").toString
+      List[SampleRow](
+        SampleRow(1, 2, 3),
+        SampleRow(4, 5, 6),
+        SampleRow(5, 4, 3),
+        SampleRow(2, 1, -1)
+      )
+        .toDF()
+        .repartition(numPartitions = 3)
+        .write
+        .format("csv")
+        .option("header", "true")
+        .mode("overwrite")
+        .option("compression", "gzip")
+        .save(samplePartedCsv)
+      val listOfPairs = sparkSession.sparkContext
+        .wholeTextFiles(samplePartedCsv)
+        .collect()
+        .toList
+
+      expect(listOfPairs.size == 3, listOfPairs.exists(_._2.contains("5.0,4.0,3.0")))
+  }
+}


### PR DESCRIPTION
This will enable us to load them directly into VE. an optimization will be to skip the String step and upload the bytes directly via memory - TODO later.

These files are normally not very big, due to the nature of Hadoop's parallelization where source data is split up.