### PR TITLE
Proof of concept: Java -> UNIX Socket -> VE -> Arrow -> Java

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,9 +90,11 @@ libraryDependencies ++= Seq(
   "org.scalatestplus" %% "scalacheck-1-15" % "3.2.9.0" % "test,ve,cmake",
   "commons-io" % "commons-io" % "2.10.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
+  "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.4.0",
   /** Log with logback in our scopes but not in production runs */
   "org.slf4j" % "log4j-over-slf4j" % "1.7.25" % "test,acc,cmake,ve",
-  "ch.qos.logback" % "logback-classic" % "1.2.3" % "test,acc,cmake,ve"
+  "ch.qos.logback" % "logback-classic" % "1.2.3" % "test,acc,cmake,ve",
+  "co.fs2" %% "fs2-io" % "3.0.6" % "test,acc,cmake,ve"
 ).map(_.excludeAll(ExclusionRule("*", "log4j"), ExclusionRule("*", "slf4j-log4j12")))
 
 libraryDependencies ++= {

--- a/src/main/resources/com/nec/arrow/functions/cpp/unix-read.cpp
+++ b/src/main/resources/com/nec/arrow/functions/cpp/unix-read.cpp
@@ -1,0 +1,89 @@
+#undef UNICODE
+
+#include <iostream>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include "transfer-definitions.h"
+#define sock_name "xsx"
+#define client_sock_name "client_sock"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+/** Based on input socket name specified in the first vector, connect to that socket, fetch the data,
+then put it into output_data
+
+The protocol is simple:
+< [ size (int) ] [data of size ] | int 0 to signify end of stream >
+
+**/
+extern "C" long read_fully_2(non_null_c_bounded_string* input_sock_name, non_null_varchar_vector* output_data)
+{
+    output_data->data = (char*) malloc(0);
+    output_data->offsets = (int*) malloc(4 * 2);
+    output_data->offsets[0] = 0;
+    output_data->count = 1;
+
+    std::cout << "A\n" << std::flush;
+
+    int clientFd = socket(AF_UNIX, SOCK_STREAM, 0);
+
+    size_t BytesRecvd = 0;
+    struct sockaddr_un serverAddr = { 0 };
+    socklen_t addrLen = 0;
+
+    serverAddr.sun_family = AF_UNIX;
+    strncpy(serverAddr.sun_path, input_sock_name->data, input_sock_name->length);
+	if( connect(clientFd, (struct sockaddr*)&serverAddr, sizeof(serverAddr)) == -1 )
+	{
+		printf("Client: Error on connect call \n");
+		return 1;
+	}
+
+    int sizeAvailable = -1;
+    size_t size;
+    FILE *stream;
+    char* bp;
+    stream = open_memstream (&bp, &size);
+    char c;
+    while (sizeAvailable != 0 && recv(clientFd, &sizeAvailable, sizeof(sizeAvailable), 0) != -1) {
+        std::cout << "Received " << sizeAvailable << std::flush;
+        if ( sizeAvailable != 0 ) {
+            for ( int i = 0; i < sizeAvailable; i++ ) {
+                // I'm aware this is not ideal :-F
+                // Just need to get it working and hand off to the C++ gods to optimize
+                recv(clientFd, &c, 1, 0);
+                fwrite(&c, 1, 1, stream);
+            }
+        }
+    }
+    close(clientFd);
+    fflush(stream);
+    output_data->data = bp ;
+    output_data->offsets[1] = size;
+    output_data->size = size;
+    fclose(stream);
+    return 0;
+}
+
+extern "C" long read_fully(non_null_varchar_vector* input_sock_name, non_null_varchar_vector* output_data)
+{
+output_data->data = (char*) malloc(0);
+output_data->offsets = (int*) malloc(4 * 2);
+int i = 0;
+for (i = 0; i < input_sock_name->size; i++ ) {
+output_data->data = (char*)realloc(output_data->data, (i + 1));
+output_data->data[i] = input_sock_name->data[i];
+}
+std::cout << i << "\n" << std::flush;
+std::cout << input_sock_name->size << "\n" << std::flush;
+output_data->offsets[0] = 0;
+output_data->offsets[1] = i;
+output_data->size = i;
+output_data->count = 1;
+return 0;
+}

--- a/src/main/scala/com/nec/cmake/CMakeBuilder.scala
+++ b/src/main/scala/com/nec/cmake/CMakeBuilder.scala
@@ -53,6 +53,9 @@ ${CppResources.All.all
         .mkString("\n")}
 
 add_library(aurora4spark SHARED aurora4spark.cpp)
+if(WIN32)
+  target_link_libraries(aurora4spark wsock32 ws2_32)
+endif()
 """
 
     val tgtCl = targetDir.resolve("CMakeLists.txt")

--- a/src/main/scala/com/nec/hadoop/WholeTextFileVectorEngineInputFormat.scala
+++ b/src/main/scala/com/nec/hadoop/WholeTextFileVectorEngineInputFormat.scala
@@ -1,0 +1,62 @@
+package com.nec.hadoop
+
+import com.nec.hadoop.WholeTextFileVectorEngineReader.VectorEngineRecord
+
+import scala.collection.JavaConverters._
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.mapreduce.InputSplit
+import org.apache.hadoop.mapreduce.JobContext
+import org.apache.hadoop.mapreduce.RecordReader
+import org.apache.hadoop.mapreduce.TaskAttemptContext
+import org.apache.hadoop.mapreduce.lib.input.CombineFileInputFormat
+
+class WholeTextFileVectorEngineInputFormat
+  extends CombineFileInputFormat[Text, VectorEngineRecord]
+  with Configurable {
+
+  override protected def isSplitable(context: JobContext, file: Path): Boolean = false
+
+  override def createRecordReader(
+    split: InputSplit,
+    context: TaskAttemptContext
+  ): RecordReader[Text, VectorEngineRecord] = {
+    val reader =
+      new ConfigurableCombineFileRecordReader(
+        split,
+        context,
+        classOf[WholeTextFileVectorEngineReader]
+      )
+    reader.setConf(getConf)
+    reader
+  }
+
+  /**
+   * Allow minPartitions set by end-user in order to keep compatibility with old Hadoop API,
+   * which is set through setMaxSplitSize
+   */
+  def setMinPartitions(context: JobContext, minPartitions: Int): Unit = {
+    val files = listStatus(context).asScala
+    val totalLen = files.map(file => if (file.isDirectory) 0L else file.getLen).sum
+    val maxSplitSize = Math
+      .ceil(
+        totalLen * 1.0 /
+          (if (minPartitions == 0) 1 else minPartitions)
+      )
+      .toLong
+
+    // For small files we need to ensure the min split size per node & rack <= maxSplitSize
+    val config = context.getConfiguration
+    val minSplitSizePerNode = config.getLong(CombineFileInputFormat.SPLIT_MINSIZE_PERNODE, 0L)
+    val minSplitSizePerRack = config.getLong(CombineFileInputFormat.SPLIT_MINSIZE_PERRACK, 0L)
+
+    if (maxSplitSize < minSplitSizePerNode) {
+      super.setMinSplitSizeNode(maxSplitSize)
+    }
+
+    if (maxSplitSize < minSplitSizePerRack) {
+      super.setMinSplitSizeRack(maxSplitSize)
+    }
+    super.setMaxSplitSize(maxSplitSize)
+  }
+}

--- a/src/main/scala/com/nec/hadoop/WholeTextFileVectorEngineReader.scala
+++ b/src/main/scala/com/nec/hadoop/WholeTextFileVectorEngineReader.scala
@@ -1,0 +1,110 @@
+package com.nec.hadoop
+
+import com.google.common.io.ByteStreams
+import com.google.common.io.Closeables
+import com.nec.hadoop.WholeTextFileVectorEngineReader.VectorEngineRecord
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.conf.{Configurable => HConfigurable}
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.io.compress.CompressionCodecFactory
+import org.apache.hadoop.mapreduce.InputSplit
+import org.apache.hadoop.mapreduce.RecordReader
+import org.apache.hadoop.mapreduce.TaskAttemptContext
+import org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReader
+import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit
+
+trait Configurable extends HConfigurable {
+  private var conf: Configuration = _
+  def setConf(c: Configuration): Unit = {
+    conf = c
+  }
+  def getConf: Configuration = conf
+}
+
+object WholeTextFileVectorEngineReader {
+  final case class VectorEngineRecord(pointer: Long, length: Int) {
+    def getRawData: Array[Byte] = Array.empty
+  }
+}
+
+class WholeTextFileVectorEngineReader(
+  split: CombineFileSplit,
+  context: TaskAttemptContext,
+  index: Integer
+) extends RecordReader[Text, VectorEngineRecord]
+  with Configurable {
+
+  private[this] val path = split.getPath(index)
+  private[this] val fs = path.getFileSystem(context.getConfiguration)
+
+  // True means the current file has been processed, then skip it.
+  private[this] var processed = false
+
+  private[this] val key: Text = new Text(path.toString)
+  private[this] var value: VectorEngineRecord = null
+
+  override def initialize(split: InputSplit, context: TaskAttemptContext): Unit = {}
+
+  override def close(): Unit = {}
+
+  override def getProgress: Float = if (processed) 1.0f else 0.0f
+
+  override def getCurrentKey: Text = key
+
+  override def getCurrentValue: VectorEngineRecord = value
+
+  override def nextKeyValue(): Boolean = {
+    if (!processed) {
+      val conf = getConf
+      val factory = new CompressionCodecFactory(conf)
+      val codec = factory.getCodec(path) // infers from file ext.
+      val fileIn = fs.open(path)
+      val innerBuffer = if (codec != null) {
+        ByteStreams.toByteArray(codec.createInputStream(fileIn))
+      } else {
+        ByteStreams.toByteArray(fileIn)
+      }
+
+      value = VectorEngineRecord(innerBuffer.size.toLong, innerBuffer.size)
+      Closeables.close(fileIn, false)
+      processed = true
+      true
+    } else {
+      false
+    }
+  }
+}
+
+/**
+ * A [[org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReader CombineFileRecordReader]]
+ * that can pass Hadoop Configuration to [[org.apache.hadoop.conf.Configurable Configurable]]
+ * RecordReaders.
+ */
+class ConfigurableCombineFileRecordReader[K, V](
+  split: InputSplit,
+  context: TaskAttemptContext,
+  recordReaderClass: Class[_ <: RecordReader[K, V] with HConfigurable]
+) extends CombineFileRecordReader[K, V](
+    split.asInstanceOf[CombineFileSplit],
+    context,
+    recordReaderClass
+  )
+  with Configurable {
+
+  override def initNextRecordReader(): Boolean = {
+    val r = super.initNextRecordReader()
+    if (r) {
+      if (getConf != null) {
+        this.curReader.asInstanceOf[HConfigurable].setConf(getConf)
+      }
+    }
+    r
+  }
+
+  override def setConf(c: Configuration): Unit = {
+    super.setConf(c)
+    if (this.curReader != null) {
+      this.curReader.asInstanceOf[HConfigurable].setConf(c)
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/WholeTextFileNativeRDD.scala
+++ b/src/main/scala/org/apache/spark/WholeTextFileNativeRDD.scala
@@ -1,0 +1,31 @@
+package org.apache.spark
+
+import com.nec.hadoop.WholeTextFileVectorEngineInputFormat
+import com.nec.hadoop.WholeTextFileVectorEngineReader.VectorEngineRecord
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.mapreduce.Job
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
+import org.apache.spark.rdd.RDD
+
+object WholeTextFileNativeRDD {
+  implicit final class RichSparkContext(sparkContext: SparkContext) {
+    def wholeNativeTextFiles(
+      path: String,
+      minPartitions: Int = sparkContext.defaultMinPartitions
+    ): RDD[(String, VectorEngineRecord)] = sparkContext.withScope {
+      val job = Job.getInstance(sparkContext.hadoopConfiguration)
+      // Use setInputPaths so that wholeTextFiles aligns with hadoopFile/textFile in taking
+      // comma separated files as input. (see SPARK-7155)
+      FileInputFormat.setInputPaths(job, path)
+      val updateConf = job.getConfiguration
+      new WholeTextFileVectorEngineRDD(
+        sparkContext,
+        classOf[WholeTextFileVectorEngineInputFormat],
+        classOf[Text],
+        classOf[VectorEngineRecord],
+        updateConf,
+        minPartitions
+      ).map(record => (record._1.toString, record._2)).setName(path)
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/WholeTextFileVectorEngineRDD.scala
+++ b/src/main/scala/org/apache/spark/WholeTextFileVectorEngineRDD.scala
@@ -1,0 +1,47 @@
+package org.apache.spark
+
+import com.nec.hadoop.Configurable
+import com.nec.hadoop.WholeTextFileVectorEngineInputFormat
+import com.nec.hadoop.WholeTextFileVectorEngineReader.VectorEngineRecord
+import org.apache.hadoop.mapreduce.task.JobContextImpl
+import org.apache.hadoop.io.Writable
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
+import org.apache.spark.rdd.NewHadoopRDD
+import org.apache.hadoop.mapreduce.InputSplit
+import org.apache.spark.rdd.NewHadoopPartition
+
+class WholeTextFileVectorEngineRDD(
+  sc: SparkContext,
+  inputFormatClass: Class[_ <: WholeTextFileVectorEngineInputFormat],
+  keyClass: Class[Text],
+  valueClass: Class[VectorEngineRecord],
+  conf: Configuration,
+  minPartitions: Int
+) extends NewHadoopRDD[Text, VectorEngineRecord](sc, inputFormatClass, keyClass, valueClass, conf) {
+
+  override def getPartitions: Array[Partition] = {
+    val conf = getConf
+    // setMinPartitions below will call FileInputFormat.listStatus(), which can be quite slow when
+    // traversing a large number of directories and files. Parallelize it.
+    conf.setIfUnset(
+      FileInputFormat.LIST_STATUS_NUM_THREADS,
+      Runtime.getRuntime.availableProcessors().toString
+    )
+    val inputFormat = inputFormatClass.getConstructor().newInstance()
+    inputFormat match {
+      case configurable: Configurable =>
+        configurable.setConf(conf)
+      case _ =>
+    }
+    val jobContext = new JobContextImpl(conf, jobId)
+    inputFormat.setMinPartitions(jobContext, minPartitions)
+    val rawSplits = inputFormat.getSplits(jobContext).toArray
+    val result = new Array[Partition](rawSplits.size)
+    for (i <- 0 until rawSplits.size) {
+      result(i) = new NewHadoopPartition(id, i, rawSplits(i).asInstanceOf[InputSplit with Writable])
+    }
+    result
+  }
+}

--- a/src/test/scala/com/nec/cmake/NativeReaderSpec.scala
+++ b/src/test/scala/com/nec/cmake/NativeReaderSpec.scala
@@ -1,0 +1,192 @@
+package com.nec.cmake
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.eed3si9n.expecty.Expecty.expect
+import com.nec.arrow.ArrowNativeInterfaceNumeric.SupportedVectorWrapper.StringWrapper
+import com.nec.arrow.ArrowNativeInterfaceNumeric.SupportedVectorWrapper.VarCharVectorWrapper
+import com.nec.cmake.NativeReaderSpec.newClientSocket
+import com.nec.cmake.NativeReaderSpec.newServerSocket
+import com.nec.cmake.NativeReaderSpec.unixSocketToNativeToArrow
+import com.nec.cmake.ReadFullCSVSpec.samplePartedCsv
+import com.nec.native.NativeEvaluator
+import com.nec.native.NativeEvaluator.CNativeEvaluator
+import com.nec.spark.SparkAdditions
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.VarCharVector
+import org.apache.arrow.vector.util.Text
+import org.apache.spark.WholeTextFileNativeRDD.RichSparkContext
+import org.scalatest.freespec.AnyFreeSpec
+
+import java.net.ServerSocket
+import java.net.Socket
+import org.scalasbt.ipcsocket.UnixDomainServerSocket
+import org.scalasbt.ipcsocket.UnixDomainSocket
+import org.scalasbt.ipcsocket.Win32NamedPipeServerSocket
+import org.scalasbt.ipcsocket.Win32NamedPipeSocket
+import org.scalasbt.ipcsocket.Win32SecurityLevel
+import org.scalatest.BeforeAndAfter
+import org.scalatest.Informing
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import scala.concurrent.duration.DurationInt
+
+object NativeReaderSpec {
+  val isWin: Boolean = System.getProperty("os.name", "").toLowerCase.startsWith("win")
+  def newServerSocket(socketName: String): ServerSocket = if (isWin)
+    new Win32NamedPipeServerSocket(socketName, false, Win32SecurityLevel.LOGON_DACL)
+  else new UnixDomainServerSocket(socketName, false)
+
+  def newClientSocket(socketName: String): Socket = if (isWin)
+    new Win32NamedPipeSocket(socketName, false)
+  else new UnixDomainSocket(socketName, false)
+
+  def unixSocketToNativeToArrow(
+    nativeEvaluator: NativeEvaluator,
+    inputList: List[String]
+  ): String = {
+    val res = nativeEvaluator
+      .forCode("""#include "unix-read.cpp"""")
+    println("Compiled.")
+    val socketName =
+      if (NativeReaderSpec.isWin) "\\\\.\\pipe\\tpipe"
+      else s"/tmp/test-sock-${scala.util.Random.nextInt()}"
+    val serverSocket = newServerSocket(socketName)
+    val serverRespond = IO
+      .blocking {
+        println("Waiting for a connection...")
+        val sockie = serverSocket.accept()
+        println(s"Got a client connection! ${sockie}")
+        try {
+          val byteBuffer = ByteBuffer.allocate(4)
+          inputList.foreach { str =>
+            byteBuffer.position(0)
+            byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
+            byteBuffer.putInt(str.length)
+            byteBuffer.position(0)
+            println("Writing to client...")
+            sockie.getOutputStream.write(byteBuffer.array())
+            sockie.getOutputStream.write(str.getBytes())
+            sockie.getOutputStream.flush()
+          }
+          byteBuffer.position(0)
+          byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
+          byteBuffer.putInt(0)
+          byteBuffer.position(0)
+          sockie.getOutputStream.write(byteBuffer.array())
+          sockie.getOutputStream.close()
+          println("Ended writing to client.")
+        } finally sockie.close()
+      }
+      .timeout(15.seconds)
+
+    val (x, y) = serverRespond.background.allocated.unsafeRunSync()
+
+    println("HERE got here..")
+
+    try {
+      val allocator = new RootAllocator(Integer.MAX_VALUE)
+      val vcv = new VarCharVector("test", allocator)
+      try {
+        println("Calling...")
+        res
+          .callFunction(
+            "read_fully_2",
+            List(Some(StringWrapper(socketName)), None),
+            List(None, Some(VarCharVectorWrapper(vcv)))
+          )
+        println("ENded calling...")
+        new String(vcv.get(0))
+      } finally {
+        vcv.close()
+        serverSocket.close()
+      }
+    } finally {
+      y.unsafeRunSync()
+    }
+  }
+}
+
+final class NativeReaderSpec
+  extends AnyFreeSpec
+  with BeforeAndAfter
+  with Informing
+  with SparkAdditions {
+  "We can put stuff into a UNIX socket, and it will give us data back" ignore {
+    val socketName =
+      if (NativeReaderSpec.isWin) "\\\\.\\pipe\\ipcsockettest"
+      else s"/tmp/test-sock-${scala.util.Random.nextInt()}"
+    val serverSocket = newServerSocket(socketName)
+    val serverRespond = IO.delay {
+      val sockie = serverSocket.accept()
+      try {
+        val num = sockie.getInputStream.read()
+        sockie.getOutputStream.write(Array[Byte](1, num.toByte, 2))
+        sockie.getOutputStream.flush()
+        sockie.getOutputStream.close()
+      } finally sockie.close()
+    }
+
+    val (x, y) = serverRespond.background.allocated.unsafeRunSync()
+    try {
+      val clientConnect = newClientSocket(socketName)
+      clientConnect.getOutputStream.write(9)
+      clientConnect.getOutputStream.flush()
+      val result = List(
+        clientConnect.getInputStream.read(),
+        clientConnect.getInputStream.read(),
+        clientConnect.getInputStream.read()
+      )
+      clientConnect.close()
+      assert(result == List(1, 9, 2))
+    } finally {
+      y.unsafeRunSync()
+    }
+  }
+
+  "We can transfer Hadoop data to the native app" ignore withSparkSession2(identity) {
+
+    /** Not yet implemented properly - this tests fails */
+
+    sparkSession =>
+      val listOfPairs = sparkSession.sparkContext
+        .wholeNativeTextFiles(samplePartedCsv)
+        .collect()
+        .toList
+        .map { case (name, ver) =>
+          name -> new String(ver.getRawData)
+        }
+
+      expect(listOfPairs.size == 3, listOfPairs.exists(_._2.contains("5.0,4.0,3.0")))
+  }
+
+  "We can read-write to a native app" ignore {
+    val allocator = new RootAllocator(Integer.MAX_VALUE)
+//    WithTestAllocator { allocator =>
+    val vcv = new VarCharVector("test", allocator)
+    val inputSock = new VarCharVector("inputSock", allocator)
+    inputSock.setValueCount(1)
+    inputSock.setSafe(0, new Text("ABC"))
+    try {
+      CNativeEvaluator
+        .forCode("""#include "unix-read.cpp"""")
+        .callFunction(
+          "read_fully",
+          List(Some(VarCharVectorWrapper(inputSock)), None),
+          List(None, Some(VarCharVectorWrapper(vcv)))
+        )
+      assert(new String(vcv.get(0)) == "ABC")
+    } finally vcv.close()
+//    }
+  }
+
+  "We can read-write with a unix socket" in {
+    val inputList = List("ABC", "DEF", "GHQEWE")
+    if (!scala.util.Properties.isWin) {
+      val expectedString = inputList.mkString
+      assert(unixSocketToNativeToArrow(CNativeEvaluator, inputList) == expectedString)
+    }
+  }
+
+}

--- a/src/test/scala/com/nec/ve/UnixSocketToVeToArrowSpec.scala
+++ b/src/test/scala/com/nec/ve/UnixSocketToVeToArrowSpec.scala
@@ -1,0 +1,39 @@
+package com.nec.ve
+import com.nec.aurora.Aurora
+import com.nec.cmake.NativeReaderSpec.unixSocketToNativeToArrow
+import com.nec.native.NativeCompiler
+import com.nec.native.NativeEvaluator.VectorEngineNativeEvaluator
+import com.nec.ve.VeKernelCompiler.VeCompilerConfig
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.freespec.AnyFreeSpec
+
+final class UnixSocketToVeToArrowSpec extends AnyFreeSpec with BeforeAndAfterAll {
+
+  private var initialized = false
+  private lazy val proc = Aurora.veo_proc_create(0)
+  private lazy val ctx: Aurora.veo_thr_ctxt = {
+    initialized = true
+    Aurora.veo_context_open(proc)
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    if (initialized) {
+      Aurora.veo_context_close(ctx)
+      Aurora.veo_proc_destroy(proc)
+    }
+  }
+  "We can read-write with a unix socket" in {
+    val (path, compiler) = NativeCompiler.fromTemporaryDirectory(VeCompilerConfig.testConfig)
+    val inputList = List("ABC", "DEF", "GHQEWE")
+    if (!scala.util.Properties.isWin) {
+      val expectedString = inputList.mkString
+      assert(
+        unixSocketToNativeToArrow(
+          new VectorEngineNativeEvaluator(proc, ctx, compiler),
+          inputList
+        ) == expectedString
+      )
+    }
+  }
+}


### PR DESCRIPTION
Works on both VE and native C (no Windows)

This shows that we are able to send data incrementally to the VE via a UNIX socket.

The next missing piece is to link up this Socket facility with the Hadoop InputStream reader.

We implemented an outline of the Hadoop InputStream reader, which would produce VE references, that we then pass back to the VE through `CEvaluationPlan`.