### PR TITLE
Fix VERewriteStrategy to generate unique code

### DIFF
--- a/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
+++ b/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
@@ -52,7 +52,7 @@ final case class VERewriteStrategy(nativeEvaluator: NativeEvaluator)
 
   @silent
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = {
-    def fName: String = s"eval_${Math.abs(plan.hashCode())}"
+    def fName: String = s"eval_${Math.abs(plan.toString.hashCode())}"
 
     if (VERewriteStrategy._enabled) {
       log.debug(


### PR DESCRIPTION
LogicalPlan does not override hashCode(), so including its value in the code makes it different on every invocation, preventing NativeCompiler from being able to do any caching, but it does override toString() so we can use that instead, and it works.