### PR TITLE
Reduce the number of vectors passed to VE.

### DIFF
--- a/src/main/scala/com/nec/spark/planning/CEvaluationPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/CEvaluationPlan.scala
@@ -1,4 +1,6 @@
 package com.nec.spark.planning
+import java.util.UUID
+
 import com.nec.arrow.ArrowNativeInterfaceNumeric
 import com.nec.arrow.ArrowNativeInterfaceNumeric.SupportedVectorWrapper.Float8VectorWrapper
 import com.nec.native.NativeEvaluator
@@ -9,13 +11,10 @@ import com.typesafe.scalalogging.LazyLogging
 import org.apache.arrow.vector.Float8Vector
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.commons.lang3.reflect.FieldUtils
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Alias
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.AttributeReference
-import org.apache.spark.sql.catalyst.expressions.NamedExpression
-import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, AttributeSet, NamedExpression, UnsafeRow}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.expressions.aggregate.Average
 import org.apache.spark.sql.catalyst.expressions.aggregate.Count
@@ -31,7 +30,6 @@ import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.sql.util.ArrowUtilsExposed
 import org.apache.spark.sql.vectorized.ArrowColumnVector
 import org.apache.spark.sql.vectorized.ColumnarBatch
-
 import scala.collection.immutable
 import scala.language.dynamics
 
@@ -64,17 +62,24 @@ object CEvaluationPlan {
 
 }
 final case class CEvaluationPlan(
-  fName: String,
-  resultExpressions: Seq[NamedExpression],
-  lines: CodeLines,
-  child: SparkPlan,
-  nativeEvaluator: NativeEvaluator
+                                  fName: String,
+                                  resultExpressions: Seq[NamedExpression],
+                                  lines: CodeLines,
+                                  child: SparkPlan,
+                                  inputReferences: Set[String],
+                                  nativeEvaluator: NativeEvaluator
 ) extends SparkPlan
   with UnaryExecNode
   with ColumnarToRowTransition
   with LazyLogging {
 
-  protected def inputAttributes: Seq[Attribute] = child.output
+  protected def inputAttributes: Seq[Attribute] = {
+    val attrs = child
+      .output
+      .filter(attr => inputReferences.contains(attr.name))
+
+    if (attrs.size == 0) child.output else attrs
+  }
 
   override def output: Seq[Attribute] = resultExpressions.zipWithIndex.map { case (ne, idx) =>
     AttributeReference(name = s"value_${idx}", dataType = DoubleType, nullable = false)()

--- a/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
+++ b/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
@@ -52,7 +52,7 @@ final case class VERewriteStrategy(sparkSession: SparkSession, nativeEvaluator: 
     def fName: String = s"eval_${Math.abs(plan.hashCode())}"
     if (VERewriteStrategy._enabled) {
       plan match {
-        case logical.Project(resultExpressions, child) if !resultExpressions.forall {
+        case proj @ logical.Project(resultExpressions, child) if !resultExpressions.forall {
               /** If it's just a rename, don't send to VE * */
               case a: Alias if a.child.isInstanceOf[Attribute] => true
               case _                                           => false
@@ -63,15 +63,16 @@ final case class VERewriteStrategy(sparkSession: SparkSession, nativeEvaluator: 
               fName,
               resultExpressions,
               CExpressionEvaluation
-                .cGenProject(fName, child.output, resultExpressions),
+                .cGenProject(fName, proj.references.map(_.name).toSet, child.output, resultExpressions),
               planLater(child),
+              proj.references.map(_.name).toSet,
               nativeEvaluator
             )
           )
         case logical.Aggregate(groupingExpressions, outerResultExpressions, child)
             if GroupBySum.isLogicalGroupBySum(plan) =>
           List(SimpleGroupBySumPlan(planLater(child), nativeEvaluator, GroupByMethod.VEBased))
-        case logical.Aggregate(
+        case agg @ logical.Aggregate(
               groupingExpressions,
               outerResultExpressions,
               logical.Project(exprs, child)
@@ -97,6 +98,7 @@ final case class VERewriteStrategy(sparkSession: SparkSession, nativeEvaluator: 
                 CExpressionEvaluation
                   .cGen(
                     fName,
+                    agg.references.map(_.name).toSet,
                     child.output,
                     resultExpressions.map { re =>
                       (
@@ -112,12 +114,13 @@ final case class VERewriteStrategy(sparkSession: SparkSession, nativeEvaluator: 
                 List("}")
               ).flatten.codeLines,
               planLater(child),
+              agg.references.map(_.name).toSet,
               nativeEvaluator
             )
           )
 
         /** There can be plans where we have Cast(Alias(AggEx) as String) - this is not yet supported */
-        case logical.Aggregate(groupingExpressions, resultExpressions, child)
+        case agg @ logical.Aggregate(groupingExpressions, resultExpressions, child)
             if resultExpressions.forall(e =>
               e.isInstanceOf[Alias] && e.asInstanceOf[Alias].child.isInstanceOf[AggregateExpression]
             ) =>
@@ -130,6 +133,7 @@ final case class VERewriteStrategy(sparkSession: SparkSession, nativeEvaluator: 
                 CExpressionEvaluation
                   .cGen(
                     fName,
+                    agg.references.map(_.name).toSet,
                     child.output,
                     resultExpressions.map { re =>
                       (
@@ -145,6 +149,7 @@ final case class VERewriteStrategy(sparkSession: SparkSession, nativeEvaluator: 
                 List("}")
               ).flatten.codeLines,
               planLater(child),
+              agg.references.map(_.name).toSet,
               nativeEvaluator
             )
           )

--- a/src/test/scala/com/nec/spark/agile/ExpressionGenerationSpec.scala
+++ b/src/test/scala/com/nec/spark/agile/ExpressionGenerationSpec.scala
@@ -44,7 +44,7 @@ final class ExpressionGenerationSpec extends AnyFreeSpec with BeforeAndAfter wit
       filter = None
     )
 
-    assert(cGen(testFName, Seq(ref), Alias(null, "summy")() -> expr) == {
+    assert(cGen(testFName, Set("value#14") ,Seq(ref), Alias(null, "summy")() -> expr) == {
       List(
         s"""extern "C" long ${testFName}(non_null_double_vector* input_0, non_null_double_vector* output_0_sum) {""",
         "output_0_sum->data = (double *)malloc(1 * sizeof(double));",
@@ -76,7 +76,7 @@ final class ExpressionGenerationSpec extends AnyFreeSpec with BeforeAndAfter wit
       filter = None
     )
 
-    assert(cGen(testFName, Seq(ref), Alias(null, "avy#123 + 51")() -> expr) == {
+    assert(cGen(testFName,Set("abcd"), Seq(ref), Alias(null, "avy#123 + 51")() -> expr) == {
       List(
         s"""extern "C" long ${testFName}(non_null_double_vector* input_0, non_null_double_vector* output_0_average_sum, non_null_double_vector* output_0_average_count) {""",
         "output_0_average_sum->data = (double *)malloc(1 * sizeof(double));",
@@ -111,7 +111,7 @@ final class ExpressionGenerationSpec extends AnyFreeSpec with BeforeAndAfter wit
       filter = None
     )
 
-    assert(cGen(testFName, Seq(ref), Alias(null, "avy#123 + 2")() -> expr) == {
+    assert(cGen(testFName, Set("abcd"), Seq(ref), Alias(null, "avy#123 + 2")() -> expr) == {
       List(
         s"""extern "C" long ${testFName}(non_null_double_vector* input_0, non_null_double_vector* output_0_average_sum, non_null_double_vector* output_0_average_count) {""",
         "output_0_average_sum->data = (double *)malloc(1 * sizeof(double));",
@@ -152,7 +152,7 @@ final class ExpressionGenerationSpec extends AnyFreeSpec with BeforeAndAfter wit
       filter = None
     )
 
-    assert(cGen(testFName, Seq(ref1, ref2), Alias(null, "avy#123 + avy#124")() -> expr) == {
+    assert(cGen(testFName, Set("abcd", "abcd_2"), Seq(ref1, ref2), Alias(null, "avy#123 + avy#124")() -> expr) == {
       List(
         s"""extern "C" long ${testFName}(non_null_double_vector* input_0, non_null_double_vector* input_1, non_null_double_vector* output_0_average_sum, non_null_double_vector* output_0_average_count) {""",
         "output_0_average_sum->data = (double *)malloc(1 * sizeof(double));",
@@ -239,6 +239,7 @@ final class ExpressionGenerationSpec extends AnyFreeSpec with BeforeAndAfter wit
     assert(
       cGen(
         testFName,
+        Set("abcd"),
         Seq(ref),
         Alias(null, "summy")() -> expr,
         Alias(null, "avy#123 - 1.0")() -> expr2
@@ -286,6 +287,7 @@ final class ExpressionGenerationSpec extends AnyFreeSpec with BeforeAndAfter wit
     assert(
       cGenProject(
         testFName,
+        Set("value#14", "value#15"),
         Seq(ref_value14, ref_value15),
         Seq(Alias(Add(ref_value14, ref_value15), "oot")())
       ) == List(
@@ -309,6 +311,7 @@ final class ExpressionGenerationSpec extends AnyFreeSpec with BeforeAndAfter wit
     assert(
       cGenProject(
         testFName,
+        Set("value#14", "value#15"),
         Seq(ref_value14, ref_value15),
         Seq(Alias(Subtract(ref_value14, ref_value15), "oot")())
       ) == List(
@@ -332,6 +335,7 @@ final class ExpressionGenerationSpec extends AnyFreeSpec with BeforeAndAfter wit
     assert(
       cGenProject(
         testFName,
+        Set("value#14", "value#15"),
         Seq(ref_value14, ref_value15),
         Seq(
           Alias(Add(ref_value14, ref_value15), "oot")(),


### PR DESCRIPTION
This PR changes the way we are passing the vectors to VE so that we only pass the vectors that are actually part of the operation. 

This should both reduce the required memory as previously if dataset had 100 columns but we did select of 1 it would still serialize and pass all of them to VE. It should also make it possible to read datasets that have types we don't yet support as long as we don't use them in SELECT.