### PR TITLE
Implement a deep stack sampler/profiler for JMH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,5 @@ java.hprof.txt
 .attach_*
 *.csv.gz
 *.crc
+
+thread-samples.json

--- a/SBT.md
+++ b/SBT.md
@@ -8,7 +8,8 @@ Requirements:
 
 ## Hadoop set up on Windows
 
-For Windows, make sure you configure Hadoop as per [Hadoop on Windows](https://wiki.apache.org/hadoop/WindowsProblems) and set the appropriate `HADOOP_HOME` (download winutils)
+For Windows, make sure you configure Hadoop as per [Hadoop on Windows](https://wiki.apache.org/hadoop/WindowsProblems)
+and set the appropriate `HADOOP_HOME` (download winutils)
 
 Then the files should look like this:
 
@@ -36,23 +37,26 @@ export SPARK_SCALA_VERSION=2.12
 
 ## Cluster tests
 
-For Cluster-mode/detection tests that run on the `VectorEngine` scope, ensure that `$SPARK_HOME/work` is writable (`mkdir -p /opt/spark/work && chmod -R 777 /opt/spark/work`).
+For Cluster-mode/detection tests that run on the `VectorEngine` scope, ensure that `$SPARK_HOME/work` is
+writable (`mkdir -p /opt/spark/work && chmod -R 777 /opt/spark/work`).
 
 ## Development for Spark 2.3 / Scala 2.11
 
 Done using SBT's cross-build: https://www.scala-sbt.org/1.x/docs/Cross-Build.html
 
-You can eg create a directory `src/main/scala-2.12` and `src/main/scala-2.11` for compiling those version-specific sources.
+You can eg create a directory `src/main/scala-2.12` and `src/main/scala-2.11` for compiling those version-specific
+sources.
 
 As such, any Spark 2.3-specific tests should be done through `src/test/scala-2.11`.
 
-In the shell, switch using `+ 2.11.12`. We tried to use https://github.com/sbt/sbt-projectmatrix - while it worked
-it did not gel so well with IntelliJ.
+In the shell, switch using `+ 2.11.12`. We tried to use https://github.com/sbt/sbt-projectmatrix - while it worked it
+did not gel so well with IntelliJ.
 
 ## SBT commands
 
 - Unit tests: `~testQuick`
-- Functional tests using CMake: `~ CMake / testQuick` - for this, on Windows use `choco install --force visualstudio2017buildtools` and then install C++ through the Visual Studio Installer.
+- Functional tests using CMake: `~ CMake / testQuick` - for this, on Windows
+  use `choco install --force visualstudio2017buildtools` and then install C++ through the Visual Studio Installer.
 - Functional tests on VE (run on a VH): `~ VectorEngine / testQuick`
 - Functional tests on JVM: `testQuick`
 - Acceptance tests, which also generate `../FEATURES.md`: `AcceptanceTest / test` (or `Acc`)
@@ -73,11 +77,12 @@ VectorEngine / runMain com.nec.ve.VeBenchmarkApp sum
 #### JMH
 
 Get a gist about JMH here in this good tutorial: http://tutorials.jenkov.com/java-performance/jmh.html
-In this project, we generate the JMH benchmarks programmatically based on Scala definitions, in order to try out 
-many different variations.
+In this project, we generate the JMH benchmarks programmatically based on Scala definitions, in order to try out many
+different variations.
 
-In order to automatically generate and invoke all currently supported benchmarks You should invoke 
-the follwing commands: 
+In order to automatically generate and invoke all currently supported benchmarks You should invoke the follwing
+commands:
+
 ```
 export CUDF_PATH=/opt/aurora4spark/cudf-0.19.2-cuda10-1.jar
 ```
@@ -109,11 +114,47 @@ bench -f 1 -wi 0 -prof jfr -i 1 -jvmArgsAppend -Dspark.ui.enabled=true .*
 
 ```
 
-The first one will set the path to cudf JAR required by rapids benchmarks, while the other one
-will generate all benchmarks defined in `BenchTestingPossibilities` class and then start them.
+The first one will set the path to cudf JAR required by rapids benchmarks, while the other one will generate all
+benchmarks defined in `BenchTestingPossibilities` class and then start them.
 
 Adding new benchmarks requires implementing `Testing` abstract class and making sure it is included
 in `BenchTestingPossibilities.possibilities` list.
+
+##### Custom profiler
+
+Add the following option to periodically collect stack traces during a benchmark run:
+
+```
+# Run profiler with default 1s sampling interval
+-prof org.openjdk.jmh.profile.nec.StackSamplingProfiler
+# Run profiler with 5s sampling interval
+-prof org.openjdk.jmh.profile.nec.StackSamplingProfiler:5s
+```
+
+The output will be in `fun-bench/<benchmark id>/thread-samples.json`.
+
+The intention of this is offline analysis to see where we are actually spending time, as it seems that we cannot get
+that information fully from JFR, and the basic stack sampler does not provide enough detail for us to make any
+conclusions.
+
+An example analyzer has been included. To use it, run `fun-bench/run`. This is an example output from a small collection:
+```
+[info] running com.nec.jmh.AnalyzeDataApp
+Choose from the following files:
+[1] fun-bench\nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-SingleShotTime\thread-samples.json
+1
+Choosing 'fun-bench\nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-SingleShotTime\thread-samples.json':'
+8 WindowsSelectorImpl.java:-2 sun.nio.ch.WindowsSelectorImpl$SubSelector#poll0
+4 Inet6AddressImpl.java:-2 java.net.Inet6AddressImpl#getHostByAddr
+2 NetworkInterface.java:-2 java.net.NetworkInterface#getAll
+1 Frame.java:779 jdk.internal.org.objectweb.asm.Frame#init
+1 Inflater.java:-2 java.util.zip.Inflater#inflateBytes
+1 SqlBaseParser.java:18952 org.apache.spark.sql.catalyst.parser.SqlBaseParser#strictIdentifier
+1 UTF8Reader.java:153 com.ctc.wstx.io.UTF8Reader#read
+1 ZipFile.java:-2 java.util.zip.ZipFile#getEntry
+```
+
+
 
 ## Currently supported queries
 

--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,12 @@ lazy val `fun-bench` = project
   .settings(
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-sql" % sparkVersion.value,
-      "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % "test,acc,cmake,ve",
-      "ch.qos.logback" % "logback-classic" % "1.2.3" % "test,acc,cmake,ve"
+      "org.slf4j" % "log4j-over-slf4j" % "1.7.25",
+      "ch.qos.logback" % "logback-classic" % "1.2.3",
+      "co.fs2" %% "fs2-io" % "3.0.6",
+      "io.circe" %% "circe-literal" % "0.14.1",
+      "io.circe" %% "circe-generic" % "0.14.1",
+      "io.circe" %% "circe-parser" % "0.14.1"
     ),
     name := "funbench",
     Jmh / run := (Jmh / run).dependsOn((Test / test)).evaluated,
@@ -38,7 +42,11 @@ lazy val `fun-bench` = project
     Test / test :=
       Def.taskDyn {
         val basicTests = Def
-          .sequential((root / Test / testQuick).toTask(""), (root / CMake / testQuick).toTask(""))
+          .sequential(
+            (ThisProject / Test / testQuick).toTask(""),
+            (root / Test / testQuick).toTask(""),
+            (root / CMake / testQuick).toTask("")
+          )
         val testsWithVe = Def.sequential(basicTests, (root / VectorEngine / testQuick).toTask(""))
         val doSkipTests = (Test / skip).value
         val isOnVe = sys.env.contains("NLC_LIB_I64")

--- a/fun-bench/src/main/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
+++ b/fun-bench/src/main/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
@@ -1,0 +1,1 @@
+org.openjdk.jmh.profile.nec.StackSamplingProfiler

--- a/fun-bench/src/main/scala/com/nec/jmh/AnalyzeDataApp.scala
+++ b/fun-bench/src/main/scala/com/nec/jmh/AnalyzeDataApp.scala
@@ -1,0 +1,45 @@
+package com.nec.jmh
+import org.openjdk.jmh.profile.nec.StackSamplingProfiler.ThreadsSamples
+
+import scala.util.Try
+import cats.effect.ExitCode
+
+import java.nio.file.Paths
+import cats.effect.IO
+import cats.effect.IOApp
+import fs2.io.file.Files
+
+object AnalyzeDataApp extends IOApp {
+  override def run(args: List[String]): IO[ExitCode] = {
+    Files[IO]
+      .walk(start = Paths.get("fun-bench"), maxDepth = 2)
+      .filter(_.toString.endsWith("samples.json"))
+      .compile
+      .toList
+      .flatMap { listOfSamples =>
+        import cats.implicits._
+        if (listOfSamples.isEmpty) IO.println("No files were found.")
+        else {
+          IO.println("Choose from the following files:") *> listOfSamples.zipWithIndex.traverse {
+            case (path, idx) =>
+              IO.println(s"[${idx + 1}] ${path}")
+          } *> IO.readLine.flatMap { str =>
+            Try(str.toInt).toOption.flatMap(v => listOfSamples.lift(v - 1)) match {
+              case None => IO.println(s"Unknown input: '${str}', exiting.")
+              case Some(sample) =>
+                import io.circe.generic.auto._
+                IO.println(s"Choosing '${sample}':'") *> IO
+                  .blocking {
+                    io.circe.parser.parse(new String(java.nio.file.Files.readAllBytes(sample)))
+                  }
+                  .flatMap(e => IO.fromEither(e).flatMap(e => IO.fromEither(e.as[ThreadsSamples])))
+                  .flatMap { samples =>
+                    AnalyzeSamples(samples).flatMap(IO.println)
+                  }
+            }
+          }
+        }
+      }
+      .as(ExitCode.Success)
+  }
+}

--- a/fun-bench/src/main/scala/com/nec/jmh/AnalyzeSamples.scala
+++ b/fun-bench/src/main/scala/com/nec/jmh/AnalyzeSamples.scala
@@ -1,0 +1,25 @@
+package com.nec.jmh
+import org.openjdk.jmh.profile.nec.StackSamplingProfiler.ThreadsSamples
+import cats.effect.IO
+
+object AnalyzeSamples {
+  val IgnoreFiles = Set("Object.java", "Unsafe.java", "ThreadImpl.java")
+  val TopN = 10
+  def apply(threadsSamples: ThreadsSamples): IO[String] = IO.blocking {
+    threadsSamples
+      .flatMap(threadsSample =>
+        threadsSample.threads.filter(_.stack.nonEmpty).flatMap(_.stack.headOption)
+      )
+      .filterNot(_.fileName.exists(f => IgnoreFiles.contains(f)))
+      .groupBy(identity)
+      .mapValues(_.size)
+      .toList
+      .sortBy(_._2)
+      .reverse
+      .take(TopN)
+      .map { case (element, count) =>
+        s"${count} ${element.fileName.map(f => f + ":" + element.lineNumber).mkString} ${element.className}#${element.methodName}"
+      }
+      .mkString("\n")
+  }
+}

--- a/fun-bench/src/main/scala/org/openjdk/jmh/profile/nec/StackSamplingProfiler.scala
+++ b/fun-bench/src/main/scala/org/openjdk/jmh/profile/nec/StackSamplingProfiler.scala
@@ -1,0 +1,148 @@
+package org.openjdk.jmh.profile.nec
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.openjdk.jmh.profile.nec.StackSamplingProfiler.DefaultInterval
+import org.openjdk.jmh.profile.nec.StackSamplingProfiler.SamplingTask
+import org.openjdk.jmh.infra.BenchmarkParams
+import org.openjdk.jmh.infra.IterationParams
+import org.openjdk.jmh.profile.InternalProfiler
+import org.openjdk.jmh.results.IterationResult
+import org.openjdk.jmh.results.Result
+import org.openjdk.jmh.results.TextResult
+import org.openjdk.jmh.runner.IterationType
+
+import java.lang.management.ManagementFactory
+import java.nio.file.Paths
+import java.time.Instant
+import java.util
+import java.util.Collections
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
+import scala.language.existentials
+
+object StackSamplingProfiler {
+
+  type ThreadsSamples = List[ThreadsSample]
+  final case class ThreadsSample(instant: Instant, threads: List[ThreadSample])
+  final case class ThreadSample(threadName: String, stack: List[StackTraceElementScala])
+  final case class StackTraceElementScala(
+    className: String,
+    methodName: String,
+    fileName: Option[String],
+    lineNumber: Int
+  ) {
+    require(className != null)
+    require(methodName != null)
+    require(fileName != null)
+  }
+  object StackTraceElementScala {
+    def apply(stackTraceElement: StackTraceElement): StackTraceElementScala =
+      StackTraceElementScala(
+        className = stackTraceElement.getClassName,
+        methodName = stackTraceElement.getMethodName,
+        fileName = Option(stackTraceElement.getFileName),
+        lineNumber = stackTraceElement.getLineNumber
+      )
+  }
+
+  final class SamplingTask(interval: FiniteDuration) {
+    var end: IO[Unit] = _
+
+    def stop(): Unit = end.unsafeRunSync()
+    def getSample: IO[ThreadsSample] = IO.delay {
+      val threadInfos = ManagementFactory.getThreadMXBean.dumpAllThreads(false, false)
+      ThreadsSample(
+        instant = Instant.now(),
+        threads = threadInfos.toList.map(threadInfo =>
+          ThreadSample(
+            threadName = threadInfo.getThreadName,
+            stack = threadInfo.getStackTrace.toList.map(stackTraceElement =>
+              StackTraceElementScala(stackTraceElement)
+            )
+          )
+        )
+      )
+    }
+    var collectedItems = scala.collection.mutable.Buffer.empty[ThreadsSample]
+    def start(): Unit = {
+      val (allocated, end) =
+        fs2.Stream
+          .awakeEvery[IO](interval)
+          .evalMap { _ =>
+            getSample
+          }
+          .evalMap(sample => IO.delay(collectedItems.append(sample)))
+          .compile
+          .drain
+          .background
+          .allocated
+          .unsafeRunSync()
+
+      this.end = end
+    }
+    def result(benchmarkParams: BenchmarkParams): TextResult = {
+      val theFile = Paths
+        .get(System.getProperty("user.dir"))
+        .resolve(benchmarkParams.id())
+        .resolve("thread-samples.json")
+        .toAbsolutePath
+      import io.circe.syntax._
+      import io.circe.generic.auto._
+      java.nio.file.Files.write(theFile, collectedItems.toList.asJson.spaces2.getBytes())
+      new TextResult(s"Saved a log of thread samples to file: ${theFile}", "ssp")
+    }
+  }
+
+  val DefaultInterval: FiniteDuration = 1.second
+
+}
+
+final class StackSamplingProfiler(params: Option[String]) extends InternalProfiler {
+
+  def this(str: String) = this(Some(str))
+
+  def this() = this(None)
+
+  @volatile
+  private var samplingTask: SamplingTask = _
+
+  override def beforeIteration(
+    benchmarkParams: BenchmarkParams,
+    iterationParams: IterationParams
+  ): Unit = {
+    import scala.concurrent.duration._
+
+    this.samplingTask = new SamplingTask(
+      params
+        .filter(_.nonEmpty)
+        .map(strInterval => Duration(strInterval).toSeconds)
+        .filter(_ > 0)
+        .map(intervalSecs => FiniteDuration(intervalSecs, SECONDS))
+        .getOrElse(DefaultInterval)
+    )
+    this.samplingTask.start()
+  }
+
+  override def afterIteration(
+    benchmarkParams: BenchmarkParams,
+    iterationParams: IterationParams,
+    result: IterationResult
+  ): util.Collection[
+    _ <: Result[T] forSome {
+      type T <: Result[T]
+    }
+  ] = {
+    this.samplingTask.stop()
+    if (iterationParams.getType == IterationType.MEASUREMENT) {
+      val result = Collections.singleton(this.samplingTask.result(benchmarkParams))
+      this.samplingTask.collectedItems.clear()
+      result
+    } else {
+      Collections.emptyList()
+    }
+  }
+
+  override def getDescription: String =
+    "Java stack profiler to collect stack traces periodically for a picture of activity"
+}

--- a/fun-bench/src/test/resources/com/nec/jmh/thread-samples.json
+++ b/fun-bench/src/test/resources/com/nec/jmh/thread-samples.json
@@ -1,0 +1,16571 @@
+[
+  {
+    "instant" : "2021-07-17T21:13:27.799Z",
+    "threads" : [
+      {
+        "threadName" : "io-scheduler",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1081
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-jmh-worker-1",
+        "stack" : [
+          {
+            "className" : "java.net.Inet6AddressImpl",
+            "methodName" : "getHostByAddr",
+            "fileName" : "Inet6AddressImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.net.InetAddress$2",
+            "methodName" : "getHostByAddr",
+            "fileName" : "InetAddress.java",
+            "lineNumber" : 933
+          },
+          {
+            "className" : "java.net.InetAddress",
+            "methodName" : "getHostFromNameService",
+            "fileName" : "InetAddress.java",
+            "lineNumber" : 618
+          },
+          {
+            "className" : "java.net.InetAddress",
+            "methodName" : "getCanonicalHostName",
+            "fileName" : "InetAddress.java",
+            "lineNumber" : 589
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "$anonfun$localCanonicalHostName$1",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1048
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$$$Lambda$167/1096976312",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.Option",
+            "methodName" : "getOrElse",
+            "fileName" : "Option.scala",
+            "lineNumber" : 189
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "localCanonicalHostName",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1048
+          },
+          {
+            "className" : "org.apache.spark.internal.config.package$",
+            "methodName" : "<init>",
+            "fileName" : "package.scala",
+            "lineNumber" : 936
+          },
+          {
+            "className" : "org.apache.spark.internal.config.package$",
+            "methodName" : "<clinit>",
+            "fileName" : "package.scala",
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.SparkConf$",
+            "methodName" : "<init>",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 654
+          },
+          {
+            "className" : "org.apache.spark.SparkConf$",
+            "methodName" : "<clinit>",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.SparkConf",
+            "methodName" : "set",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 94
+          },
+          {
+            "className" : "org.apache.spark.SparkConf",
+            "methodName" : "set",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 83
+          },
+          {
+            "className" : "org.apache.spark.SparkConf",
+            "methodName" : "setMaster",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 115
+          },
+          {
+            "className" : "com.nec.spark.planning.JoinPlanSpec$TestingOUR",
+            "methodName" : "prepareSession",
+            "fileName" : "JoinPlanSpec.scala",
+            "lineNumber" : 145
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "prepare",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 356
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "_jmh_tryInit_f_state_testingour_testingour_injvm_jvm1_G",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 480
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "TestingOUR_TestingOUR_InJVM_JVM_SingleShotTime",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 377
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 470
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 453
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-11",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-10",
+        "stack" : [
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpThreads0",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 496
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 484
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask",
+            "methodName" : "$anonfun$getSample$1",
+            "fileName" : "StackSamplingProfiler.scala",
+            "lineNumber" : 50
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask$$Lambda$170/142100135",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "runLoop",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 383
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "asyncContinueSuccessfulR",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 1132
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "run",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 126
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 359
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-9",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-8",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-4",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-3",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "Attach Listener",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Signal Dispatcher",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Finalizer",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 165
+          },
+          {
+            "className" : "java.lang.ref.Finalizer$FinalizerThread",
+            "methodName" : "run",
+            "fileName" : "Finalizer.java",
+            "lineNumber" : 216
+          }
+        ]
+      },
+      {
+        "threadName" : "Reference Handler",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.lang.ref.Reference",
+            "methodName" : "tryHandlePending",
+            "fileName" : "Reference.java",
+            "lineNumber" : 191
+          },
+          {
+            "className" : "java.lang.ref.Reference$ReferenceHandler",
+            "methodName" : "run",
+            "fileName" : "Reference.java",
+            "lineNumber" : 153
+          }
+        ]
+      },
+      {
+        "threadName" : "main",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "poll",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 467
+          },
+          {
+            "className" : "java.util.concurrent.ExecutorCompletionService",
+            "methodName" : "poll",
+            "fileName" : "ExecutorCompletionService.java",
+            "lineNumber" : 202
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler",
+            "methodName" : "runIteration",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 367
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 281
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 233
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "doSingle",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 138
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmarksForked",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 75
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedRunner",
+            "methodName" : "run",
+            "fileName" : "ForkedRunner.java",
+            "lineNumber" : 72
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedMain",
+            "methodName" : "main",
+            "fileName" : "ForkedMain.java",
+            "lineNumber" : 84
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "instant" : "2021-07-17T21:13:28.576Z",
+    "threads" : [
+      {
+        "threadName" : "io-scheduler",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1081
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-jmh-worker-1",
+        "stack" : [
+          {
+            "className" : "java.net.Inet6AddressImpl",
+            "methodName" : "getHostByAddr",
+            "fileName" : "Inet6AddressImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.net.InetAddress$2",
+            "methodName" : "getHostByAddr",
+            "fileName" : "InetAddress.java",
+            "lineNumber" : 933
+          },
+          {
+            "className" : "java.net.InetAddress",
+            "methodName" : "getHostFromNameService",
+            "fileName" : "InetAddress.java",
+            "lineNumber" : 618
+          },
+          {
+            "className" : "java.net.InetAddress",
+            "methodName" : "getCanonicalHostName",
+            "fileName" : "InetAddress.java",
+            "lineNumber" : 589
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "$anonfun$localCanonicalHostName$1",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1048
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$$$Lambda$167/1096976312",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.Option",
+            "methodName" : "getOrElse",
+            "fileName" : "Option.scala",
+            "lineNumber" : 189
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "localCanonicalHostName",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1048
+          },
+          {
+            "className" : "org.apache.spark.internal.config.package$",
+            "methodName" : "<init>",
+            "fileName" : "package.scala",
+            "lineNumber" : 936
+          },
+          {
+            "className" : "org.apache.spark.internal.config.package$",
+            "methodName" : "<clinit>",
+            "fileName" : "package.scala",
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.SparkConf$",
+            "methodName" : "<init>",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 654
+          },
+          {
+            "className" : "org.apache.spark.SparkConf$",
+            "methodName" : "<clinit>",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.SparkConf",
+            "methodName" : "set",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 94
+          },
+          {
+            "className" : "org.apache.spark.SparkConf",
+            "methodName" : "set",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 83
+          },
+          {
+            "className" : "org.apache.spark.SparkConf",
+            "methodName" : "setMaster",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 115
+          },
+          {
+            "className" : "com.nec.spark.planning.JoinPlanSpec$TestingOUR",
+            "methodName" : "prepareSession",
+            "fileName" : "JoinPlanSpec.scala",
+            "lineNumber" : 145
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "prepare",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 356
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "_jmh_tryInit_f_state_testingour_testingour_injvm_jvm1_G",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 480
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "TestingOUR_TestingOUR_InJVM_JVM_SingleShotTime",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 377
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 470
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 453
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-11",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-10",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-9",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-8",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-4",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-3",
+        "stack" : [
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpThreads0",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 496
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 484
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask",
+            "methodName" : "$anonfun$getSample$1",
+            "fileName" : "StackSamplingProfiler.scala",
+            "lineNumber" : 50
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask$$Lambda$170/142100135",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "runLoop",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 383
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "asyncContinueSuccessfulR",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 1132
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "run",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 126
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 359
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "Attach Listener",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Signal Dispatcher",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Finalizer",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 165
+          },
+          {
+            "className" : "java.lang.ref.Finalizer$FinalizerThread",
+            "methodName" : "run",
+            "fileName" : "Finalizer.java",
+            "lineNumber" : 216
+          }
+        ]
+      },
+      {
+        "threadName" : "Reference Handler",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.lang.ref.Reference",
+            "methodName" : "tryHandlePending",
+            "fileName" : "Reference.java",
+            "lineNumber" : 191
+          },
+          {
+            "className" : "java.lang.ref.Reference$ReferenceHandler",
+            "methodName" : "run",
+            "fileName" : "Reference.java",
+            "lineNumber" : 153
+          }
+        ]
+      },
+      {
+        "threadName" : "main",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "poll",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 467
+          },
+          {
+            "className" : "java.util.concurrent.ExecutorCompletionService",
+            "methodName" : "poll",
+            "fileName" : "ExecutorCompletionService.java",
+            "lineNumber" : 202
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler",
+            "methodName" : "runIteration",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 367
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 281
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 233
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "doSingle",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 138
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmarksForked",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 75
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedRunner",
+            "methodName" : "run",
+            "fileName" : "ForkedRunner.java",
+            "lineNumber" : 72
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedMain",
+            "methodName" : "main",
+            "fileName" : "ForkedMain.java",
+            "lineNumber" : 84
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "instant" : "2021-07-17T21:13:29.580Z",
+    "threads" : [
+      {
+        "threadName" : "io-scheduler",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1081
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-jmh-worker-1",
+        "stack" : [
+          {
+            "className" : "java.net.Inet6AddressImpl",
+            "methodName" : "getHostByAddr",
+            "fileName" : "Inet6AddressImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.net.InetAddress$2",
+            "methodName" : "getHostByAddr",
+            "fileName" : "InetAddress.java",
+            "lineNumber" : 933
+          },
+          {
+            "className" : "java.net.InetAddress",
+            "methodName" : "getHostFromNameService",
+            "fileName" : "InetAddress.java",
+            "lineNumber" : 618
+          },
+          {
+            "className" : "java.net.InetAddress",
+            "methodName" : "getCanonicalHostName",
+            "fileName" : "InetAddress.java",
+            "lineNumber" : 589
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "$anonfun$localCanonicalHostName$1",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1048
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$$$Lambda$167/1096976312",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.Option",
+            "methodName" : "getOrElse",
+            "fileName" : "Option.scala",
+            "lineNumber" : 189
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "localCanonicalHostName",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1048
+          },
+          {
+            "className" : "org.apache.spark.internal.config.package$",
+            "methodName" : "<init>",
+            "fileName" : "package.scala",
+            "lineNumber" : 936
+          },
+          {
+            "className" : "org.apache.spark.internal.config.package$",
+            "methodName" : "<clinit>",
+            "fileName" : "package.scala",
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.SparkConf$",
+            "methodName" : "<init>",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 654
+          },
+          {
+            "className" : "org.apache.spark.SparkConf$",
+            "methodName" : "<clinit>",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.SparkConf",
+            "methodName" : "set",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 94
+          },
+          {
+            "className" : "org.apache.spark.SparkConf",
+            "methodName" : "set",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 83
+          },
+          {
+            "className" : "org.apache.spark.SparkConf",
+            "methodName" : "setMaster",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 115
+          },
+          {
+            "className" : "com.nec.spark.planning.JoinPlanSpec$TestingOUR",
+            "methodName" : "prepareSession",
+            "fileName" : "JoinPlanSpec.scala",
+            "lineNumber" : 145
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "prepare",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 356
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "_jmh_tryInit_f_state_testingour_testingour_injvm_jvm1_G",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 480
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "TestingOUR_TestingOUR_InJVM_JVM_SingleShotTime",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 377
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 470
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 453
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-11",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-10",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-9",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-8",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-4",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-3",
+        "stack" : [
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpThreads0",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 496
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 484
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask",
+            "methodName" : "$anonfun$getSample$1",
+            "fileName" : "StackSamplingProfiler.scala",
+            "lineNumber" : 50
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask$$Lambda$170/142100135",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "runLoop",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 383
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "asyncContinueSuccessfulR",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 1132
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "run",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 126
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 359
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "Attach Listener",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Signal Dispatcher",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Finalizer",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 165
+          },
+          {
+            "className" : "java.lang.ref.Finalizer$FinalizerThread",
+            "methodName" : "run",
+            "fileName" : "Finalizer.java",
+            "lineNumber" : 216
+          }
+        ]
+      },
+      {
+        "threadName" : "Reference Handler",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.lang.ref.Reference",
+            "methodName" : "tryHandlePending",
+            "fileName" : "Reference.java",
+            "lineNumber" : 191
+          },
+          {
+            "className" : "java.lang.ref.Reference$ReferenceHandler",
+            "methodName" : "run",
+            "fileName" : "Reference.java",
+            "lineNumber" : 153
+          }
+        ]
+      },
+      {
+        "threadName" : "main",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "poll",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 467
+          },
+          {
+            "className" : "java.util.concurrent.ExecutorCompletionService",
+            "methodName" : "poll",
+            "fileName" : "ExecutorCompletionService.java",
+            "lineNumber" : 202
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler",
+            "methodName" : "runIteration",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 367
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 281
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 233
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "doSingle",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 138
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmarksForked",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 75
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedRunner",
+            "methodName" : "run",
+            "fileName" : "ForkedRunner.java",
+            "lineNumber" : 72
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedMain",
+            "methodName" : "main",
+            "fileName" : "ForkedMain.java",
+            "lineNumber" : 84
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "instant" : "2021-07-17T21:13:30.568Z",
+    "threads" : [
+      {
+        "threadName" : "io-scheduler",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1081
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-jmh-worker-1",
+        "stack" : [
+          {
+            "className" : "java.net.Inet6AddressImpl",
+            "methodName" : "getHostByAddr",
+            "fileName" : "Inet6AddressImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.net.InetAddress$2",
+            "methodName" : "getHostByAddr",
+            "fileName" : "InetAddress.java",
+            "lineNumber" : 933
+          },
+          {
+            "className" : "java.net.InetAddress",
+            "methodName" : "getHostFromNameService",
+            "fileName" : "InetAddress.java",
+            "lineNumber" : 618
+          },
+          {
+            "className" : "java.net.InetAddress",
+            "methodName" : "getCanonicalHostName",
+            "fileName" : "InetAddress.java",
+            "lineNumber" : 589
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "$anonfun$localCanonicalHostName$1",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1048
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$$$Lambda$167/1096976312",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.Option",
+            "methodName" : "getOrElse",
+            "fileName" : "Option.scala",
+            "lineNumber" : 189
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "localCanonicalHostName",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1048
+          },
+          {
+            "className" : "org.apache.spark.internal.config.package$",
+            "methodName" : "<init>",
+            "fileName" : "package.scala",
+            "lineNumber" : 936
+          },
+          {
+            "className" : "org.apache.spark.internal.config.package$",
+            "methodName" : "<clinit>",
+            "fileName" : "package.scala",
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.SparkConf$",
+            "methodName" : "<init>",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 654
+          },
+          {
+            "className" : "org.apache.spark.SparkConf$",
+            "methodName" : "<clinit>",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.SparkConf",
+            "methodName" : "set",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 94
+          },
+          {
+            "className" : "org.apache.spark.SparkConf",
+            "methodName" : "set",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 83
+          },
+          {
+            "className" : "org.apache.spark.SparkConf",
+            "methodName" : "setMaster",
+            "fileName" : "SparkConf.scala",
+            "lineNumber" : 115
+          },
+          {
+            "className" : "com.nec.spark.planning.JoinPlanSpec$TestingOUR",
+            "methodName" : "prepareSession",
+            "fileName" : "JoinPlanSpec.scala",
+            "lineNumber" : 145
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "prepare",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 356
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "_jmh_tryInit_f_state_testingour_testingour_injvm_jvm1_G",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 480
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "TestingOUR_TestingOUR_InJVM_JVM_SingleShotTime",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 377
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 470
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 453
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-11",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-10",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-9",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-8",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-4",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-3",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-1",
+        "stack" : [
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpThreads0",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 496
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 484
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask",
+            "methodName" : "$anonfun$getSample$1",
+            "fileName" : "StackSamplingProfiler.scala",
+            "lineNumber" : 50
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask$$Lambda$170/142100135",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "runLoop",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 383
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "asyncContinueSuccessfulR",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 1132
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "run",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 126
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 359
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "Attach Listener",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Signal Dispatcher",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Finalizer",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 165
+          },
+          {
+            "className" : "java.lang.ref.Finalizer$FinalizerThread",
+            "methodName" : "run",
+            "fileName" : "Finalizer.java",
+            "lineNumber" : 216
+          }
+        ]
+      },
+      {
+        "threadName" : "Reference Handler",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.lang.ref.Reference",
+            "methodName" : "tryHandlePending",
+            "fileName" : "Reference.java",
+            "lineNumber" : 191
+          },
+          {
+            "className" : "java.lang.ref.Reference$ReferenceHandler",
+            "methodName" : "run",
+            "fileName" : "Reference.java",
+            "lineNumber" : 153
+          }
+        ]
+      },
+      {
+        "threadName" : "main",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "poll",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 467
+          },
+          {
+            "className" : "java.util.concurrent.ExecutorCompletionService",
+            "methodName" : "poll",
+            "fileName" : "ExecutorCompletionService.java",
+            "lineNumber" : 202
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler",
+            "methodName" : "runIteration",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 367
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 281
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 233
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "doSingle",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 138
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmarksForked",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 75
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedRunner",
+            "methodName" : "run",
+            "fileName" : "ForkedRunner.java",
+            "lineNumber" : 72
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedMain",
+            "methodName" : "main",
+            "fileName" : "ForkedMain.java",
+            "lineNumber" : 84
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "instant" : "2021-07-17T21:13:31.580Z",
+    "threads" : [
+      {
+        "threadName" : "io-scheduler",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1081
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-jmh-worker-1",
+        "stack" : [
+          {
+            "className" : "com.ctc.wstx.io.UTF8Reader",
+            "methodName" : "read",
+            "fileName" : "UTF8Reader.java",
+            "lineNumber" : 153
+          },
+          {
+            "className" : "com.ctc.wstx.io.ReaderSource",
+            "methodName" : "readInto",
+            "fileName" : "ReaderSource.java",
+            "lineNumber" : 89
+          },
+          {
+            "className" : "com.ctc.wstx.io.BranchingReaderSource",
+            "methodName" : "readInto",
+            "fileName" : "BranchingReaderSource.java",
+            "lineNumber" : 57
+          },
+          {
+            "className" : "com.ctc.wstx.sr.StreamScanner",
+            "methodName" : "loadMore",
+            "fileName" : "StreamScanner.java",
+            "lineNumber" : 998
+          },
+          {
+            "className" : "com.ctc.wstx.sr.StreamScanner",
+            "methodName" : "getNext",
+            "fileName" : "StreamScanner.java",
+            "lineNumber" : 757
+          },
+          {
+            "className" : "com.ctc.wstx.sr.BasicStreamReader",
+            "methodName" : "nextFromTree",
+            "fileName" : "BasicStreamReader.java",
+            "lineNumber" : 2793
+          },
+          {
+            "className" : "com.ctc.wstx.sr.BasicStreamReader",
+            "methodName" : "next",
+            "fileName" : "BasicStreamReader.java",
+            "lineNumber" : 1123
+          },
+          {
+            "className" : "org.apache.hadoop.conf.Configuration$Parser",
+            "methodName" : "parseNext",
+            "fileName" : "Configuration.java",
+            "lineNumber" : 3277
+          },
+          {
+            "className" : "org.apache.hadoop.conf.Configuration$Parser",
+            "methodName" : "parse",
+            "fileName" : "Configuration.java",
+            "lineNumber" : 3071
+          },
+          {
+            "className" : "org.apache.hadoop.conf.Configuration",
+            "methodName" : "loadResource",
+            "fileName" : "Configuration.java",
+            "lineNumber" : 2964
+          },
+          {
+            "className" : "org.apache.hadoop.conf.Configuration",
+            "methodName" : "loadResources",
+            "fileName" : "Configuration.java",
+            "lineNumber" : 2925
+          },
+          {
+            "className" : "org.apache.hadoop.conf.Configuration",
+            "methodName" : "getProps",
+            "fileName" : "Configuration.java",
+            "lineNumber" : 2805
+          },
+          {
+            "className" : "org.apache.hadoop.conf.Configuration",
+            "methodName" : "get",
+            "fileName" : "Configuration.java",
+            "lineNumber" : 1199
+          },
+          {
+            "className" : "org.apache.hadoop.conf.Configuration",
+            "methodName" : "getTrimmed",
+            "fileName" : "Configuration.java",
+            "lineNumber" : 1253
+          },
+          {
+            "className" : "org.apache.hadoop.conf.Configuration",
+            "methodName" : "getBoolean",
+            "fileName" : "Configuration.java",
+            "lineNumber" : 1659
+          },
+          {
+            "className" : "org.apache.hadoop.security.SecurityUtil",
+            "methodName" : "setConfigurationInternal",
+            "fileName" : "SecurityUtil.java",
+            "lineNumber" : 99
+          },
+          {
+            "className" : "org.apache.hadoop.security.SecurityUtil",
+            "methodName" : "<clinit>",
+            "fileName" : "SecurityUtil.java",
+            "lineNumber" : 88
+          },
+          {
+            "className" : "org.apache.hadoop.security.UserGroupInformation",
+            "methodName" : "initialize",
+            "fileName" : "UserGroupInformation.java",
+            "lineNumber" : 316
+          },
+          {
+            "className" : "org.apache.hadoop.security.UserGroupInformation",
+            "methodName" : "ensureInitialized",
+            "fileName" : "UserGroupInformation.java",
+            "lineNumber" : 304
+          },
+          {
+            "className" : "org.apache.hadoop.security.UserGroupInformation",
+            "methodName" : "doSubjectLogin",
+            "fileName" : "UserGroupInformation.java",
+            "lineNumber" : 1828
+          },
+          {
+            "className" : "org.apache.hadoop.security.UserGroupInformation",
+            "methodName" : "createLoginUser",
+            "fileName" : "UserGroupInformation.java",
+            "lineNumber" : 710
+          },
+          {
+            "className" : "org.apache.hadoop.security.UserGroupInformation",
+            "methodName" : "getLoginUser",
+            "fileName" : "UserGroupInformation.java",
+            "lineNumber" : 660
+          },
+          {
+            "className" : "org.apache.hadoop.security.UserGroupInformation",
+            "methodName" : "getCurrentUser",
+            "fileName" : "UserGroupInformation.java",
+            "lineNumber" : 571
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "$anonfun$getCurrentUserName$1",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 2476
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$$$Lambda$308/2039729496",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.Option",
+            "methodName" : "getOrElse",
+            "fileName" : "Option.scala",
+            "lineNumber" : 189
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "getCurrentUserName",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 2476
+          },
+          {
+            "className" : "org.apache.spark.SparkContext",
+            "methodName" : "<init>",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 314
+          },
+          {
+            "className" : "org.apache.spark.SparkContext$",
+            "methodName" : "getOrCreate",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 2678
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$Builder",
+            "methodName" : "$anonfun$getOrCreate$2",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 942
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$Builder$$Lambda$296/1830214803",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.Option",
+            "methodName" : "getOrElse",
+            "fileName" : "Option.scala",
+            "lineNumber" : 189
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$Builder",
+            "methodName" : "getOrCreate",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 936
+          },
+          {
+            "className" : "com.nec.spark.planning.JoinPlanSpec$TestingOUR",
+            "methodName" : "prepareSession",
+            "fileName" : "JoinPlanSpec.scala",
+            "lineNumber" : 158
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "prepare",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 356
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "_jmh_tryInit_f_state_testingour_testingour_injvm_jvm1_G",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 480
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "TestingOUR_TestingOUR_InJVM_JVM_SingleShotTime",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 377
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 470
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 453
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-11",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-10",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-9",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-8",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-4",
+        "stack" : [
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpThreads0",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 496
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 484
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask",
+            "methodName" : "$anonfun$getSample$1",
+            "fileName" : "StackSamplingProfiler.scala",
+            "lineNumber" : 50
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask$$Lambda$170/142100135",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "runLoop",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 383
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "asyncContinueSuccessfulR",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 1132
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "run",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 126
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 359
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-3",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "Attach Listener",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Signal Dispatcher",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Finalizer",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 165
+          },
+          {
+            "className" : "java.lang.ref.Finalizer$FinalizerThread",
+            "methodName" : "run",
+            "fileName" : "Finalizer.java",
+            "lineNumber" : 216
+          }
+        ]
+      },
+      {
+        "threadName" : "Reference Handler",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.lang.ref.Reference",
+            "methodName" : "tryHandlePending",
+            "fileName" : "Reference.java",
+            "lineNumber" : 191
+          },
+          {
+            "className" : "java.lang.ref.Reference$ReferenceHandler",
+            "methodName" : "run",
+            "fileName" : "Reference.java",
+            "lineNumber" : 153
+          }
+        ]
+      },
+      {
+        "threadName" : "main",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "poll",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 467
+          },
+          {
+            "className" : "java.util.concurrent.ExecutorCompletionService",
+            "methodName" : "poll",
+            "fileName" : "ExecutorCompletionService.java",
+            "lineNumber" : 202
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler",
+            "methodName" : "runIteration",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 367
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 281
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 233
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "doSingle",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 138
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmarksForked",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 75
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedRunner",
+            "methodName" : "run",
+            "fileName" : "ForkedRunner.java",
+            "lineNumber" : 72
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedMain",
+            "methodName" : "main",
+            "fileName" : "ForkedMain.java",
+            "lineNumber" : 84
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "instant" : "2021-07-17T21:13:32.573Z",
+    "threads" : [
+      {
+        "threadName" : "io-scheduler",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1081
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-jmh-worker-1",
+        "stack" : [
+          {
+            "className" : "java.net.NetworkInterface",
+            "methodName" : "getAll",
+            "fileName" : "NetworkInterface.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.net.NetworkInterface",
+            "methodName" : "getNetworkInterfaces",
+            "fileName" : "NetworkInterface.java",
+            "lineNumber" : 355
+          },
+          {
+            "className" : "sun.security.provider.SeedGenerator",
+            "methodName" : "addNetworkAdapterInfo",
+            "fileName" : "SeedGenerator.java",
+            "lineNumber" : 233
+          },
+          {
+            "className" : "sun.security.provider.SeedGenerator",
+            "methodName" : "access$000",
+            "fileName" : "SeedGenerator.java",
+            "lineNumber" : 80
+          },
+          {
+            "className" : "sun.security.provider.SeedGenerator$1",
+            "methodName" : "run",
+            "fileName" : "SeedGenerator.java",
+            "lineNumber" : 183
+          },
+          {
+            "className" : "sun.security.provider.SeedGenerator$1",
+            "methodName" : "run",
+            "fileName" : "SeedGenerator.java",
+            "lineNumber" : 168
+          },
+          {
+            "className" : "java.security.AccessController",
+            "methodName" : "doPrivileged",
+            "fileName" : "AccessController.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.security.provider.SeedGenerator",
+            "methodName" : "getSystemEntropy",
+            "fileName" : "SeedGenerator.java",
+            "lineNumber" : 168
+          },
+          {
+            "className" : "sun.security.provider.SecureRandom$SeederHolder",
+            "methodName" : "<clinit>",
+            "fileName" : "SecureRandom.java",
+            "lineNumber" : 201
+          },
+          {
+            "className" : "sun.security.provider.SecureRandom",
+            "methodName" : "engineNextBytes",
+            "fileName" : "SecureRandom.java",
+            "lineNumber" : 221
+          },
+          {
+            "className" : "java.security.SecureRandom",
+            "methodName" : "nextBytes",
+            "fileName" : "SecureRandom.java",
+            "lineNumber" : 478
+          },
+          {
+            "className" : "sun.nio.ch.PipeImpl$Initializer$LoopbackConnector",
+            "methodName" : "run",
+            "fileName" : "PipeImpl.java",
+            "lineNumber" : 128
+          },
+          {
+            "className" : "sun.nio.ch.PipeImpl$Initializer",
+            "methodName" : "run",
+            "fileName" : "PipeImpl.java",
+            "lineNumber" : 76
+          },
+          {
+            "className" : "sun.nio.ch.PipeImpl$Initializer",
+            "methodName" : "run",
+            "fileName" : "PipeImpl.java",
+            "lineNumber" : 61
+          },
+          {
+            "className" : "java.security.AccessController",
+            "methodName" : "doPrivileged",
+            "fileName" : "AccessController.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.nio.ch.PipeImpl",
+            "methodName" : "<init>",
+            "fileName" : "PipeImpl.java",
+            "lineNumber" : 171
+          },
+          {
+            "className" : "sun.nio.ch.SelectorProviderImpl",
+            "methodName" : "openPipe",
+            "fileName" : "SelectorProviderImpl.java",
+            "lineNumber" : 50
+          },
+          {
+            "className" : "java.nio.channels.Pipe",
+            "methodName" : "open",
+            "fileName" : "Pipe.java",
+            "lineNumber" : 155
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl",
+            "methodName" : "<init>",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 142
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorProvider",
+            "methodName" : "openSelector",
+            "fileName" : "WindowsSelectorProvider.java",
+            "lineNumber" : 44
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "openSelector",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 173
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "<init>",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 142
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoopGroup",
+            "methodName" : "newChild",
+            "fileName" : "NioEventLoopGroup.java",
+            "lineNumber" : 146
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoopGroup",
+            "methodName" : "newChild",
+            "fileName" : "NioEventLoopGroup.java",
+            "lineNumber" : 37
+          },
+          {
+            "className" : "io.netty.util.concurrent.MultithreadEventExecutorGroup",
+            "methodName" : "<init>",
+            "fileName" : "MultithreadEventExecutorGroup.java",
+            "lineNumber" : 84
+          },
+          {
+            "className" : "io.netty.util.concurrent.MultithreadEventExecutorGroup",
+            "methodName" : "<init>",
+            "fileName" : "MultithreadEventExecutorGroup.java",
+            "lineNumber" : 58
+          },
+          {
+            "className" : "io.netty.util.concurrent.MultithreadEventExecutorGroup",
+            "methodName" : "<init>",
+            "fileName" : "MultithreadEventExecutorGroup.java",
+            "lineNumber" : 47
+          },
+          {
+            "className" : "io.netty.channel.MultithreadEventLoopGroup",
+            "methodName" : "<init>",
+            "fileName" : "MultithreadEventLoopGroup.java",
+            "lineNumber" : 59
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoopGroup",
+            "methodName" : "<init>",
+            "fileName" : "NioEventLoopGroup.java",
+            "lineNumber" : 86
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoopGroup",
+            "methodName" : "<init>",
+            "fileName" : "NioEventLoopGroup.java",
+            "lineNumber" : 81
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoopGroup",
+            "methodName" : "<init>",
+            "fileName" : "NioEventLoopGroup.java",
+            "lineNumber" : 68
+          },
+          {
+            "className" : "org.apache.spark.network.util.NettyUtils",
+            "methodName" : "createEventLoop",
+            "fileName" : "NettyUtils.java",
+            "lineNumber" : 66
+          },
+          {
+            "className" : "org.apache.spark.network.client.TransportClientFactory",
+            "methodName" : "<init>",
+            "fileName" : "TransportClientFactory.java",
+            "lineNumber" : 106
+          },
+          {
+            "className" : "org.apache.spark.network.TransportContext",
+            "methodName" : "createClientFactory",
+            "fileName" : "TransportContext.java",
+            "lineNumber" : 142
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.NettyRpcEnv",
+            "methodName" : "<init>",
+            "fileName" : "NettyRpcEnv.scala",
+            "lineNumber" : 77
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.NettyRpcEnvFactory",
+            "methodName" : "create",
+            "fileName" : "NettyRpcEnv.scala",
+            "lineNumber" : 493
+          },
+          {
+            "className" : "org.apache.spark.rpc.RpcEnv$",
+            "methodName" : "create",
+            "fileName" : "RpcEnv.scala",
+            "lineNumber" : 57
+          },
+          {
+            "className" : "org.apache.spark.SparkEnv$",
+            "methodName" : "create",
+            "fileName" : "SparkEnv.scala",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "org.apache.spark.SparkEnv$",
+            "methodName" : "createDriverEnv",
+            "fileName" : "SparkEnv.scala",
+            "lineNumber" : 189
+          },
+          {
+            "className" : "org.apache.spark.SparkContext",
+            "methodName" : "createSparkEnv",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 277
+          },
+          {
+            "className" : "org.apache.spark.SparkContext",
+            "methodName" : "<init>",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 458
+          },
+          {
+            "className" : "org.apache.spark.SparkContext$",
+            "methodName" : "getOrCreate",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 2678
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$Builder",
+            "methodName" : "$anonfun$getOrCreate$2",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 942
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$Builder$$Lambda$296/1830214803",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.Option",
+            "methodName" : "getOrElse",
+            "fileName" : "Option.scala",
+            "lineNumber" : 189
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$Builder",
+            "methodName" : "getOrCreate",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 936
+          },
+          {
+            "className" : "com.nec.spark.planning.JoinPlanSpec$TestingOUR",
+            "methodName" : "prepareSession",
+            "fileName" : "JoinPlanSpec.scala",
+            "lineNumber" : 158
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "prepare",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 356
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "_jmh_tryInit_f_state_testingour_testingour_injvm_jvm1_G",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 480
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "TestingOUR_TestingOUR_InJVM_JVM_SingleShotTime",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 377
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 470
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 453
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-11",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-10",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-9",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-8",
+        "stack" : [
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpThreads0",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 496
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 484
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask",
+            "methodName" : "$anonfun$getSample$1",
+            "fileName" : "StackSamplingProfiler.scala",
+            "lineNumber" : 50
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask$$Lambda$170/142100135",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "runLoop",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 383
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "asyncContinueSuccessfulR",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 1132
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "run",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 126
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 359
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-4",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-3",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "Attach Listener",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Signal Dispatcher",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Finalizer",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 165
+          },
+          {
+            "className" : "java.lang.ref.Finalizer$FinalizerThread",
+            "methodName" : "run",
+            "fileName" : "Finalizer.java",
+            "lineNumber" : 216
+          }
+        ]
+      },
+      {
+        "threadName" : "Reference Handler",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.lang.ref.Reference",
+            "methodName" : "tryHandlePending",
+            "fileName" : "Reference.java",
+            "lineNumber" : 191
+          },
+          {
+            "className" : "java.lang.ref.Reference$ReferenceHandler",
+            "methodName" : "run",
+            "fileName" : "Reference.java",
+            "lineNumber" : 153
+          }
+        ]
+      },
+      {
+        "threadName" : "main",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "poll",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 467
+          },
+          {
+            "className" : "java.util.concurrent.ExecutorCompletionService",
+            "methodName" : "poll",
+            "fileName" : "ExecutorCompletionService.java",
+            "lineNumber" : 202
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler",
+            "methodName" : "runIteration",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 367
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 281
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 233
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "doSingle",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 138
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmarksForked",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 75
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedRunner",
+            "methodName" : "run",
+            "fileName" : "ForkedRunner.java",
+            "lineNumber" : 72
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedMain",
+            "methodName" : "main",
+            "fileName" : "ForkedMain.java",
+            "lineNumber" : 84
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "instant" : "2021-07-17T21:13:33.569Z",
+    "threads" : [
+      {
+        "threadName" : "io-scheduler",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1081
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-jmh-worker-1",
+        "stack" : [
+          {
+            "className" : "java.net.NetworkInterface",
+            "methodName" : "getAll",
+            "fileName" : "NetworkInterface.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.net.NetworkInterface",
+            "methodName" : "getNetworkInterfaces",
+            "fileName" : "NetworkInterface.java",
+            "lineNumber" : 355
+          },
+          {
+            "className" : "io.netty.util.internal.MacAddressUtil",
+            "methodName" : "bestAvailableMac",
+            "fileName" : "MacAddressUtil.java",
+            "lineNumber" : 55
+          },
+          {
+            "className" : "io.netty.util.internal.MacAddressUtil",
+            "methodName" : "defaultMachineId",
+            "fileName" : "MacAddressUtil.java",
+            "lineNumber" : 138
+          },
+          {
+            "className" : "io.netty.channel.DefaultChannelId",
+            "methodName" : "<clinit>",
+            "fileName" : "DefaultChannelId.java",
+            "lineNumber" : 99
+          },
+          {
+            "className" : "io.netty.channel.AbstractChannel",
+            "methodName" : "newId",
+            "fileName" : "AbstractChannel.java",
+            "lineNumber" : 101
+          },
+          {
+            "className" : "io.netty.channel.AbstractChannel",
+            "methodName" : "<init>",
+            "fileName" : "AbstractChannel.java",
+            "lineNumber" : 73
+          },
+          {
+            "className" : "io.netty.channel.nio.AbstractNioChannel",
+            "methodName" : "<init>",
+            "fileName" : "AbstractNioChannel.java",
+            "lineNumber" : 80
+          },
+          {
+            "className" : "io.netty.channel.nio.AbstractNioMessageChannel",
+            "methodName" : "<init>",
+            "fileName" : "AbstractNioMessageChannel.java",
+            "lineNumber" : 42
+          },
+          {
+            "className" : "io.netty.channel.socket.nio.NioServerSocketChannel",
+            "methodName" : "<init>",
+            "fileName" : "NioServerSocketChannel.java",
+            "lineNumber" : 89
+          },
+          {
+            "className" : "io.netty.channel.socket.nio.NioServerSocketChannel",
+            "methodName" : "<init>",
+            "fileName" : "NioServerSocketChannel.java",
+            "lineNumber" : 75
+          },
+          {
+            "className" : "sun.reflect.NativeConstructorAccessorImpl",
+            "methodName" : "newInstance0",
+            "fileName" : "NativeConstructorAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeConstructorAccessorImpl",
+            "methodName" : "newInstance",
+            "fileName" : "NativeConstructorAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingConstructorAccessorImpl",
+            "methodName" : "newInstance",
+            "fileName" : "DelegatingConstructorAccessorImpl.java",
+            "lineNumber" : 45
+          },
+          {
+            "className" : "java.lang.reflect.Constructor",
+            "methodName" : "newInstance",
+            "fileName" : "Constructor.java",
+            "lineNumber" : 423
+          },
+          {
+            "className" : "io.netty.channel.ReflectiveChannelFactory",
+            "methodName" : "newChannel",
+            "fileName" : "ReflectiveChannelFactory.java",
+            "lineNumber" : 44
+          },
+          {
+            "className" : "io.netty.bootstrap.AbstractBootstrap",
+            "methodName" : "initAndRegister",
+            "fileName" : "AbstractBootstrap.java",
+            "lineNumber" : 310
+          },
+          {
+            "className" : "io.netty.bootstrap.AbstractBootstrap",
+            "methodName" : "doBind",
+            "fileName" : "AbstractBootstrap.java",
+            "lineNumber" : 272
+          },
+          {
+            "className" : "io.netty.bootstrap.AbstractBootstrap",
+            "methodName" : "bind",
+            "fileName" : "AbstractBootstrap.java",
+            "lineNumber" : 268
+          },
+          {
+            "className" : "org.apache.spark.network.server.TransportServer",
+            "methodName" : "init",
+            "fileName" : "TransportServer.java",
+            "lineNumber" : 149
+          },
+          {
+            "className" : "org.apache.spark.network.server.TransportServer",
+            "methodName" : "<init>",
+            "fileName" : "TransportServer.java",
+            "lineNumber" : 84
+          },
+          {
+            "className" : "org.apache.spark.network.TransportContext",
+            "methodName" : "createServer",
+            "fileName" : "TransportContext.java",
+            "lineNumber" : 157
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.NettyRpcEnv",
+            "methodName" : "startServer",
+            "fileName" : "NettyRpcEnv.scala",
+            "lineNumber" : 125
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.NettyRpcEnvFactory",
+            "methodName" : "$anonfun$create$1",
+            "fileName" : "NettyRpcEnv.scala",
+            "lineNumber" : 496
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.NettyRpcEnvFactory",
+            "methodName" : "$anonfun$create$1$adapted",
+            "fileName" : "NettyRpcEnv.scala",
+            "lineNumber" : 495
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.NettyRpcEnvFactory$$Lambda$449/1147891143",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "$anonfun$startServiceOnPort$2",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 2320
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$$$Lambda$453/1375767080",
+            "methodName" : "apply$mcVI$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.collection.immutable.Range",
+            "methodName" : "foreach$mVc$sp",
+            "fileName" : "Range.scala",
+            "lineNumber" : 158
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "startServiceOnPort",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 2312
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.NettyRpcEnvFactory",
+            "methodName" : "create",
+            "fileName" : "NettyRpcEnv.scala",
+            "lineNumber" : 500
+          },
+          {
+            "className" : "org.apache.spark.rpc.RpcEnv$",
+            "methodName" : "create",
+            "fileName" : "RpcEnv.scala",
+            "lineNumber" : 57
+          },
+          {
+            "className" : "org.apache.spark.SparkEnv$",
+            "methodName" : "create",
+            "fileName" : "SparkEnv.scala",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "org.apache.spark.SparkEnv$",
+            "methodName" : "createDriverEnv",
+            "fileName" : "SparkEnv.scala",
+            "lineNumber" : 189
+          },
+          {
+            "className" : "org.apache.spark.SparkContext",
+            "methodName" : "createSparkEnv",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 277
+          },
+          {
+            "className" : "org.apache.spark.SparkContext",
+            "methodName" : "<init>",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 458
+          },
+          {
+            "className" : "org.apache.spark.SparkContext$",
+            "methodName" : "getOrCreate",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 2678
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$Builder",
+            "methodName" : "$anonfun$getOrCreate$2",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 942
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$Builder$$Lambda$296/1830214803",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.Option",
+            "methodName" : "getOrElse",
+            "fileName" : "Option.scala",
+            "lineNumber" : 189
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$Builder",
+            "methodName" : "getOrCreate",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 936
+          },
+          {
+            "className" : "com.nec.spark.planning.JoinPlanSpec$TestingOUR",
+            "methodName" : "prepareSession",
+            "fileName" : "JoinPlanSpec.scala",
+            "lineNumber" : 158
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "prepare",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 356
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "_jmh_tryInit_f_state_testingour_testingour_injvm_jvm1_G",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 480
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "TestingOUR_TestingOUR_InJVM_JVM_SingleShotTime",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 377
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 470
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 453
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-11",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-10",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-9",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-8",
+        "stack" : [
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpThreads0",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 496
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 484
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask",
+            "methodName" : "$anonfun$getSample$1",
+            "fileName" : "StackSamplingProfiler.scala",
+            "lineNumber" : 50
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask$$Lambda$170/142100135",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "runLoop",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 383
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "asyncContinueSuccessfulR",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 1132
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "run",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 126
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 359
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-4",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-3",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "Attach Listener",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Signal Dispatcher",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Finalizer",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 165
+          },
+          {
+            "className" : "java.lang.ref.Finalizer$FinalizerThread",
+            "methodName" : "run",
+            "fileName" : "Finalizer.java",
+            "lineNumber" : 216
+          }
+        ]
+      },
+      {
+        "threadName" : "Reference Handler",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.lang.ref.Reference",
+            "methodName" : "tryHandlePending",
+            "fileName" : "Reference.java",
+            "lineNumber" : 191
+          },
+          {
+            "className" : "java.lang.ref.Reference$ReferenceHandler",
+            "methodName" : "run",
+            "fileName" : "Reference.java",
+            "lineNumber" : 153
+          }
+        ]
+      },
+      {
+        "threadName" : "main",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "poll",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 467
+          },
+          {
+            "className" : "java.util.concurrent.ExecutorCompletionService",
+            "methodName" : "poll",
+            "fileName" : "ExecutorCompletionService.java",
+            "lineNumber" : 202
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler",
+            "methodName" : "runIteration",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 367
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 281
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 233
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "doSingle",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 138
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmarksForked",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 75
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedRunner",
+            "methodName" : "run",
+            "fileName" : "ForkedRunner.java",
+            "lineNumber" : 72
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedMain",
+            "methodName" : "main",
+            "fileName" : "ForkedMain.java",
+            "lineNumber" : 84
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "instant" : "2021-07-17T21:13:34.575Z",
+    "threads" : [
+      {
+        "threadName" : "shuffle-boss-6-1",
+        "stack" : [
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll0",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 314
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "access$400",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 293
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl",
+            "methodName" : "doSelect",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 174
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "lockAndDoSelect",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 86
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 97
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 101
+          },
+          {
+            "className" : "io.netty.channel.nio.SelectedSelectionKeySetSelector",
+            "methodName" : "select",
+            "fileName" : "SelectedSelectionKeySetSelector.java",
+            "lineNumber" : 68
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "select",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 803
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "run",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 457
+          },
+          {
+            "className" : "io.netty.util.concurrent.SingleThreadEventExecutor$4",
+            "methodName" : "run",
+            "fileName" : "SingleThreadEventExecutor.java",
+            "lineNumber" : 989
+          },
+          {
+            "className" : "io.netty.util.internal.ThreadExecutorMap$2",
+            "methodName" : "run",
+            "fileName" : "ThreadExecutorMap.java",
+            "lineNumber" : 74
+          },
+          {
+            "className" : "io.netty.util.concurrent.FastThreadLocalRunnable",
+            "methodName" : "run",
+            "fileName" : "FastThreadLocalRunnable.java",
+            "lineNumber" : 30
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "executor-heartbeater",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "driver-heartbeater",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dag-scheduler-event-loop",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingDeque",
+            "methodName" : "takeFirst",
+            "fileName" : "LinkedBlockingDeque.java",
+            "lineNumber" : 492
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingDeque",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingDeque.java",
+            "lineNumber" : 680
+          },
+          {
+            "className" : "org.apache.spark.util.EventLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "EventLoop.scala",
+            "lineNumber" : 47
+          }
+        ]
+      },
+      {
+        "threadName" : "Timer-1",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "mainLoop",
+            "fileName" : "Timer.java",
+            "lineNumber" : 526
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "run",
+            "fileName" : "Timer.java",
+            "lineNumber" : 505
+          }
+        ]
+      },
+      {
+        "threadName" : "Timer-0",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "mainLoop",
+            "fileName" : "Timer.java",
+            "lineNumber" : 526
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "run",
+            "fileName" : "Timer.java",
+            "lineNumber" : 505
+          }
+        ]
+      },
+      {
+        "threadName" : "netty-rpc-env-timeout",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "heartbeat-receiver-event-loop-thread",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "RemoteBlock-temp-file-clean-thread",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "org.apache.spark.storage.BlockManager$RemoteBlockDownloadFileManager",
+            "methodName" : "org$apache$spark$storage$BlockManager$RemoteBlockDownloadFileManager$$keepCleaning",
+            "fileName" : "BlockManager.scala",
+            "lineNumber" : 2034
+          },
+          {
+            "className" : "org.apache.spark.storage.BlockManager$RemoteBlockDownloadFileManager$$anon$2",
+            "methodName" : "run",
+            "fileName" : "BlockManager.scala",
+            "lineNumber" : 2002
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-BlockManagerEndpoint1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-BlockManagerMaster",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-4",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-3",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-event-loop-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-event-loop-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "rpc-boss-3-1",
+        "stack" : [
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll0",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 314
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "access$400",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 293
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl",
+            "methodName" : "doSelect",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 174
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "lockAndDoSelect",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 86
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 97
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 101
+          },
+          {
+            "className" : "io.netty.channel.nio.SelectedSelectionKeySetSelector",
+            "methodName" : "select",
+            "fileName" : "SelectedSelectionKeySetSelector.java",
+            "lineNumber" : 68
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "select",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 803
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "run",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 457
+          },
+          {
+            "className" : "io.netty.util.concurrent.SingleThreadEventExecutor$4",
+            "methodName" : "run",
+            "fileName" : "SingleThreadEventExecutor.java",
+            "lineNumber" : 989
+          },
+          {
+            "className" : "io.netty.util.internal.ThreadExecutorMap$2",
+            "methodName" : "run",
+            "fileName" : "ThreadExecutorMap.java",
+            "lineNumber" : 74
+          },
+          {
+            "className" : "io.netty.util.concurrent.FastThreadLocalRunnable",
+            "methodName" : "run",
+            "fileName" : "FastThreadLocalRunnable.java",
+            "lineNumber" : 30
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-scheduler",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1081
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-jmh-worker-1",
+        "stack" : [
+          {
+            "className" : "java.util.zip.Inflater",
+            "methodName" : "inflateBytes",
+            "fileName" : "Inflater.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.zip.Inflater",
+            "methodName" : "inflate",
+            "fileName" : "Inflater.java",
+            "lineNumber" : 259
+          },
+          {
+            "className" : "java.util.zip.InflaterInputStream",
+            "methodName" : "read",
+            "fileName" : "InflaterInputStream.java",
+            "lineNumber" : 152
+          },
+          {
+            "className" : "sun.misc.Resource",
+            "methodName" : "getBytes",
+            "fileName" : "Resource.java",
+            "lineNumber" : 124
+          },
+          {
+            "className" : "java.net.URLClassLoader",
+            "methodName" : "defineClass",
+            "fileName" : "URLClassLoader.java",
+            "lineNumber" : 463
+          },
+          {
+            "className" : "java.net.URLClassLoader",
+            "methodName" : "access$100",
+            "fileName" : "URLClassLoader.java",
+            "lineNumber" : 74
+          },
+          {
+            "className" : "java.net.URLClassLoader$1",
+            "methodName" : "run",
+            "fileName" : "URLClassLoader.java",
+            "lineNumber" : 369
+          },
+          {
+            "className" : "java.net.URLClassLoader$1",
+            "methodName" : "run",
+            "fileName" : "URLClassLoader.java",
+            "lineNumber" : 363
+          },
+          {
+            "className" : "java.security.AccessController",
+            "methodName" : "doPrivileged",
+            "fileName" : "AccessController.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.net.URLClassLoader",
+            "methodName" : "findClass",
+            "fileName" : "URLClassLoader.java",
+            "lineNumber" : 362
+          },
+          {
+            "className" : "java.lang.ClassLoader",
+            "methodName" : "loadClass",
+            "fileName" : "ClassLoader.java",
+            "lineNumber" : 419
+          },
+          {
+            "className" : "sun.misc.Launcher$AppClassLoader",
+            "methodName" : "loadClass",
+            "fileName" : "Launcher.java",
+            "lineNumber" : 352
+          },
+          {
+            "className" : "java.lang.ClassLoader",
+            "methodName" : "loadClass",
+            "fileName" : "ClassLoader.java",
+            "lineNumber" : 352
+          },
+          {
+            "className" : "org.apache.spark.ui.JettyUtils$",
+            "methodName" : "createServletHandler",
+            "fileName" : "JettyUtils.scala",
+            "lineNumber" : 117
+          },
+          {
+            "className" : "org.apache.spark.ui.JettyUtils$",
+            "methodName" : "createServletHandler",
+            "fileName" : "JettyUtils.scala",
+            "lineNumber" : 104
+          },
+          {
+            "className" : "org.apache.spark.metrics.sink.MetricsServlet",
+            "methodName" : "getHandlers",
+            "fileName" : "MetricsServlet.scala",
+            "lineNumber" : 53
+          },
+          {
+            "className" : "org.apache.spark.metrics.MetricsSystem",
+            "methodName" : "$anonfun$getServletHandlers$2",
+            "fileName" : "MetricsSystem.scala",
+            "lineNumber" : 93
+          },
+          {
+            "className" : "org.apache.spark.metrics.MetricsSystem$$Lambda$629/1427437516",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.Option",
+            "methodName" : "map",
+            "fileName" : "Option.scala",
+            "lineNumber" : 230
+          },
+          {
+            "className" : "org.apache.spark.metrics.MetricsSystem",
+            "methodName" : "getServletHandlers",
+            "fileName" : "MetricsSystem.scala",
+            "lineNumber" : 93
+          },
+          {
+            "className" : "org.apache.spark.SparkContext",
+            "methodName" : "<init>",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 597
+          },
+          {
+            "className" : "org.apache.spark.SparkContext$",
+            "methodName" : "getOrCreate",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 2678
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$Builder",
+            "methodName" : "$anonfun$getOrCreate$2",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 942
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$Builder$$Lambda$296/1830214803",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.Option",
+            "methodName" : "getOrElse",
+            "fileName" : "Option.scala",
+            "lineNumber" : 189
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$Builder",
+            "methodName" : "getOrCreate",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 936
+          },
+          {
+            "className" : "com.nec.spark.planning.JoinPlanSpec$TestingOUR",
+            "methodName" : "prepareSession",
+            "fileName" : "JoinPlanSpec.scala",
+            "lineNumber" : 158
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "sparkSession",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 346
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "prepare",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 356
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "_jmh_tryInit_f_state_testingour_testingour_injvm_jvm1_G",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 480
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "TestingOUR_TestingOUR_InJVM_JVM_SingleShotTime",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 377
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 470
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 453
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-11",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-10",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-9",
+        "stack" : [
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpThreads0",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 496
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 484
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask",
+            "methodName" : "$anonfun$getSample$1",
+            "fileName" : "StackSamplingProfiler.scala",
+            "lineNumber" : 50
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask$$Lambda$170/142100135",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "runLoop",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 383
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "asyncContinueSuccessfulR",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 1132
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "run",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 126
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 359
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-8",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-4",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-3",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "Attach Listener",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Signal Dispatcher",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Finalizer",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 165
+          },
+          {
+            "className" : "java.lang.ref.Finalizer$FinalizerThread",
+            "methodName" : "run",
+            "fileName" : "Finalizer.java",
+            "lineNumber" : 216
+          }
+        ]
+      },
+      {
+        "threadName" : "Reference Handler",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.lang.ref.Reference",
+            "methodName" : "tryHandlePending",
+            "fileName" : "Reference.java",
+            "lineNumber" : 191
+          },
+          {
+            "className" : "java.lang.ref.Reference$ReferenceHandler",
+            "methodName" : "run",
+            "fileName" : "Reference.java",
+            "lineNumber" : 153
+          }
+        ]
+      },
+      {
+        "threadName" : "main",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "poll",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 467
+          },
+          {
+            "className" : "java.util.concurrent.ExecutorCompletionService",
+            "methodName" : "poll",
+            "fileName" : "ExecutorCompletionService.java",
+            "lineNumber" : 202
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler",
+            "methodName" : "runIteration",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 367
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 281
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 233
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "doSingle",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 138
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmarksForked",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 75
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedRunner",
+            "methodName" : "run",
+            "fileName" : "ForkedRunner.java",
+            "lineNumber" : 72
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedMain",
+            "methodName" : "main",
+            "fileName" : "ForkedMain.java",
+            "lineNumber" : 84
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "instant" : "2021-07-17T21:13:35.574Z",
+    "threads" : [
+      {
+        "threadName" : "spark-listener-group-shared",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "$anonfun$dispatch$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 101
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$Lambda$653/1072891606",
+            "methodName" : "apply$mcJ$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.runtime.java8.JFunction0$mcJ$sp",
+            "methodName" : "apply",
+            "fileName" : "JFunction0$mcJ$sp.java",
+            "lineNumber" : 23
+          },
+          {
+            "className" : "scala.util.DynamicVariable",
+            "methodName" : "withValue",
+            "fileName" : "DynamicVariable.scala",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "org$apache$spark$scheduler$AsyncEventQueue$$dispatch",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 100
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "$anonfun$run$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2$$Lambda$651/146769391",
+            "methodName" : "apply$mcV$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "tryOrStopSparkContext",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1381
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "run",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          }
+        ]
+      },
+      {
+        "threadName" : "element-tracking-store-worker",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "spark-listener-group-executorManagement",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "$anonfun$dispatch$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 110
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$Lambda$653/1072891606",
+            "methodName" : "apply$mcJ$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.runtime.java8.JFunction0$mcJ$sp",
+            "methodName" : "apply",
+            "fileName" : "JFunction0$mcJ$sp.java",
+            "lineNumber" : 23
+          },
+          {
+            "className" : "scala.util.DynamicVariable",
+            "methodName" : "withValue",
+            "fileName" : "DynamicVariable.scala",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "org$apache$spark$scheduler$AsyncEventQueue$$dispatch",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 100
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "$anonfun$run$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2$$Lambda$651/146769391",
+            "methodName" : "apply$mcV$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "tryOrStopSparkContext",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1381
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "run",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          }
+        ]
+      },
+      {
+        "threadName" : "spark-listener-group-appStatus",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "$anonfun$dispatch$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 110
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$Lambda$653/1072891606",
+            "methodName" : "apply$mcJ$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.runtime.java8.JFunction0$mcJ$sp",
+            "methodName" : "apply",
+            "fileName" : "JFunction0$mcJ$sp.java",
+            "lineNumber" : 23
+          },
+          {
+            "className" : "scala.util.DynamicVariable",
+            "methodName" : "withValue",
+            "fileName" : "DynamicVariable.scala",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "org$apache$spark$scheduler$AsyncEventQueue$$dispatch",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 100
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "$anonfun$run$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2$$Lambda$651/146769391",
+            "methodName" : "apply$mcV$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "tryOrStopSparkContext",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1381
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "run",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          }
+        ]
+      },
+      {
+        "threadName" : "context-cleaner-periodic-gc",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "Spark Context Cleaner",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "org.apache.spark.ContextCleaner",
+            "methodName" : "$anonfun$keepCleaning$1",
+            "fileName" : "ContextCleaner.scala",
+            "lineNumber" : 182
+          },
+          {
+            "className" : "org.apache.spark.ContextCleaner$$Lambda$646/941877840",
+            "methodName" : "apply$mcV$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "tryOrStopSparkContext",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1381
+          },
+          {
+            "className" : "org.apache.spark.ContextCleaner",
+            "methodName" : "org$apache$spark$ContextCleaner$$keepCleaning",
+            "fileName" : "ContextCleaner.scala",
+            "lineNumber" : 180
+          },
+          {
+            "className" : "org.apache.spark.ContextCleaner$$anon$1",
+            "methodName" : "run",
+            "fileName" : "ContextCleaner.scala",
+            "lineNumber" : 77
+          }
+        ]
+      },
+      {
+        "threadName" : "shuffle-boss-6-1",
+        "stack" : [
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll0",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 314
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "access$400",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 293
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl",
+            "methodName" : "doSelect",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 174
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "lockAndDoSelect",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 86
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 97
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 101
+          },
+          {
+            "className" : "io.netty.channel.nio.SelectedSelectionKeySetSelector",
+            "methodName" : "select",
+            "fileName" : "SelectedSelectionKeySetSelector.java",
+            "lineNumber" : 68
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "select",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 803
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "run",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 457
+          },
+          {
+            "className" : "io.netty.util.concurrent.SingleThreadEventExecutor$4",
+            "methodName" : "run",
+            "fileName" : "SingleThreadEventExecutor.java",
+            "lineNumber" : 989
+          },
+          {
+            "className" : "io.netty.util.internal.ThreadExecutorMap$2",
+            "methodName" : "run",
+            "fileName" : "ThreadExecutorMap.java",
+            "lineNumber" : 74
+          },
+          {
+            "className" : "io.netty.util.concurrent.FastThreadLocalRunnable",
+            "methodName" : "run",
+            "fileName" : "FastThreadLocalRunnable.java",
+            "lineNumber" : 30
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "executor-heartbeater",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "driver-heartbeater",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dag-scheduler-event-loop",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingDeque",
+            "methodName" : "takeFirst",
+            "fileName" : "LinkedBlockingDeque.java",
+            "lineNumber" : 492
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingDeque",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingDeque.java",
+            "lineNumber" : 680
+          },
+          {
+            "className" : "org.apache.spark.util.EventLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "EventLoop.scala",
+            "lineNumber" : 47
+          }
+        ]
+      },
+      {
+        "threadName" : "Timer-1",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "mainLoop",
+            "fileName" : "Timer.java",
+            "lineNumber" : 526
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "run",
+            "fileName" : "Timer.java",
+            "lineNumber" : 505
+          }
+        ]
+      },
+      {
+        "threadName" : "Timer-0",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "mainLoop",
+            "fileName" : "Timer.java",
+            "lineNumber" : 526
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "run",
+            "fileName" : "Timer.java",
+            "lineNumber" : 505
+          }
+        ]
+      },
+      {
+        "threadName" : "netty-rpc-env-timeout",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "heartbeat-receiver-event-loop-thread",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "RemoteBlock-temp-file-clean-thread",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "org.apache.spark.storage.BlockManager$RemoteBlockDownloadFileManager",
+            "methodName" : "org$apache$spark$storage$BlockManager$RemoteBlockDownloadFileManager$$keepCleaning",
+            "fileName" : "BlockManager.scala",
+            "lineNumber" : 2034
+          },
+          {
+            "className" : "org.apache.spark.storage.BlockManager$RemoteBlockDownloadFileManager$$anon$2",
+            "methodName" : "run",
+            "fileName" : "BlockManager.scala",
+            "lineNumber" : 2002
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-BlockManagerEndpoint1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-BlockManagerMaster",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-4",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-3",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-event-loop-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-event-loop-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "rpc-boss-3-1",
+        "stack" : [
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll0",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 314
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "access$400",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 293
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl",
+            "methodName" : "doSelect",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 174
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "lockAndDoSelect",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 86
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 97
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 101
+          },
+          {
+            "className" : "io.netty.channel.nio.SelectedSelectionKeySetSelector",
+            "methodName" : "select",
+            "fileName" : "SelectedSelectionKeySetSelector.java",
+            "lineNumber" : 68
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "select",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 803
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "run",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 457
+          },
+          {
+            "className" : "io.netty.util.concurrent.SingleThreadEventExecutor$4",
+            "methodName" : "run",
+            "fileName" : "SingleThreadEventExecutor.java",
+            "lineNumber" : 989
+          },
+          {
+            "className" : "io.netty.util.internal.ThreadExecutorMap$2",
+            "methodName" : "run",
+            "fileName" : "ThreadExecutorMap.java",
+            "lineNumber" : 74
+          },
+          {
+            "className" : "io.netty.util.concurrent.FastThreadLocalRunnable",
+            "methodName" : "run",
+            "fileName" : "FastThreadLocalRunnable.java",
+            "lineNumber" : 30
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-scheduler",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1081
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-jmh-worker-1",
+        "stack" : [
+          {
+            "className" : "java.util.zip.ZipFile",
+            "methodName" : "getEntry",
+            "fileName" : "ZipFile.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.zip.ZipFile",
+            "methodName" : "getEntry",
+            "fileName" : "ZipFile.java",
+            "lineNumber" : 321
+          },
+          {
+            "className" : "java.util.jar.JarFile",
+            "methodName" : "getEntry",
+            "fileName" : "JarFile.java",
+            "lineNumber" : 242
+          },
+          {
+            "className" : "java.util.jar.JarFile",
+            "methodName" : "getJarEntry",
+            "fileName" : "JarFile.java",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "sun.misc.URLClassPath$JarLoader",
+            "methodName" : "getResource",
+            "fileName" : "URLClassPath.java",
+            "lineNumber" : 1054
+          },
+          {
+            "className" : "sun.misc.URLClassPath",
+            "methodName" : "getResource",
+            "fileName" : "URLClassPath.java",
+            "lineNumber" : 249
+          },
+          {
+            "className" : "java.net.URLClassLoader$1",
+            "methodName" : "run",
+            "fileName" : "URLClassLoader.java",
+            "lineNumber" : 366
+          },
+          {
+            "className" : "java.net.URLClassLoader$1",
+            "methodName" : "run",
+            "fileName" : "URLClassLoader.java",
+            "lineNumber" : 363
+          },
+          {
+            "className" : "java.security.AccessController",
+            "methodName" : "doPrivileged",
+            "fileName" : "AccessController.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.net.URLClassLoader",
+            "methodName" : "findClass",
+            "fileName" : "URLClassLoader.java",
+            "lineNumber" : 362
+          },
+          {
+            "className" : "java.lang.ClassLoader",
+            "methodName" : "loadClass",
+            "fileName" : "ClassLoader.java",
+            "lineNumber" : 419
+          },
+          {
+            "className" : "sun.misc.Launcher$AppClassLoader",
+            "methodName" : "loadClass",
+            "fileName" : "Launcher.java",
+            "lineNumber" : 352
+          },
+          {
+            "className" : "java.lang.ClassLoader",
+            "methodName" : "loadClass",
+            "fileName" : "ClassLoader.java",
+            "lineNumber" : 352
+          },
+          {
+            "className" : "org.apache.hadoop.hdfs.web.WebHdfsFileSystem",
+            "methodName" : "<init>",
+            "fileName" : "WebHdfsFileSystem.java",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "sun.reflect.NativeConstructorAccessorImpl",
+            "methodName" : "newInstance0",
+            "fileName" : "NativeConstructorAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeConstructorAccessorImpl",
+            "methodName" : "newInstance",
+            "fileName" : "NativeConstructorAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingConstructorAccessorImpl",
+            "methodName" : "newInstance",
+            "fileName" : "DelegatingConstructorAccessorImpl.java",
+            "lineNumber" : 45
+          },
+          {
+            "className" : "java.lang.reflect.Constructor",
+            "methodName" : "newInstance",
+            "fileName" : "Constructor.java",
+            "lineNumber" : 423
+          },
+          {
+            "className" : "java.lang.Class",
+            "methodName" : "newInstance",
+            "fileName" : "Class.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "java.util.ServiceLoader$LazyIterator",
+            "methodName" : "nextService",
+            "fileName" : "ServiceLoader.java",
+            "lineNumber" : 380
+          },
+          {
+            "className" : "java.util.ServiceLoader$LazyIterator",
+            "methodName" : "next",
+            "fileName" : "ServiceLoader.java",
+            "lineNumber" : 404
+          },
+          {
+            "className" : "java.util.ServiceLoader$1",
+            "methodName" : "next",
+            "fileName" : "ServiceLoader.java",
+            "lineNumber" : 480
+          },
+          {
+            "className" : "org.apache.hadoop.fs.FileSystem",
+            "methodName" : "loadFileSystems",
+            "fileName" : "FileSystem.java",
+            "lineNumber" : 3217
+          },
+          {
+            "className" : "org.apache.hadoop.fs.FileSystem",
+            "methodName" : "getFileSystemClass",
+            "fileName" : "FileSystem.java",
+            "lineNumber" : 3262
+          },
+          {
+            "className" : "org.apache.hadoop.fs.FsUrlStreamHandlerFactory",
+            "methodName" : "<init>",
+            "fileName" : "FsUrlStreamHandlerFactory.java",
+            "lineNumber" : 77
+          },
+          {
+            "className" : "org.apache.spark.sql.internal.SharedState$",
+            "methodName" : "liftedTree1$1",
+            "fileName" : "SharedState.scala",
+            "lineNumber" : 180
+          },
+          {
+            "className" : "org.apache.spark.sql.internal.SharedState$",
+            "methodName" : "org$apache$spark$sql$internal$SharedState$$setFsUrlStreamHandlerFactory",
+            "fileName" : "SharedState.scala",
+            "lineNumber" : 179
+          },
+          {
+            "className" : "org.apache.spark.sql.internal.SharedState",
+            "methodName" : "<init>",
+            "fileName" : "SharedState.scala",
+            "lineNumber" : 53
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession",
+            "methodName" : "$anonfun$sharedState$1",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 135
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$$Lambda$978/1295062928",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.Option",
+            "methodName" : "getOrElse",
+            "fileName" : "Option.scala",
+            "lineNumber" : 189
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession",
+            "methodName" : "sharedState$lzycompute",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 135
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession",
+            "methodName" : "sharedState",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 134
+          },
+          {
+            "className" : "org.apache.spark.sql.internal.BaseSessionStateBuilder",
+            "methodName" : "build",
+            "fileName" : "BaseSessionStateBuilder.scala",
+            "lineNumber" : 335
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$",
+            "methodName" : "org$apache$spark$sql$SparkSession$$instantiateSessionState",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 1142
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession",
+            "methodName" : "$anonfun$sessionState$2",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 156
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$$Lambda$977/1580268581",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.Option",
+            "methodName" : "getOrElse",
+            "fileName" : "Option.scala",
+            "lineNumber" : 189
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession",
+            "methodName" : "sessionState$lzycompute",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 152
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession",
+            "methodName" : "sessionState",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 149
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession",
+            "methodName" : "$anonfun$new$3",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 109
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$$Lambda$975/1003454959",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.Option",
+            "methodName" : "map",
+            "fileName" : "Option.scala",
+            "lineNumber" : 230
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession",
+            "methodName" : "$anonfun$new$1",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 109
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession$$Lambda$719/1882924073",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.sql.internal.SQLConf$",
+            "methodName" : "get",
+            "fileName" : "SQLConf.scala",
+            "lineNumber" : 196
+          },
+          {
+            "className" : "org.apache.spark.sql.types.DataType",
+            "methodName" : "sameType",
+            "fileName" : "DataType.scala",
+            "lineNumber" : 97
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.analysis.TypeCoercion$",
+            "methodName" : "$anonfun$haveSameType$1",
+            "fileName" : "TypeCoercion.scala",
+            "lineNumber" : 291
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.analysis.TypeCoercion$",
+            "methodName" : "$anonfun$haveSameType$1$adapted",
+            "fileName" : "TypeCoercion.scala",
+            "lineNumber" : 291
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.analysis.TypeCoercion$$$Lambda$970/1645756961",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.collection.LinearSeqOptimized",
+            "methodName" : "forall",
+            "fileName" : "LinearSeqOptimized.scala",
+            "lineNumber" : 85
+          },
+          {
+            "className" : "scala.collection.LinearSeqOptimized",
+            "methodName" : "forall$",
+            "fileName" : "LinearSeqOptimized.scala",
+            "lineNumber" : 82
+          },
+          {
+            "className" : "scala.collection.immutable.List",
+            "methodName" : "forall",
+            "fileName" : "List.scala",
+            "lineNumber" : 89
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.analysis.TypeCoercion$",
+            "methodName" : "haveSameType",
+            "fileName" : "TypeCoercion.scala",
+            "lineNumber" : 291
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.expressions.ComplexTypeMergingExpression",
+            "methodName" : "dataTypeCheck",
+            "fileName" : "Expression.scala",
+            "lineNumber" : 1057
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.expressions.ComplexTypeMergingExpression",
+            "methodName" : "dataTypeCheck$",
+            "fileName" : "Expression.scala",
+            "lineNumber" : 1052
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.expressions.If",
+            "methodName" : "dataTypeCheck",
+            "fileName" : "conditionalExpressions.scala",
+            "lineNumber" : 36
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.expressions.ComplexTypeMergingExpression",
+            "methodName" : "org$apache$spark$sql$catalyst$expressions$ComplexTypeMergingExpression$$internalDataType",
+            "fileName" : "Expression.scala",
+            "lineNumber" : 1063
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.expressions.ComplexTypeMergingExpression",
+            "methodName" : "org$apache$spark$sql$catalyst$expressions$ComplexTypeMergingExpression$$internalDataType$",
+            "fileName" : "Expression.scala",
+            "lineNumber" : 1062
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.expressions.If",
+            "methodName" : "org$apache$spark$sql$catalyst$expressions$ComplexTypeMergingExpression$$internalDataType$lzycompute",
+            "fileName" : "conditionalExpressions.scala",
+            "lineNumber" : 36
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.expressions.If",
+            "methodName" : "org$apache$spark$sql$catalyst$expressions$ComplexTypeMergingExpression$$internalDataType",
+            "fileName" : "conditionalExpressions.scala",
+            "lineNumber" : 36
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.expressions.ComplexTypeMergingExpression",
+            "methodName" : "dataType",
+            "fileName" : "Expression.scala",
+            "lineNumber" : 1067
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.expressions.ComplexTypeMergingExpression",
+            "methodName" : "dataType$",
+            "fileName" : "Expression.scala",
+            "lineNumber" : 1067
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.expressions.If",
+            "methodName" : "dataType",
+            "fileName" : "conditionalExpressions.scala",
+            "lineNumber" : 36
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.encoders.ExpressionEncoder",
+            "methodName" : "isSerializedAsStruct",
+            "fileName" : "ExpressionEncoder.scala",
+            "lineNumber" : 309
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.encoders.ExpressionEncoder",
+            "methodName" : "isSerializedAsStructForTopLevel",
+            "fileName" : "ExpressionEncoder.scala",
+            "lineNumber" : 319
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.encoders.ExpressionEncoder",
+            "methodName" : "<init>",
+            "fileName" : "ExpressionEncoder.scala",
+            "lineNumber" : 248
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.encoders.ExpressionEncoder$",
+            "methodName" : "apply",
+            "fileName" : "ExpressionEncoder.scala",
+            "lineNumber" : 61
+          },
+          {
+            "className" : "org.apache.spark.sql.Encoders$",
+            "methodName" : "product",
+            "fileName" : "Encoders.scala",
+            "lineNumber" : 285
+          },
+          {
+            "className" : "org.apache.spark.sql.LowPrioritySQLImplicits",
+            "methodName" : "newProductEncoder",
+            "fileName" : "SQLImplicits.scala",
+            "lineNumber" : 251
+          },
+          {
+            "className" : "org.apache.spark.sql.LowPrioritySQLImplicits",
+            "methodName" : "newProductEncoder$",
+            "fileName" : "SQLImplicits.scala",
+            "lineNumber" : 251
+          },
+          {
+            "className" : "org.apache.spark.sql.SQLImplicits",
+            "methodName" : "newProductEncoder",
+            "fileName" : "SQLImplicits.scala",
+            "lineNumber" : 32
+          },
+          {
+            "className" : "com.nec.spark.planning.JoinPlanSpec$TestingOUR",
+            "methodName" : "prepareInput",
+            "fileName" : "JoinPlanSpec.scala",
+            "lineNumber" : 180
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "prepare",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 356
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "_jmh_tryInit_f_state_testingour_testingour_injvm_jvm1_G",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 480
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "TestingOUR_TestingOUR_InJVM_JVM_SingleShotTime",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 377
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 470
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 453
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-11",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-10",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-9",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-8",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-5",
+        "stack" : [
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpThreads0",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 496
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 484
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask",
+            "methodName" : "$anonfun$getSample$1",
+            "fileName" : "StackSamplingProfiler.scala",
+            "lineNumber" : 50
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask$$Lambda$170/142100135",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "runLoop",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 383
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "asyncContinueSuccessfulR",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 1132
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "run",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 126
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 359
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-4",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-3",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "Attach Listener",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Signal Dispatcher",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Finalizer",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 165
+          },
+          {
+            "className" : "java.lang.ref.Finalizer$FinalizerThread",
+            "methodName" : "run",
+            "fileName" : "Finalizer.java",
+            "lineNumber" : 216
+          }
+        ]
+      },
+      {
+        "threadName" : "Reference Handler",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.lang.ref.Reference",
+            "methodName" : "tryHandlePending",
+            "fileName" : "Reference.java",
+            "lineNumber" : 191
+          },
+          {
+            "className" : "java.lang.ref.Reference$ReferenceHandler",
+            "methodName" : "run",
+            "fileName" : "Reference.java",
+            "lineNumber" : 153
+          }
+        ]
+      },
+      {
+        "threadName" : "main",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "poll",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 467
+          },
+          {
+            "className" : "java.util.concurrent.ExecutorCompletionService",
+            "methodName" : "poll",
+            "fileName" : "ExecutorCompletionService.java",
+            "lineNumber" : 202
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler",
+            "methodName" : "runIteration",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 367
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 281
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 233
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "doSingle",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 138
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmarksForked",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 75
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedRunner",
+            "methodName" : "run",
+            "fileName" : "ForkedRunner.java",
+            "lineNumber" : 72
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedMain",
+            "methodName" : "main",
+            "fileName" : "ForkedMain.java",
+            "lineNumber" : 84
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "instant" : "2021-07-17T21:13:36.571Z",
+    "threads" : [
+      {
+        "threadName" : "spark-listener-group-shared",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "$anonfun$dispatch$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 101
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$Lambda$653/1072891606",
+            "methodName" : "apply$mcJ$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.runtime.java8.JFunction0$mcJ$sp",
+            "methodName" : "apply",
+            "fileName" : "JFunction0$mcJ$sp.java",
+            "lineNumber" : 23
+          },
+          {
+            "className" : "scala.util.DynamicVariable",
+            "methodName" : "withValue",
+            "fileName" : "DynamicVariable.scala",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "org$apache$spark$scheduler$AsyncEventQueue$$dispatch",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 100
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "$anonfun$run$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2$$Lambda$651/146769391",
+            "methodName" : "apply$mcV$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "tryOrStopSparkContext",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1381
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "run",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          }
+        ]
+      },
+      {
+        "threadName" : "element-tracking-store-worker",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "spark-listener-group-executorManagement",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "$anonfun$dispatch$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 110
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$Lambda$653/1072891606",
+            "methodName" : "apply$mcJ$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.runtime.java8.JFunction0$mcJ$sp",
+            "methodName" : "apply",
+            "fileName" : "JFunction0$mcJ$sp.java",
+            "lineNumber" : 23
+          },
+          {
+            "className" : "scala.util.DynamicVariable",
+            "methodName" : "withValue",
+            "fileName" : "DynamicVariable.scala",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "org$apache$spark$scheduler$AsyncEventQueue$$dispatch",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 100
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "$anonfun$run$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2$$Lambda$651/146769391",
+            "methodName" : "apply$mcV$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "tryOrStopSparkContext",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1381
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "run",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          }
+        ]
+      },
+      {
+        "threadName" : "spark-listener-group-appStatus",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "$anonfun$dispatch$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 110
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$Lambda$653/1072891606",
+            "methodName" : "apply$mcJ$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.runtime.java8.JFunction0$mcJ$sp",
+            "methodName" : "apply",
+            "fileName" : "JFunction0$mcJ$sp.java",
+            "lineNumber" : 23
+          },
+          {
+            "className" : "scala.util.DynamicVariable",
+            "methodName" : "withValue",
+            "fileName" : "DynamicVariable.scala",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "org$apache$spark$scheduler$AsyncEventQueue$$dispatch",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 100
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "$anonfun$run$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2$$Lambda$651/146769391",
+            "methodName" : "apply$mcV$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "tryOrStopSparkContext",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1381
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "run",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          }
+        ]
+      },
+      {
+        "threadName" : "context-cleaner-periodic-gc",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "Spark Context Cleaner",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "org.apache.spark.ContextCleaner",
+            "methodName" : "$anonfun$keepCleaning$1",
+            "fileName" : "ContextCleaner.scala",
+            "lineNumber" : 182
+          },
+          {
+            "className" : "org.apache.spark.ContextCleaner$$Lambda$646/941877840",
+            "methodName" : "apply$mcV$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "tryOrStopSparkContext",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1381
+          },
+          {
+            "className" : "org.apache.spark.ContextCleaner",
+            "methodName" : "org$apache$spark$ContextCleaner$$keepCleaning",
+            "fileName" : "ContextCleaner.scala",
+            "lineNumber" : 180
+          },
+          {
+            "className" : "org.apache.spark.ContextCleaner$$anon$1",
+            "methodName" : "run",
+            "fileName" : "ContextCleaner.scala",
+            "lineNumber" : 77
+          }
+        ]
+      },
+      {
+        "threadName" : "shuffle-boss-6-1",
+        "stack" : [
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll0",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 314
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "access$400",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 293
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl",
+            "methodName" : "doSelect",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 174
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "lockAndDoSelect",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 86
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 97
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 101
+          },
+          {
+            "className" : "io.netty.channel.nio.SelectedSelectionKeySetSelector",
+            "methodName" : "select",
+            "fileName" : "SelectedSelectionKeySetSelector.java",
+            "lineNumber" : 68
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "select",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 803
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "run",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 457
+          },
+          {
+            "className" : "io.netty.util.concurrent.SingleThreadEventExecutor$4",
+            "methodName" : "run",
+            "fileName" : "SingleThreadEventExecutor.java",
+            "lineNumber" : 989
+          },
+          {
+            "className" : "io.netty.util.internal.ThreadExecutorMap$2",
+            "methodName" : "run",
+            "fileName" : "ThreadExecutorMap.java",
+            "lineNumber" : 74
+          },
+          {
+            "className" : "io.netty.util.concurrent.FastThreadLocalRunnable",
+            "methodName" : "run",
+            "fileName" : "FastThreadLocalRunnable.java",
+            "lineNumber" : 30
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "executor-heartbeater",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "driver-heartbeater",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dag-scheduler-event-loop",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingDeque",
+            "methodName" : "takeFirst",
+            "fileName" : "LinkedBlockingDeque.java",
+            "lineNumber" : 492
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingDeque",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingDeque.java",
+            "lineNumber" : 680
+          },
+          {
+            "className" : "org.apache.spark.util.EventLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "EventLoop.scala",
+            "lineNumber" : 47
+          }
+        ]
+      },
+      {
+        "threadName" : "Timer-1",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "mainLoop",
+            "fileName" : "Timer.java",
+            "lineNumber" : 526
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "run",
+            "fileName" : "Timer.java",
+            "lineNumber" : 505
+          }
+        ]
+      },
+      {
+        "threadName" : "Timer-0",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "mainLoop",
+            "fileName" : "Timer.java",
+            "lineNumber" : 526
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "run",
+            "fileName" : "Timer.java",
+            "lineNumber" : 505
+          }
+        ]
+      },
+      {
+        "threadName" : "netty-rpc-env-timeout",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "heartbeat-receiver-event-loop-thread",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "RemoteBlock-temp-file-clean-thread",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "org.apache.spark.storage.BlockManager$RemoteBlockDownloadFileManager",
+            "methodName" : "org$apache$spark$storage$BlockManager$RemoteBlockDownloadFileManager$$keepCleaning",
+            "fileName" : "BlockManager.scala",
+            "lineNumber" : 2034
+          },
+          {
+            "className" : "org.apache.spark.storage.BlockManager$RemoteBlockDownloadFileManager$$anon$2",
+            "methodName" : "run",
+            "fileName" : "BlockManager.scala",
+            "lineNumber" : 2002
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-BlockManagerEndpoint1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-BlockManagerMaster",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-4",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-3",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-event-loop-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-event-loop-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "rpc-boss-3-1",
+        "stack" : [
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll0",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 314
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "access$400",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 293
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl",
+            "methodName" : "doSelect",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 174
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "lockAndDoSelect",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 86
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 97
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 101
+          },
+          {
+            "className" : "io.netty.channel.nio.SelectedSelectionKeySetSelector",
+            "methodName" : "select",
+            "fileName" : "SelectedSelectionKeySetSelector.java",
+            "lineNumber" : 68
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "select",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 803
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "run",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 457
+          },
+          {
+            "className" : "io.netty.util.concurrent.SingleThreadEventExecutor$4",
+            "methodName" : "run",
+            "fileName" : "SingleThreadEventExecutor.java",
+            "lineNumber" : 989
+          },
+          {
+            "className" : "io.netty.util.internal.ThreadExecutorMap$2",
+            "methodName" : "run",
+            "fileName" : "ThreadExecutorMap.java",
+            "lineNumber" : 74
+          },
+          {
+            "className" : "io.netty.util.concurrent.FastThreadLocalRunnable",
+            "methodName" : "run",
+            "fileName" : "FastThreadLocalRunnable.java",
+            "lineNumber" : 30
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-scheduler",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1081
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-jmh-worker-1",
+        "stack" : [
+          {
+            "className" : "org.apache.spark.sql.catalyst.parser.SqlBaseParser",
+            "methodName" : "strictIdentifier",
+            "fileName" : "SqlBaseParser.java",
+            "lineNumber" : 18952
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.parser.SqlBaseParser",
+            "methodName" : "identifier",
+            "fileName" : "SqlBaseParser.java",
+            "lineNumber" : 18865
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.parser.SqlBaseParser",
+            "methodName" : "errorCapturingIdentifier",
+            "fileName" : "SqlBaseParser.java",
+            "lineNumber" : 18703
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.parser.SqlBaseParser",
+            "methodName" : "tableIdentifier",
+            "fileName" : "SqlBaseParser.java",
+            "lineNumber" : 13552
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.parser.SqlBaseParser",
+            "methodName" : "singleTableIdentifier",
+            "fileName" : "SqlBaseParser.java",
+            "lineNumber" : 455
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.parser.AbstractSqlParser",
+            "methodName" : "$anonfun$parseTableIdentifier$1",
+            "fileName" : "ParseDriver.scala",
+            "lineNumber" : 49
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.parser.AbstractSqlParser$$Lambda$1280/2137088636",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.parser.AbstractSqlParser",
+            "methodName" : "parse",
+            "fileName" : "ParseDriver.scala",
+            "lineNumber" : 107
+          },
+          {
+            "className" : "org.apache.spark.sql.execution.SparkSqlParser",
+            "methodName" : "parse",
+            "fileName" : "SparkSqlParser.scala",
+            "lineNumber" : 49
+          },
+          {
+            "className" : "org.apache.spark.sql.catalyst.parser.AbstractSqlParser",
+            "methodName" : "parseTableIdentifier",
+            "fileName" : "ParseDriver.scala",
+            "lineNumber" : 48
+          },
+          {
+            "className" : "org.apache.spark.sql.Dataset",
+            "methodName" : "createTempViewCommand",
+            "fileName" : "Dataset.scala",
+            "lineNumber" : 3345
+          },
+          {
+            "className" : "org.apache.spark.sql.Dataset",
+            "methodName" : "createOrReplaceTempView",
+            "fileName" : "Dataset.scala",
+            "lineNumber" : 3300
+          },
+          {
+            "className" : "com.nec.spark.planning.JoinPlanSpec$TestingOUR",
+            "methodName" : "prepareInput",
+            "fileName" : "JoinPlanSpec.scala",
+            "lineNumber" : 183
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input$lzycompute",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "input",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 347
+          },
+          {
+            "className" : "nec.DynamicBenchmark$State_TestingOUR_TestingOUR_InJVM_JVM",
+            "methodName" : "prepare",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 356
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "_jmh_tryInit_f_state_testingour_testingour_injvm_jvm1_G",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 480
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "TestingOUR_TestingOUR_InJVM_JVM_SingleShotTime",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 377
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 470
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 453
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-11",
+        "stack" : [
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpThreads0",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 496
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 484
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask",
+            "methodName" : "$anonfun$getSample$1",
+            "fileName" : "StackSamplingProfiler.scala",
+            "lineNumber" : 50
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask$$Lambda$170/142100135",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "runLoop",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 383
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "asyncContinueSuccessfulR",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 1132
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "run",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 126
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 359
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-10",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-9",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-8",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-4",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-3",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "Attach Listener",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Signal Dispatcher",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Finalizer",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 165
+          },
+          {
+            "className" : "java.lang.ref.Finalizer$FinalizerThread",
+            "methodName" : "run",
+            "fileName" : "Finalizer.java",
+            "lineNumber" : 216
+          }
+        ]
+      },
+      {
+        "threadName" : "Reference Handler",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.lang.ref.Reference",
+            "methodName" : "tryHandlePending",
+            "fileName" : "Reference.java",
+            "lineNumber" : 191
+          },
+          {
+            "className" : "java.lang.ref.Reference$ReferenceHandler",
+            "methodName" : "run",
+            "fileName" : "Reference.java",
+            "lineNumber" : 153
+          }
+        ]
+      },
+      {
+        "threadName" : "main",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "poll",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 467
+          },
+          {
+            "className" : "java.util.concurrent.ExecutorCompletionService",
+            "methodName" : "poll",
+            "fileName" : "ExecutorCompletionService.java",
+            "lineNumber" : 202
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler",
+            "methodName" : "runIteration",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 367
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 281
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 233
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "doSingle",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 138
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmarksForked",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 75
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedRunner",
+            "methodName" : "run",
+            "fileName" : "ForkedRunner.java",
+            "lineNumber" : 72
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedMain",
+            "methodName" : "main",
+            "fileName" : "ForkedMain.java",
+            "lineNumber" : 84
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "instant" : "2021-07-17T21:13:37.582Z",
+    "threads" : [
+      {
+        "threadName" : "Executor task launch worker for task 0.0 in stage 0.0 (TID 0)",
+        "stack" : [
+          {
+            "className" : "jdk.internal.org.objectweb.asm.Frame",
+            "methodName" : "init",
+            "fileName" : "Frame.java",
+            "lineNumber" : 779
+          },
+          {
+            "className" : "jdk.internal.org.objectweb.asm.Frame",
+            "methodName" : "execute",
+            "fileName" : "Frame.java",
+            "lineNumber" : 1232
+          },
+          {
+            "className" : "jdk.internal.org.objectweb.asm.MethodWriter",
+            "methodName" : "visitMethodInsn",
+            "fileName" : "MethodWriter.java",
+            "lineNumber" : 922
+          },
+          {
+            "className" : "java.lang.invoke.BoundMethodHandle$Factory",
+            "methodName" : "generateConcreteBMHClass",
+            "fileName" : "BoundMethodHandle.java",
+            "lineNumber" : 650
+          },
+          {
+            "className" : "java.lang.invoke.BoundMethodHandle$Factory$1",
+            "methodName" : "apply",
+            "fileName" : "BoundMethodHandle.java",
+            "lineNumber" : 492
+          },
+          {
+            "className" : "java.lang.invoke.BoundMethodHandle$Factory$1",
+            "methodName" : "apply",
+            "fileName" : "BoundMethodHandle.java",
+            "lineNumber" : 489
+          },
+          {
+            "className" : "java.util.concurrent.ConcurrentHashMap",
+            "methodName" : "computeIfAbsent",
+            "fileName" : "ConcurrentHashMap.java",
+            "lineNumber" : 1688
+          },
+          {
+            "className" : "java.lang.invoke.BoundMethodHandle$Factory",
+            "methodName" : "getConcreteBMHClass",
+            "fileName" : "BoundMethodHandle.java",
+            "lineNumber" : 488
+          },
+          {
+            "className" : "java.lang.invoke.BoundMethodHandle$SpeciesData$1",
+            "methodName" : "apply",
+            "fileName" : "BoundMethodHandle.java",
+            "lineNumber" : 386
+          },
+          {
+            "className" : "java.lang.invoke.BoundMethodHandle$SpeciesData$1",
+            "methodName" : "apply",
+            "fileName" : "BoundMethodHandle.java",
+            "lineNumber" : 383
+          },
+          {
+            "className" : "java.util.concurrent.ConcurrentHashMap",
+            "methodName" : "computeIfAbsent",
+            "fileName" : "ConcurrentHashMap.java",
+            "lineNumber" : 1688
+          },
+          {
+            "className" : "java.lang.invoke.BoundMethodHandle$SpeciesData",
+            "methodName" : "get",
+            "fileName" : "BoundMethodHandle.java",
+            "lineNumber" : 383
+          },
+          {
+            "className" : "java.lang.invoke.BoundMethodHandle$SpeciesData",
+            "methodName" : "extendWith",
+            "fileName" : "BoundMethodHandle.java",
+            "lineNumber" : 378
+          },
+          {
+            "className" : "java.lang.invoke.LambdaFormEditor",
+            "methodName" : "newSpeciesData",
+            "fileName" : "LambdaFormEditor.java",
+            "lineNumber" : 396
+          },
+          {
+            "className" : "java.lang.invoke.LambdaFormEditor",
+            "methodName" : "makeArgumentCombinationForm",
+            "fileName" : "LambdaFormEditor.java",
+            "lineNumber" : 664
+          },
+          {
+            "className" : "java.lang.invoke.LambdaFormEditor",
+            "methodName" : "filterArgumentForm",
+            "fileName" : "LambdaFormEditor.java",
+            "lineNumber" : 645
+          },
+          {
+            "className" : "java.lang.invoke.MethodHandleImpl",
+            "methodName" : "makePairwiseConvertByEditor",
+            "fileName" : "MethodHandleImpl.java",
+            "lineNumber" : 230
+          },
+          {
+            "className" : "java.lang.invoke.MethodHandleImpl",
+            "methodName" : "makePairwiseConvert",
+            "fileName" : "MethodHandleImpl.java",
+            "lineNumber" : 194
+          },
+          {
+            "className" : "java.lang.invoke.MethodHandleImpl",
+            "methodName" : "makePairwiseConvert",
+            "fileName" : "MethodHandleImpl.java",
+            "lineNumber" : 380
+          },
+          {
+            "className" : "java.lang.invoke.MethodHandle",
+            "methodName" : "asTypeUncached",
+            "fileName" : "MethodHandle.java",
+            "lineNumber" : 776
+          },
+          {
+            "className" : "java.lang.invoke.MethodHandle",
+            "methodName" : "asType",
+            "fileName" : "MethodHandle.java",
+            "lineNumber" : 761
+          },
+          {
+            "className" : "java.lang.invoke.MethodHandleImpl$AsVarargsCollector",
+            "methodName" : "asTypeUncached",
+            "fileName" : "MethodHandleImpl.java",
+            "lineNumber" : 508
+          },
+          {
+            "className" : "java.lang.invoke.MethodHandle",
+            "methodName" : "asType",
+            "fileName" : "MethodHandle.java",
+            "lineNumber" : 761
+          },
+          {
+            "className" : "java.lang.invoke.CallSite",
+            "methodName" : "makeSite",
+            "fileName" : "CallSite.java",
+            "lineNumber" : 323
+          },
+          {
+            "className" : "java.lang.invoke.MethodHandleNatives",
+            "methodName" : "linkCallSiteImpl",
+            "fileName" : "MethodHandleNatives.java",
+            "lineNumber" : 307
+          },
+          {
+            "className" : "java.lang.invoke.MethodHandleNatives",
+            "methodName" : "linkCallSite",
+            "fileName" : "MethodHandleNatives.java",
+            "lineNumber" : 297
+          },
+          {
+            "className" : "org.apache.spark.rdd.RDD",
+            "methodName" : "$deserializeLambda$",
+            "fileName" : "RDD.scala",
+            "lineNumber" : -1
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "java.lang.invoke.SerializedLambda",
+            "methodName" : "readResolve",
+            "fileName" : "SerializedLambda.java",
+            "lineNumber" : 230
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "java.io.ObjectStreamClass",
+            "methodName" : "invokeReadResolve",
+            "fileName" : "ObjectStreamClass.java",
+            "lineNumber" : 1274
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readOrdinaryObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2196
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject0",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 1667
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "defaultReadFields",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2405
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readSerialData",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2329
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readOrdinaryObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2187
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject0",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 1667
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "defaultReadFields",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2405
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readSerialData",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2329
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readOrdinaryObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2187
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject0",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 1667
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 503
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 461
+          },
+          {
+            "className" : "scala.collection.immutable.List$SerializationProxy",
+            "methodName" : "readObject",
+            "fileName" : "List.scala",
+            "lineNumber" : 488
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "java.io.ObjectStreamClass",
+            "methodName" : "invokeReadObject",
+            "fileName" : "ObjectStreamClass.java",
+            "lineNumber" : 1184
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readSerialData",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2296
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readOrdinaryObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2187
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject0",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 1667
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "defaultReadFields",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2405
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readSerialData",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2329
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readOrdinaryObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2187
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject0",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 1667
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "defaultReadFields",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2405
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readSerialData",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2329
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readOrdinaryObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2187
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject0",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 1667
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 503
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 461
+          },
+          {
+            "className" : "scala.collection.immutable.List$SerializationProxy",
+            "methodName" : "readObject",
+            "fileName" : "List.scala",
+            "lineNumber" : 488
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "java.io.ObjectStreamClass",
+            "methodName" : "invokeReadObject",
+            "fileName" : "ObjectStreamClass.java",
+            "lineNumber" : 1184
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readSerialData",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2296
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readOrdinaryObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2187
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject0",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 1667
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "defaultReadFields",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2405
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readSerialData",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2329
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readOrdinaryObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2187
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject0",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 1667
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "defaultReadFields",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2405
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readSerialData",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2329
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readOrdinaryObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2187
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject0",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 1667
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 503
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 461
+          },
+          {
+            "className" : "scala.collection.immutable.List$SerializationProxy",
+            "methodName" : "readObject",
+            "fileName" : "List.scala",
+            "lineNumber" : 488
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "java.io.ObjectStreamClass",
+            "methodName" : "invokeReadObject",
+            "fileName" : "ObjectStreamClass.java",
+            "lineNumber" : 1184
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readSerialData",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2296
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readOrdinaryObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2187
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject0",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 1667
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "defaultReadFields",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2405
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readSerialData",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2329
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readOrdinaryObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2187
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject0",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 1667
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "defaultReadFields",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2405
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readSerialData",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2329
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readOrdinaryObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 2187
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject0",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 1667
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 503
+          },
+          {
+            "className" : "java.io.ObjectInputStream",
+            "methodName" : "readObject",
+            "fileName" : "ObjectInputStream.java",
+            "lineNumber" : 461
+          },
+          {
+            "className" : "org.apache.spark.serializer.JavaDeserializationStream",
+            "methodName" : "readObject",
+            "fileName" : "JavaSerializer.scala",
+            "lineNumber" : 76
+          },
+          {
+            "className" : "org.apache.spark.serializer.JavaSerializerInstance",
+            "methodName" : "deserialize",
+            "fileName" : "JavaSerializer.scala",
+            "lineNumber" : 115
+          },
+          {
+            "className" : "org.apache.spark.scheduler.ResultTask",
+            "methodName" : "runTask",
+            "fileName" : "ResultTask.scala",
+            "lineNumber" : 83
+          },
+          {
+            "className" : "org.apache.spark.scheduler.Task",
+            "methodName" : "run",
+            "fileName" : "Task.scala",
+            "lineNumber" : 131
+          },
+          {
+            "className" : "org.apache.spark.executor.Executor$TaskRunner",
+            "methodName" : "$anonfun$run$3",
+            "fileName" : "Executor.scala",
+            "lineNumber" : 497
+          },
+          {
+            "className" : "org.apache.spark.executor.Executor$TaskRunner$$Lambda$2051/200302970",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "tryWithSafeFinally",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1439
+          },
+          {
+            "className" : "org.apache.spark.executor.Executor$TaskRunner",
+            "methodName" : "run",
+            "fileName" : "Executor.scala",
+            "lineNumber" : 500
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "spark-listener-group-shared",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "$anonfun$dispatch$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 110
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$Lambda$653/1072891606",
+            "methodName" : "apply$mcJ$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.runtime.java8.JFunction0$mcJ$sp",
+            "methodName" : "apply",
+            "fileName" : "JFunction0$mcJ$sp.java",
+            "lineNumber" : 23
+          },
+          {
+            "className" : "scala.util.DynamicVariable",
+            "methodName" : "withValue",
+            "fileName" : "DynamicVariable.scala",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "org$apache$spark$scheduler$AsyncEventQueue$$dispatch",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 100
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "$anonfun$run$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2$$Lambda$651/146769391",
+            "methodName" : "apply$mcV$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "tryOrStopSparkContext",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1381
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "run",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          }
+        ]
+      },
+      {
+        "threadName" : "element-tracking-store-worker",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "spark-listener-group-executorManagement",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "$anonfun$dispatch$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 110
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$Lambda$653/1072891606",
+            "methodName" : "apply$mcJ$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.runtime.java8.JFunction0$mcJ$sp",
+            "methodName" : "apply",
+            "fileName" : "JFunction0$mcJ$sp.java",
+            "lineNumber" : 23
+          },
+          {
+            "className" : "scala.util.DynamicVariable",
+            "methodName" : "withValue",
+            "fileName" : "DynamicVariable.scala",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "org$apache$spark$scheduler$AsyncEventQueue$$dispatch",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 100
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "$anonfun$run$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2$$Lambda$651/146769391",
+            "methodName" : "apply$mcV$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "tryOrStopSparkContext",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1381
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "run",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          }
+        ]
+      },
+      {
+        "threadName" : "spark-listener-group-appStatus",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "$anonfun$dispatch$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 110
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$Lambda$653/1072891606",
+            "methodName" : "apply$mcJ$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "scala.runtime.java8.JFunction0$mcJ$sp",
+            "methodName" : "apply",
+            "fileName" : "JFunction0$mcJ$sp.java",
+            "lineNumber" : 23
+          },
+          {
+            "className" : "scala.util.DynamicVariable",
+            "methodName" : "withValue",
+            "fileName" : "DynamicVariable.scala",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue",
+            "methodName" : "org$apache$spark$scheduler$AsyncEventQueue$$dispatch",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 100
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "$anonfun$run$1",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2$$Lambda$651/146769391",
+            "methodName" : "apply$mcV$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "tryOrStopSparkContext",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1381
+          },
+          {
+            "className" : "org.apache.spark.scheduler.AsyncEventQueue$$anon$2",
+            "methodName" : "run",
+            "fileName" : "AsyncEventQueue.scala",
+            "lineNumber" : 96
+          }
+        ]
+      },
+      {
+        "threadName" : "context-cleaner-periodic-gc",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "Spark Context Cleaner",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "org.apache.spark.ContextCleaner",
+            "methodName" : "$anonfun$keepCleaning$1",
+            "fileName" : "ContextCleaner.scala",
+            "lineNumber" : 182
+          },
+          {
+            "className" : "org.apache.spark.ContextCleaner$$Lambda$646/941877840",
+            "methodName" : "apply$mcV$sp",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.util.Utils$",
+            "methodName" : "tryOrStopSparkContext",
+            "fileName" : "Utils.scala",
+            "lineNumber" : 1381
+          },
+          {
+            "className" : "org.apache.spark.ContextCleaner",
+            "methodName" : "org$apache$spark$ContextCleaner$$keepCleaning",
+            "fileName" : "ContextCleaner.scala",
+            "lineNumber" : 180
+          },
+          {
+            "className" : "org.apache.spark.ContextCleaner$$anon$1",
+            "methodName" : "run",
+            "fileName" : "ContextCleaner.scala",
+            "lineNumber" : 77
+          }
+        ]
+      },
+      {
+        "threadName" : "shuffle-boss-6-1",
+        "stack" : [
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll0",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 314
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "access$400",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 293
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl",
+            "methodName" : "doSelect",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 174
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "lockAndDoSelect",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 86
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 97
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 101
+          },
+          {
+            "className" : "io.netty.channel.nio.SelectedSelectionKeySetSelector",
+            "methodName" : "select",
+            "fileName" : "SelectedSelectionKeySetSelector.java",
+            "lineNumber" : 68
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "select",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 803
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "run",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 457
+          },
+          {
+            "className" : "io.netty.util.concurrent.SingleThreadEventExecutor$4",
+            "methodName" : "run",
+            "fileName" : "SingleThreadEventExecutor.java",
+            "lineNumber" : 989
+          },
+          {
+            "className" : "io.netty.util.internal.ThreadExecutorMap$2",
+            "methodName" : "run",
+            "fileName" : "ThreadExecutorMap.java",
+            "lineNumber" : 74
+          },
+          {
+            "className" : "io.netty.util.concurrent.FastThreadLocalRunnable",
+            "methodName" : "run",
+            "fileName" : "FastThreadLocalRunnable.java",
+            "lineNumber" : 30
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "executor-heartbeater",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "driver-heartbeater",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dag-scheduler-event-loop",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingDeque",
+            "methodName" : "takeFirst",
+            "fileName" : "LinkedBlockingDeque.java",
+            "lineNumber" : 492
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingDeque",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingDeque.java",
+            "lineNumber" : 680
+          },
+          {
+            "className" : "org.apache.spark.util.EventLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "EventLoop.scala",
+            "lineNumber" : 47
+          }
+        ]
+      },
+      {
+        "threadName" : "Timer-1",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "mainLoop",
+            "fileName" : "Timer.java",
+            "lineNumber" : 526
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "run",
+            "fileName" : "Timer.java",
+            "lineNumber" : 505
+          }
+        ]
+      },
+      {
+        "threadName" : "Timer-0",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "mainLoop",
+            "fileName" : "Timer.java",
+            "lineNumber" : 526
+          },
+          {
+            "className" : "java.util.TimerThread",
+            "methodName" : "run",
+            "fileName" : "Timer.java",
+            "lineNumber" : 505
+          }
+        ]
+      },
+      {
+        "threadName" : "netty-rpc-env-timeout",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "heartbeat-receiver-event-loop-thread",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1093
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "RemoteBlock-temp-file-clean-thread",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "org.apache.spark.storage.BlockManager$RemoteBlockDownloadFileManager",
+            "methodName" : "org$apache$spark$storage$BlockManager$RemoteBlockDownloadFileManager$$keepCleaning",
+            "fileName" : "BlockManager.scala",
+            "lineNumber" : 2034
+          },
+          {
+            "className" : "org.apache.spark.storage.BlockManager$RemoteBlockDownloadFileManager$$anon$2",
+            "methodName" : "run",
+            "fileName" : "BlockManager.scala",
+            "lineNumber" : 2002
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-BlockManagerEndpoint1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-BlockManagerMaster",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-4",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-3",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "map-output-dispatcher-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.MapOutputTrackerMaster$MessageLoop",
+            "methodName" : "run",
+            "fileName" : "MapOutputTracker.scala",
+            "lineNumber" : 452
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-event-loop-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "dispatcher-event-loop-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "take",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 442
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop",
+            "methodName" : "org$apache$spark$rpc$netty$MessageLoop$$receiveLoop",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 69
+          },
+          {
+            "className" : "org.apache.spark.rpc.netty.MessageLoop$$anon$1",
+            "methodName" : "run",
+            "fileName" : "MessageLoop.scala",
+            "lineNumber" : 41
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "rpc-boss-3-1",
+        "stack" : [
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll0",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "poll",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 314
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl$SubSelector",
+            "methodName" : "access$400",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 293
+          },
+          {
+            "className" : "sun.nio.ch.WindowsSelectorImpl",
+            "methodName" : "doSelect",
+            "fileName" : "WindowsSelectorImpl.java",
+            "lineNumber" : 174
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "lockAndDoSelect",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 86
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 97
+          },
+          {
+            "className" : "sun.nio.ch.SelectorImpl",
+            "methodName" : "select",
+            "fileName" : "SelectorImpl.java",
+            "lineNumber" : 101
+          },
+          {
+            "className" : "io.netty.channel.nio.SelectedSelectionKeySetSelector",
+            "methodName" : "select",
+            "fileName" : "SelectedSelectionKeySetSelector.java",
+            "lineNumber" : 68
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "select",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 803
+          },
+          {
+            "className" : "io.netty.channel.nio.NioEventLoop",
+            "methodName" : "run",
+            "fileName" : "NioEventLoop.java",
+            "lineNumber" : 457
+          },
+          {
+            "className" : "io.netty.util.concurrent.SingleThreadEventExecutor$4",
+            "methodName" : "run",
+            "fileName" : "SingleThreadEventExecutor.java",
+            "lineNumber" : 989
+          },
+          {
+            "className" : "io.netty.util.internal.ThreadExecutorMap$2",
+            "methodName" : "run",
+            "fileName" : "ThreadExecutorMap.java",
+            "lineNumber" : 74
+          },
+          {
+            "className" : "io.netty.util.concurrent.FastThreadLocalRunnable",
+            "methodName" : "run",
+            "fileName" : "FastThreadLocalRunnable.java",
+            "lineNumber" : 30
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-scheduler",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "await",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2044
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 1081
+          },
+          {
+            "className" : "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue",
+            "methodName" : "take",
+            "fileName" : "ScheduledThreadPoolExecutor.java",
+            "lineNumber" : 809
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "getTask",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1074
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1134
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-jmh-worker-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer",
+            "methodName" : "parkAndCheckInterrupt",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 837
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer",
+            "methodName" : "doAcquireSharedInterruptibly",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 999
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer",
+            "methodName" : "acquireSharedInterruptibly",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 1308
+          },
+          {
+            "className" : "scala.concurrent.impl.Promise$DefaultPromise",
+            "methodName" : "tryAwait",
+            "fileName" : "Promise.scala",
+            "lineNumber" : 242
+          },
+          {
+            "className" : "scala.concurrent.impl.Promise$DefaultPromise",
+            "methodName" : "ready",
+            "fileName" : "Promise.scala",
+            "lineNumber" : 258
+          },
+          {
+            "className" : "scala.concurrent.impl.Promise$DefaultPromise",
+            "methodName" : "ready",
+            "fileName" : "Promise.scala",
+            "lineNumber" : 187
+          },
+          {
+            "className" : "org.apache.spark.util.ThreadUtils$",
+            "methodName" : "awaitReady",
+            "fileName" : "ThreadUtils.scala",
+            "lineNumber" : 334
+          },
+          {
+            "className" : "org.apache.spark.scheduler.DAGScheduler",
+            "methodName" : "runJob",
+            "fileName" : "DAGScheduler.scala",
+            "lineNumber" : 859
+          },
+          {
+            "className" : "org.apache.spark.SparkContext",
+            "methodName" : "runJob",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 2202
+          },
+          {
+            "className" : "org.apache.spark.SparkContext",
+            "methodName" : "runJob",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 2223
+          },
+          {
+            "className" : "org.apache.spark.SparkContext",
+            "methodName" : "runJob",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 2242
+          },
+          {
+            "className" : "org.apache.spark.SparkContext",
+            "methodName" : "runJob",
+            "fileName" : "SparkContext.scala",
+            "lineNumber" : 2267
+          },
+          {
+            "className" : "org.apache.spark.rdd.RDD",
+            "methodName" : "$anonfun$collect$1",
+            "fileName" : "RDD.scala",
+            "lineNumber" : 1030
+          },
+          {
+            "className" : "org.apache.spark.rdd.RDD$$Lambda$1737/811668779",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.rdd.RDDOperationScope$",
+            "methodName" : "withScope",
+            "fileName" : "RDDOperationScope.scala",
+            "lineNumber" : 151
+          },
+          {
+            "className" : "org.apache.spark.rdd.RDDOperationScope$",
+            "methodName" : "withScope",
+            "fileName" : "RDDOperationScope.scala",
+            "lineNumber" : 112
+          },
+          {
+            "className" : "org.apache.spark.rdd.RDD",
+            "methodName" : "withScope",
+            "fileName" : "RDD.scala",
+            "lineNumber" : 414
+          },
+          {
+            "className" : "org.apache.spark.rdd.RDD",
+            "methodName" : "collect",
+            "fileName" : "RDD.scala",
+            "lineNumber" : 1029
+          },
+          {
+            "className" : "org.apache.spark.sql.execution.SparkPlan",
+            "methodName" : "executeCollect",
+            "fileName" : "SparkPlan.scala",
+            "lineNumber" : 390
+          },
+          {
+            "className" : "org.apache.spark.sql.Dataset",
+            "methodName" : "collectFromPlan",
+            "fileName" : "Dataset.scala",
+            "lineNumber" : 3696
+          },
+          {
+            "className" : "org.apache.spark.sql.Dataset",
+            "methodName" : "$anonfun$collect$1",
+            "fileName" : "Dataset.scala",
+            "lineNumber" : 2965
+          },
+          {
+            "className" : "org.apache.spark.sql.Dataset$$Lambda$1611/1386274329",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.sql.Dataset",
+            "methodName" : "$anonfun$withAction$1",
+            "fileName" : "Dataset.scala",
+            "lineNumber" : 3687
+          },
+          {
+            "className" : "org.apache.spark.sql.Dataset$$Lambda$1288/1920690117",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.sql.execution.SQLExecution$",
+            "methodName" : "$anonfun$withNewExecutionId$5",
+            "fileName" : "SQLExecution.scala",
+            "lineNumber" : 103
+          },
+          {
+            "className" : "org.apache.spark.sql.execution.SQLExecution$$$Lambda$1296/1363064209",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.sql.execution.SQLExecution$",
+            "methodName" : "withSQLConfPropagated",
+            "fileName" : "SQLExecution.scala",
+            "lineNumber" : 163
+          },
+          {
+            "className" : "org.apache.spark.sql.execution.SQLExecution$",
+            "methodName" : "$anonfun$withNewExecutionId$1",
+            "fileName" : "SQLExecution.scala",
+            "lineNumber" : 90
+          },
+          {
+            "className" : "org.apache.spark.sql.execution.SQLExecution$$$Lambda$1289/1081169596",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "org.apache.spark.sql.SparkSession",
+            "methodName" : "withActive",
+            "fileName" : "SparkSession.scala",
+            "lineNumber" : 772
+          },
+          {
+            "className" : "org.apache.spark.sql.execution.SQLExecution$",
+            "methodName" : "withNewExecutionId",
+            "fileName" : "SQLExecution.scala",
+            "lineNumber" : 64
+          },
+          {
+            "className" : "org.apache.spark.sql.Dataset",
+            "methodName" : "withAction",
+            "fileName" : "Dataset.scala",
+            "lineNumber" : 3685
+          },
+          {
+            "className" : "org.apache.spark.sql.Dataset",
+            "methodName" : "collect",
+            "fileName" : "Dataset.scala",
+            "lineNumber" : 2965
+          },
+          {
+            "className" : "com.nec.spark.agile.BenchmarkDebugging$RichDataSet",
+            "methodName" : "debugResults",
+            "fileName" : "BenchmarkDebugging.scala",
+            "lineNumber" : 38
+          },
+          {
+            "className" : "nec.DynamicBenchmark",
+            "methodName" : "TestingOUR_TestingOUR_InJVM_JVM",
+            "fileName" : "DynamicBenchmark.scala",
+            "lineNumber" : 737
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "TestingOUR_TestingOUR_InJVM_JVM_ss_jmhStub",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 433
+          },
+          {
+            "className" : "nec.jmh_generated.DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest",
+            "methodName" : "TestingOUR_TestingOUR_InJVM_JVM_SingleShotTime",
+            "fileName" : "DynamicBenchmark_TestingOUR_TestingOUR_InJVM_JVM_jmhTest.java",
+            "lineNumber" : 385
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke0",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.reflect.NativeMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "NativeMethodAccessorImpl.java",
+            "lineNumber" : 62
+          },
+          {
+            "className" : "sun.reflect.DelegatingMethodAccessorImpl",
+            "methodName" : "invoke",
+            "fileName" : "DelegatingMethodAccessorImpl.java",
+            "lineNumber" : 43
+          },
+          {
+            "className" : "java.lang.reflect.Method",
+            "methodName" : "invoke",
+            "fileName" : "Method.java",
+            "lineNumber" : 498
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 470
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask",
+            "methodName" : "call",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 453
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.Executors$RunnableAdapter",
+            "methodName" : "call",
+            "fileName" : "Executors.java",
+            "lineNumber" : 511
+          },
+          {
+            "className" : "java.util.concurrent.FutureTask",
+            "methodName" : "run",
+            "fileName" : "FutureTask.java",
+            "lineNumber" : 266
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor",
+            "methodName" : "runWorker",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 1149
+          },
+          {
+            "className" : "java.util.concurrent.ThreadPoolExecutor$Worker",
+            "methodName" : "run",
+            "fileName" : "ThreadPoolExecutor.java",
+            "lineNumber" : 624
+          },
+          {
+            "className" : "java.lang.Thread",
+            "methodName" : "run",
+            "fileName" : "Thread.java",
+            "lineNumber" : 748
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-11",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-10",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-9",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-8",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-7",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-6",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-5",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-4",
+        "stack" : [
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpThreads0",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 496
+          },
+          {
+            "className" : "sun.management.ThreadImpl",
+            "methodName" : "dumpAllThreads",
+            "fileName" : "ThreadImpl.java",
+            "lineNumber" : 484
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask",
+            "methodName" : "$anonfun$getSample$1",
+            "fileName" : "StackSamplingProfiler.scala",
+            "lineNumber" : 50
+          },
+          {
+            "className" : "org.openjdk.jmh.profile.nec.StackSamplingProfiler$SamplingTask$$Lambda$170/142100135",
+            "methodName" : "apply",
+            "fileName" : null,
+            "lineNumber" : -1
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "runLoop",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 383
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "asyncContinueSuccessfulR",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 1132
+          },
+          {
+            "className" : "cats.effect.IOFiber",
+            "methodName" : "run",
+            "fileName" : "IOFiber.scala",
+            "lineNumber" : 126
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 359
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-3",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-2",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-1",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "io-compute-0",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "park",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 175
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "parkLoop$1",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 225
+          },
+          {
+            "className" : "cats.effect.unsafe.WorkerThread",
+            "methodName" : "run",
+            "fileName" : "WorkerThread.scala",
+            "lineNumber" : 324
+          }
+        ]
+      },
+      {
+        "threadName" : "Attach Listener",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Signal Dispatcher",
+        "stack" : [
+        ]
+      },
+      {
+        "threadName" : "Finalizer",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 144
+          },
+          {
+            "className" : "java.lang.ref.ReferenceQueue",
+            "methodName" : "remove",
+            "fileName" : "ReferenceQueue.java",
+            "lineNumber" : 165
+          },
+          {
+            "className" : "java.lang.ref.Finalizer$FinalizerThread",
+            "methodName" : "run",
+            "fileName" : "Finalizer.java",
+            "lineNumber" : 216
+          }
+        ]
+      },
+      {
+        "threadName" : "Reference Handler",
+        "stack" : [
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.lang.Object",
+            "methodName" : "wait",
+            "fileName" : "Object.java",
+            "lineNumber" : 502
+          },
+          {
+            "className" : "java.lang.ref.Reference",
+            "methodName" : "tryHandlePending",
+            "fileName" : "Reference.java",
+            "lineNumber" : 191
+          },
+          {
+            "className" : "java.lang.ref.Reference$ReferenceHandler",
+            "methodName" : "run",
+            "fileName" : "Reference.java",
+            "lineNumber" : 153
+          }
+        ]
+      },
+      {
+        "threadName" : "main",
+        "stack" : [
+          {
+            "className" : "sun.misc.Unsafe",
+            "methodName" : "park",
+            "fileName" : "Unsafe.java",
+            "lineNumber" : -2
+          },
+          {
+            "className" : "java.util.concurrent.locks.LockSupport",
+            "methodName" : "parkNanos",
+            "fileName" : "LockSupport.java",
+            "lineNumber" : 215
+          },
+          {
+            "className" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+            "methodName" : "awaitNanos",
+            "fileName" : "AbstractQueuedSynchronizer.java",
+            "lineNumber" : 2083
+          },
+          {
+            "className" : "java.util.concurrent.LinkedBlockingQueue",
+            "methodName" : "poll",
+            "fileName" : "LinkedBlockingQueue.java",
+            "lineNumber" : 467
+          },
+          {
+            "className" : "java.util.concurrent.ExecutorCompletionService",
+            "methodName" : "poll",
+            "fileName" : "ExecutorCompletionService.java",
+            "lineNumber" : 202
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BenchmarkHandler",
+            "methodName" : "runIteration",
+            "fileName" : "BenchmarkHandler.java",
+            "lineNumber" : 367
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 281
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmark",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 233
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "doSingle",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 138
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.BaseRunner",
+            "methodName" : "runBenchmarksForked",
+            "fileName" : "BaseRunner.java",
+            "lineNumber" : 75
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedRunner",
+            "methodName" : "run",
+            "fileName" : "ForkedRunner.java",
+            "lineNumber" : 72
+          },
+          {
+            "className" : "org.openjdk.jmh.runner.ForkedMain",
+            "methodName" : "main",
+            "fileName" : "ForkedMain.java",
+            "lineNumber" : 84
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/fun-bench/src/test/scala/com/nec/jmh/AnalyzeSamplesSpec.scala
+++ b/fun-bench/src/test/scala/com/nec/jmh/AnalyzeSamplesSpec.scala
@@ -1,0 +1,23 @@
+package com.nec.jmh
+import cats.effect.unsafe.implicits.global
+import com.nec.jmh.AnalyzeSamplesSpec.TestSample
+import org.apache.commons.io.IOUtils
+import org.openjdk.jmh.profile.nec.StackSamplingProfiler.ThreadsSamples
+import org.scalatest.freespec.AnyFreeSpec
+
+import java.nio.charset.Charset
+
+object AnalyzeSamplesSpec {
+  import io.circe.generic.auto._
+  val TestSample: ThreadsSamples = io.circe.parser
+    .parse(IOUtils.resourceToString("/com/nec/jmh/thread-samples.json", Charset.defaultCharset()))
+    .flatMap(_.as[ThreadsSamples])
+    .fold(throw _, identity)
+}
+
+final class AnalyzeSamplesSpec extends AnyFreeSpec {
+  "'SqlBaseParser' is reported" in {
+    val str = AnalyzeSamples.apply(TestSample).unsafeRunSync()
+    assert(str.contains("SqlBaseParser"))
+  }
+}


### PR DESCRIPTION
The purpose of this is to identify exactly where time is spent, because there is a constant factor that we might not be aware of.

The output file is a JSON and all the detail how to use this in `SBT.md`

A simple analyzer is included which should be sufficient on the benchmarks. You will need to customize `AnalyzeSamples` (please make PRs with improvements for it eg which files we should ignore) for higher quality output

This should help us find all the funny things that could be happening while our processes are running.