### PR TITLE
Add test proving we can handle multiple join ops.

### DIFF
--- a/src/test/scala/com/nec/cmake/DynamicCSqlExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/cmake/DynamicCSqlExpressionEvaluationSpec.scala
@@ -217,6 +217,105 @@ final class DynamicCSqlExpressionEvaluationSpec
     }
   }
 
+  val sql_multi_join =
+    s"SELECT nums.${SampleColA},nums2.${SampleColA}, nums.${SampleColB}, nums2.${SampleColB}," +
+      s"nums3.${SampleColA}, nums4.${SampleColA}, nums3.${SampleColB}, nums4.${SampleColB}" +
+      s" FROM nums JOIN nums2 ON nums.${SampleColA} = nums2.${SampleColA} JOIN nums AS nums3 " +
+      s"ON nums.${SampleColA} = nums3.${SampleColA} JOIN nums2 AS nums4 ON nums.${SampleColA} = nums4.${SampleColA}"
+  "Support multiple inner join operations" in withSparkSession2(configuration) { sparkSession =>
+    makeCsvNumsMultiColumnJoin(sparkSession)
+    import sparkSession.implicits._
+
+    sparkSession.sql(sql_multi_join).ensureJoinPlanEvaluated().debugSqlHere { ds =>
+      ds.as[
+        (
+          Option[Double],
+          Option[Double],
+          Option[Double],
+          Option[Double],
+          Option[Double],
+          Option[Double],
+          Option[Double],
+          Option[Double]
+        )
+      ].collect()
+        .toList should contain theSameElementsAs
+        List(
+          (
+            Some(1.0),
+            Some(1.0),
+            Some(2.0),
+            Some(41.0),
+            Some(1.0),
+            Some(1.0),
+            Some(2.0),
+            Some(41.0)
+          ),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), Some(3.0), None),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), Some(3.0), Some(44.0)),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), Some(3.0), None),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), Some(3.0), Some(44.0)),
+          (Some(2.0), Some(2.0), Some(3.0), Some(44.0), Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), Some(3.0), Some(44.0), Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), Some(3.0), Some(44.0), Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), Some(3.0), Some(44.0), Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), Some(3.0), Some(44.0), Some(2.0), Some(2.0), Some(3.0), None),
+          (
+            Some(2.0),
+            Some(2.0),
+            Some(3.0),
+            Some(44.0),
+            Some(2.0),
+            Some(2.0),
+            Some(3.0),
+            Some(44.0)
+          ),
+          (
+            Some(52.0),
+            Some(52.0),
+            Some(6.0),
+            Some(61.0),
+            Some(52.0),
+            Some(52.0),
+            Some(6.0),
+            Some(61.0)
+          ),
+          (Some(4.0), Some(4.0), Some(5.0), None, Some(4.0), Some(4.0), Some(5.0), None),
+          (Some(4.0), Some(4.0), Some(5.0), None, Some(4.0), Some(4.0), None, None),
+          (Some(4.0), Some(4.0), None, None, Some(4.0), Some(4.0), Some(5.0), None),
+          (Some(4.0), Some(4.0), None, None, Some(4.0), Some(4.0), None, None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), Some(3.0), None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), Some(3.0), Some(44.0)),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), Some(3.0), None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), Some(3.0), Some(44.0)),
+          (Some(2.0), Some(2.0), Some(3.0), None, Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), Some(3.0), None, Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), Some(3.0), None, Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), Some(3.0), None, Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), Some(3.0), None, Some(2.0), Some(2.0), Some(3.0), None),
+          (Some(2.0), Some(2.0), Some(3.0), None, Some(2.0), Some(2.0), Some(3.0), Some(44.0)),
+          (Some(3.0), Some(3.0), Some(4.0), None, Some(3.0), Some(3.0), Some(4.0), None),
+          (Some(20.0), Some(20.0), None, Some(32.0), Some(20.0), Some(20.0), None, Some(32.0))
+        )
+    }
+  }
+
   val sql_join_key_select =
     s"SELECT nums.${SampleColA},nums2.${SampleColA}, nums.${SampleColB}, nums2.${SampleColB} FROM nums JOIN nums2 ON nums.${SampleColA} = nums2.${SampleColA}"
   "Support INNER EQUAL JOIN with selection of join key" in withSparkSession2(configuration) {

--- a/src/test/scala/com/nec/ve/DynamicVeSqlExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/ve/DynamicVeSqlExpressionEvaluationSpec.scala
@@ -232,6 +232,105 @@ final class DynamicVeSqlExpressionEvaluationSpec
     }
   }
 
+  val sql_multi_join =
+    s"SELECT nums.${SampleColA},nums2.${SampleColA}, nums.${SampleColB}, nums2.${SampleColB}," +
+      s"nums3.${SampleColA}, nums4.${SampleColA}, nums3.${SampleColB}, nums4.${SampleColB}" +
+      s" FROM nums JOIN nums2 ON nums.${SampleColA} = nums2.${SampleColA} JOIN nums AS nums3 " +
+      s"ON nums.${SampleColA} = nums3.${SampleColA} JOIN nums2 AS nums4 ON nums.${SampleColA} = nums4.${SampleColA}"
+  "Support multiple inner join operations" in withSparkSession2(configuration) { sparkSession =>
+    makeCsvNumsMultiColumnJoin(sparkSession)
+    import sparkSession.implicits._
+
+    sparkSession.sql(sql_multi_join).ensureJoinPlanEvaluated().debugSqlHere { ds =>
+      ds.as[
+        (
+          Option[Double],
+            Option[Double],
+            Option[Double],
+            Option[Double],
+            Option[Double],
+            Option[Double],
+            Option[Double],
+            Option[Double]
+          )
+      ].collect()
+        .toList should contain theSameElementsAs
+        List(
+          (
+            Some(1.0),
+            Some(1.0),
+            Some(2.0),
+            Some(41.0),
+            Some(1.0),
+            Some(1.0),
+            Some(2.0),
+            Some(41.0)
+          ),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), Some(3.0), None),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), Some(3.0), Some(44.0)),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), Some(3.0), None),
+          (Some(2.0), Some(2.0), None, Some(44.0), Some(2.0), Some(2.0), Some(3.0), Some(44.0)),
+          (Some(2.0), Some(2.0), Some(3.0), Some(44.0), Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), Some(3.0), Some(44.0), Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), Some(3.0), Some(44.0), Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), Some(3.0), Some(44.0), Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), Some(3.0), Some(44.0), Some(2.0), Some(2.0), Some(3.0), None),
+          (
+            Some(2.0),
+            Some(2.0),
+            Some(3.0),
+            Some(44.0),
+            Some(2.0),
+            Some(2.0),
+            Some(3.0),
+            Some(44.0)
+          ),
+          (
+            Some(52.0),
+            Some(52.0),
+            Some(6.0),
+            Some(61.0),
+            Some(52.0),
+            Some(52.0),
+            Some(6.0),
+            Some(61.0)
+          ),
+          (Some(4.0), Some(4.0), Some(5.0), None, Some(4.0), Some(4.0), Some(5.0), None),
+          (Some(4.0), Some(4.0), Some(5.0), None, Some(4.0), Some(4.0), None, None),
+          (Some(4.0), Some(4.0), None, None, Some(4.0), Some(4.0), Some(5.0), None),
+          (Some(4.0), Some(4.0), None, None, Some(4.0), Some(4.0), None, None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), Some(3.0), None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), Some(3.0), Some(44.0)),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), Some(3.0), None),
+          (Some(2.0), Some(2.0), None, None, Some(2.0), Some(2.0), Some(3.0), Some(44.0)),
+          (Some(2.0), Some(2.0), Some(3.0), None, Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), Some(3.0), None, Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), Some(3.0), None, Some(2.0), Some(2.0), None, None),
+          (Some(2.0), Some(2.0), Some(3.0), None, Some(2.0), Some(2.0), None, Some(44.0)),
+          (Some(2.0), Some(2.0), Some(3.0), None, Some(2.0), Some(2.0), Some(3.0), None),
+          (Some(2.0), Some(2.0), Some(3.0), None, Some(2.0), Some(2.0), Some(3.0), Some(44.0)),
+          (Some(3.0), Some(3.0), Some(4.0), None, Some(3.0), Some(3.0), Some(4.0), None),
+          (Some(20.0), Some(20.0), None, Some(32.0), Some(20.0), Some(20.0), None, Some(32.0))
+        )
+    }
+  }
+
   val sql_join_key_select =
     s"SELECT nums.${SampleColA},nums2.${SampleColA}, nums.${SampleColB}, nums2.${SampleColB}" +
       s" FROM nums JOIN nums2 ON nums.${SampleColA} = nums2.${SampleColA}"


### PR DESCRIPTION
This PR adds a test that proves we are able to handle multiple separate `JOIN` operations. Currently, we are going to replace each plan separately so for the sql in test we are going to produce the following plan:

```
*(5) Project [ColA#0, ColA#4, ColB#1, ColB#5, ColA#8, ColA#10, ColB#9, ColB#11]
+- GeneratedJoinPlan CodeLines(
#include "frovedis/dataframe/join.hpp"
#include <cmath>
#include <bitset>
#include "frovedis/dataframe/join.cc"
extern "C" long eval_2013474191(nullable_double_vector* input_0, nullable_double_vector* input_1, nullable_double_vector* input_2, nullable_double_vector* input_3, nullable_double_vector* input_4, nullable_double_vector* input_5, nullable_double_vector* input_6, nullable_double_vector* input_7, nullable_double_vector* output_0, nullable_double_vector* output_1, nullable_double_vector* output_2, nullable_double_vector* output_3, nullable_double_vector* output_4, nullable_double_vector* output_5, nullable_double_vector* output_6, nullable_double_vector* output_7)
{
std::vector <double> left_vec;
std::vector<size_t> left_idx;
std::vector <double> right_vec;
std::vector<size_t> right_idx;
#pragma _NEC ivdep
for(int i = 0; i < input_0->count; i++) { 
left_vec.push_back(input_0->data[i]);
left_idx.push_back(i);
right_vec.push_back(input_3->data[i]);
right_idx.push_back(i);
}
std::vector<size_t> right_out;
std::vector<size_t> left_out;
frovedis::equi_join<double>(left_vec, left_idx, right_vec, right_idx, left_out, right_out);
long validityBuffSize = ceil(left_out.size() / 8.0);
output_0->data=(double *) malloc(left_out.size() * sizeof(double));
output_0->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_0;
int j_0 = 0;
output_1->data=(double *) malloc(left_out.size() * sizeof(double));
output_1->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_1;
int j_1 = 0;
output_2->data=(double *) malloc(left_out.size() * sizeof(double));
output_2->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_2;
int j_2 = 0;
output_3->data=(double *) malloc(left_out.size() * sizeof(double));
output_3->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_3;
int j_3 = 0;
output_4->data=(double *) malloc(left_out.size() * sizeof(double));
output_4->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_4;
int j_4 = 0;
output_5->data=(double *) malloc(left_out.size() * sizeof(double));
output_5->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_5;
int j_5 = 0;
output_6->data=(double *) malloc(left_out.size() * sizeof(double));
output_6->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_6;
int j_6 = 0;
output_7->data=(double *) malloc(left_out.size() * sizeof(double));
output_7->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_7;
int j_7 = 0;
#pragma _NEC ivdep
for (int i = 0; i < left_out.size(); i++) {
if(((input_0->validityBuffer[left_out[i]/8] >> left_out[i] % 8) & 0x1) == 1) {
validity_bitset_0.set(i%8, true);
output_0->data[i] = input_0->data[left_out[i]];
} else {
validity_bitset_0.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_0->validityBuffer[j_0] = (static_cast<unsigned char>(validity_bitset_0.to_ulong()));
j_0 += 1;
validity_bitset_0.reset(); }
if(((input_4->validityBuffer[left_out[i]/8] >> left_out[i] % 8) & 0x1) == 1) {
validity_bitset_1.set(i%8, true);
output_1->data[i] = input_4->data[left_out[i]];
} else {
validity_bitset_1.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_1->validityBuffer[j_1] = (static_cast<unsigned char>(validity_bitset_1.to_ulong()));
j_1 += 1;
validity_bitset_1.reset(); }
if(((input_1->validityBuffer[left_out[i]/8] >> left_out[i] % 8) & 0x1) == 1) {
validity_bitset_2.set(i%8, true);
output_2->data[i] = input_1->data[left_out[i]];
} else {
validity_bitset_2.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_2->validityBuffer[j_2] = (static_cast<unsigned char>(validity_bitset_2.to_ulong()));
j_2 += 1;
validity_bitset_2.reset(); }
if(((input_5->validityBuffer[left_out[i]/8] >> left_out[i] % 8) & 0x1) == 1) {
validity_bitset_3.set(i%8, true);
output_3->data[i] = input_5->data[left_out[i]];
} else {
validity_bitset_3.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_3->validityBuffer[j_3] = (static_cast<unsigned char>(validity_bitset_3.to_ulong()));
j_3 += 1;
validity_bitset_3.reset(); }
if(((input_2->validityBuffer[left_out[i]/8] >> left_out[i] % 8) & 0x1) == 1) {
validity_bitset_4.set(i%8, true);
output_4->data[i] = input_2->data[left_out[i]];
} else {
validity_bitset_4.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_4->validityBuffer[j_4] = (static_cast<unsigned char>(validity_bitset_4.to_ulong()));
j_4 += 1;
validity_bitset_4.reset(); }
if(((input_6->validityBuffer[left_out[i]/8] >> left_out[i] % 8) & 0x1) == 1) {
validity_bitset_5.set(i%8, true);
output_5->data[i] = input_6->data[left_out[i]];
} else {
validity_bitset_5.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_5->validityBuffer[j_5] = (static_cast<unsigned char>(validity_bitset_5.to_ulong()));
j_5 += 1;
validity_bitset_5.reset(); }
if(((input_3->validityBuffer[right_out[i]/8] >> right_out[i] % 8) & 0x1) == 1) {
validity_bitset_6.set(i%8, true);
output_6->data[i] = input_3->data[right_out[i]];
} else {
validity_bitset_6.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_6->validityBuffer[j_6] = (static_cast<unsigned char>(validity_bitset_6.to_ulong()));
j_6 += 1;
validity_bitset_6.reset(); }
if(((input_7->validityBuffer[right_out[i]/8] >> right_out[i] % 8) & 0x1) == 1) {
validity_bitset_7.set(i%8, true);
output_7->data[i] = input_7->data[right_out[i]];
} else {
validity_bitset_7.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_7->validityBuffer[j_7] = (static_cast<unsigned char>(validity_bitset_7.to_ulong()));
j_7 += 1;
validity_bitset_7.reset(); }
}
output_0->count = left_out.size();
output_1->count = left_out.size();
output_2->count = left_out.size();
output_3->count = left_out.size();
output_4->count = left_out.size();
output_5->count = left_out.size();
output_6->count = left_out.size();
output_7->count = left_out.size();
return 0;
}
), com.nec.native.NativeEvaluator$CNativeEvaluator$@20864cd1, [ColA#0, ColA#4, ColA#8, ColA#10, ColB#1, ColB#5, ColB#9, ColB#11], [ColA#0, ColB#1, ColA#4, ColB#5, ColA#8, ColB#9, ColA#10, ColB#11], eval_2013474191
   :- GeneratedJoinPlan CodeLines(
#include "frovedis/dataframe/join.hpp"
#include <cmath>
#include <bitset>
#include "frovedis/dataframe/join.cc"
extern "C" long eval_199143337(nullable_double_vector* input_0, nullable_double_vector* input_1, nullable_double_vector* input_2, nullable_double_vector* input_3, nullable_double_vector* input_4, nullable_double_vector* input_5, nullable_double_vector* output_0, nullable_double_vector* output_1, nullable_double_vector* output_2, nullable_double_vector* output_3, nullable_double_vector* output_4, nullable_double_vector* output_5)
{
std::vector <double> left_vec;
std::vector<size_t> left_idx;
std::vector <double> right_vec;
std::vector<size_t> right_idx;
#pragma _NEC ivdep
for(int i = 0; i < input_0->count; i++) { 
left_vec.push_back(input_0->data[i]);
left_idx.push_back(i);
right_vec.push_back(input_2->data[i]);
right_idx.push_back(i);
}
std::vector<size_t> right_out;
std::vector<size_t> left_out;
frovedis::equi_join<double>(left_vec, left_idx, right_vec, right_idx, left_out, right_out);
long validityBuffSize = ceil(left_out.size() / 8.0);
output_0->data=(double *) malloc(left_out.size() * sizeof(double));
output_0->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_0;
int j_0 = 0;
output_1->data=(double *) malloc(left_out.size() * sizeof(double));
output_1->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_1;
int j_1 = 0;
output_2->data=(double *) malloc(left_out.size() * sizeof(double));
output_2->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_2;
int j_2 = 0;
output_3->data=(double *) malloc(left_out.size() * sizeof(double));
output_3->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_3;
int j_3 = 0;
output_4->data=(double *) malloc(left_out.size() * sizeof(double));
output_4->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_4;
int j_4 = 0;
output_5->data=(double *) malloc(left_out.size() * sizeof(double));
output_5->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_5;
int j_5 = 0;
#pragma _NEC ivdep
for (int i = 0; i < left_out.size(); i++) {
if(((input_0->validityBuffer[left_out[i]/8] >> left_out[i] % 8) & 0x1) == 1) {
validity_bitset_0.set(i%8, true);
output_0->data[i] = input_0->data[left_out[i]];
} else {
validity_bitset_0.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_0->validityBuffer[j_0] = (static_cast<unsigned char>(validity_bitset_0.to_ulong()));
j_0 += 1;
validity_bitset_0.reset(); }
if(((input_3->validityBuffer[left_out[i]/8] >> left_out[i] % 8) & 0x1) == 1) {
validity_bitset_1.set(i%8, true);
output_1->data[i] = input_3->data[left_out[i]];
} else {
validity_bitset_1.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_1->validityBuffer[j_1] = (static_cast<unsigned char>(validity_bitset_1.to_ulong()));
j_1 += 1;
validity_bitset_1.reset(); }
if(((input_1->validityBuffer[left_out[i]/8] >> left_out[i] % 8) & 0x1) == 1) {
validity_bitset_2.set(i%8, true);
output_2->data[i] = input_1->data[left_out[i]];
} else {
validity_bitset_2.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_2->validityBuffer[j_2] = (static_cast<unsigned char>(validity_bitset_2.to_ulong()));
j_2 += 1;
validity_bitset_2.reset(); }
if(((input_4->validityBuffer[left_out[i]/8] >> left_out[i] % 8) & 0x1) == 1) {
validity_bitset_3.set(i%8, true);
output_3->data[i] = input_4->data[left_out[i]];
} else {
validity_bitset_3.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_3->validityBuffer[j_3] = (static_cast<unsigned char>(validity_bitset_3.to_ulong()));
j_3 += 1;
validity_bitset_3.reset(); }
if(((input_2->validityBuffer[right_out[i]/8] >> right_out[i] % 8) & 0x1) == 1) {
validity_bitset_4.set(i%8, true);
output_4->data[i] = input_2->data[right_out[i]];
} else {
validity_bitset_4.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_4->validityBuffer[j_4] = (static_cast<unsigned char>(validity_bitset_4.to_ulong()));
j_4 += 1;
validity_bitset_4.reset(); }
if(((input_5->validityBuffer[right_out[i]/8] >> right_out[i] % 8) & 0x1) == 1) {
validity_bitset_5.set(i%8, true);
output_5->data[i] = input_5->data[right_out[i]];
} else {
validity_bitset_5.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_5->validityBuffer[j_5] = (static_cast<unsigned char>(validity_bitset_5.to_ulong()));
j_5 += 1;
validity_bitset_5.reset(); }
}
output_0->count = left_out.size();
output_1->count = left_out.size();
output_2->count = left_out.size();
output_3->count = left_out.size();
output_4->count = left_out.size();
output_5->count = left_out.size();
return 0;
}
), com.nec.native.NativeEvaluator$CNativeEvaluator$@20864cd1, [ColA#0, ColA#4, ColA#8, ColB#1, ColB#5, ColB#9], [ColA#0, ColB#1, ColA#4, ColB#5, ColA#8, ColB#9], eval_199143337
   :  :- GeneratedJoinPlan CodeLines(
#include "frovedis/dataframe/join.hpp"
#include <cmath>
#include <bitset>
#include "frovedis/dataframe/join.cc"
extern "C" long eval_190913133(nullable_double_vector* input_0, nullable_double_vector* input_1, nullable_double_vector* input_2, nullable_double_vector* input_3, nullable_double_vector* output_0, nullable_double_vector* output_1, nullable_double_vector* output_2, nullable_double_vector* output_3)
{
std::vector <double> left_vec;
std::vector<size_t> left_idx;
std::vector <double> right_vec;
std::vector<size_t> right_idx;
#pragma _NEC ivdep
for(int i = 0; i < input_0->count; i++) { 
left_vec.push_back(input_0->data[i]);
left_idx.push_back(i);
right_vec.push_back(input_1->data[i]);
right_idx.push_back(i);
}
std::vector<size_t> right_out;
std::vector<size_t> left_out;
frovedis::equi_join<double>(left_vec, left_idx, right_vec, right_idx, left_out, right_out);
long validityBuffSize = ceil(left_out.size() / 8.0);
output_0->data=(double *) malloc(left_out.size() * sizeof(double));
output_0->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_0;
int j_0 = 0;
output_1->data=(double *) malloc(left_out.size() * sizeof(double));
output_1->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_1;
int j_1 = 0;
output_2->data=(double *) malloc(left_out.size() * sizeof(double));
output_2->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_2;
int j_2 = 0;
output_3->data=(double *) malloc(left_out.size() * sizeof(double));
output_3->validityBuffer=(unsigned char *) malloc(validityBuffSize * sizeof(unsigned char*));
std::bitset<8> validity_bitset_3;
int j_3 = 0;
#pragma _NEC ivdep
for (int i = 0; i < left_out.size(); i++) {
if(((input_0->validityBuffer[left_out[i]/8] >> left_out[i] % 8) & 0x1) == 1) {
validity_bitset_0.set(i%8, true);
output_0->data[i] = input_0->data[left_out[i]];
} else {
validity_bitset_0.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_0->validityBuffer[j_0] = (static_cast<unsigned char>(validity_bitset_0.to_ulong()));
j_0 += 1;
validity_bitset_0.reset(); }
if(((input_2->validityBuffer[left_out[i]/8] >> left_out[i] % 8) & 0x1) == 1) {
validity_bitset_1.set(i%8, true);
output_1->data[i] = input_2->data[left_out[i]];
} else {
validity_bitset_1.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_1->validityBuffer[j_1] = (static_cast<unsigned char>(validity_bitset_1.to_ulong()));
j_1 += 1;
validity_bitset_1.reset(); }
if(((input_1->validityBuffer[right_out[i]/8] >> right_out[i] % 8) & 0x1) == 1) {
validity_bitset_2.set(i%8, true);
output_2->data[i] = input_1->data[right_out[i]];
} else {
validity_bitset_2.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_2->validityBuffer[j_2] = (static_cast<unsigned char>(validity_bitset_2.to_ulong()));
j_2 += 1;
validity_bitset_2.reset(); }
if(((input_3->validityBuffer[right_out[i]/8] >> right_out[i] % 8) & 0x1) == 1) {
validity_bitset_3.set(i%8, true);
output_3->data[i] = input_3->data[right_out[i]];
} else {
validity_bitset_3.set(i%8, false);
}
if(i % 8 == 7 || i == left_out.size() - 1) { 
output_3->validityBuffer[j_3] = (static_cast<unsigned char>(validity_bitset_3.to_ulong()));
j_3 += 1;
validity_bitset_3.reset(); }
}
output_0->count = left_out.size();
output_1->count = left_out.size();
output_2->count = left_out.size();
output_3->count = left_out.size();
return 0;
}
), com.nec.native.NativeEvaluator$CNativeEvaluator$@20864cd1, [ColA#0, ColA#4, ColB#1, ColB#5], [ColA#0, ColB#1, ColA#4, ColB#5], eval_190913133
   :  :  :- *(1) Filter isnotnull(ColA#0)
   :  :  :  +- FileScan csv [ColA#0,ColB#1] Batched: false, DataFilters: [isnotnull(ColA#0)], Format: CSV, Location: InMemoryFileIndex[file:/Users/wosin/aurora4spark/src/test/resources/com/nec/spark/sampleMultiColu..., PartitionFilters: [], PushedFilters: [IsNotNull(ColA)], ReadSchema: struct<ColA:double,ColB:double>
   :  :  +- *(2) Filter isnotnull(ColA#4)
   :  :     +- FileScan csv [ColA#4,ColB#5] Batched: false, DataFilters: [isnotnull(ColA#4)], Format: CSV, Location: InMemoryFileIndex[file:/Users/wosin/aurora4spark/src/test/resources/com/nec/spark/sampleMultiColu..., PartitionFilters: [], PushedFilters: [IsNotNull(ColA)], ReadSchema: struct<ColA:double,ColB:double>
   :  +- *(3) Filter isnotnull(ColA#8)
   :     +- FileScan csv [ColA#8,ColB#9] Batched: false, DataFilters: [isnotnull(ColA#8)], Format: CSV, Location: InMemoryFileIndex[file:/Users/wosin/aurora4spark/src/test/resources/com/nec/spark/sampleMultiColu..., PartitionFilters: [], PushedFilters: [IsNotNull(ColA)], ReadSchema: struct<ColA:double,ColB:double>
   +- *(4) Filter isnotnull(ColA#10)
      +- FileScan csv [ColA#10,ColB#11] Batched: false, DataFilters: [isnotnull(ColA#10)], Format: CSV, Location: InMemoryFileIndex[file:/Users/wosin/aurora4spark/src/test/resources/com/nec/spark/sampleMultiColu..., PartitionFilters: [], PushedFilters: [IsNotNull(ColA)], ReadSchema: struct<ColA:double,ColB:double>
```
The performance of that won't be too good, since we are going to transfer data 4 times - separately for every plan.  Possible improvements are:
* Introduce somekind of melding of multiple `JOIN` operations into one. 
* Reduce the transfer by keeping the data that has already been transfered and just passing pointers.

The second option is much more flexible and should allow us to achieve better performance.