### PR TITLE
Do not ignore "spark.sql.extensions" configuration

### DIFF
--- a/src/main/scala/com/nec/spark/Aurora4SparkDriverPlugin.scala
+++ b/src/main/scala/com/nec/spark/Aurora4SparkDriverPlugin.scala
@@ -43,7 +43,7 @@ class Aurora4SparkDriverPlugin extends DriverPlugin with LazyLogging {
     val allExtensions = List(classOf[LocalVeoExtension], classOf[NativeCsvExtension])
     pluginContext
       .conf()
-      .set("spark.sql.extensions", allExtensions.map(_.getCanonicalName).mkString(","))
+      .set("spark.sql.extensions", allExtensions.map(_.getCanonicalName).mkString(",") + "," + sc.getConf.get("spark.sql.extensions", ""))
 
     val tmpBuildDir = Files.createTempDirectory("ve-spark-tmp")
     val testArgs: Map[String, String] = Map(


### PR DESCRIPTION
Tested working with and without `--conf spark.sql.extensions=org.apache.spark.sql.OapExtensions`.