### PR TITLE
D som hacks

### DIFF
--- a/src/main/scala/com/nec/spark/agile/SparkVeMapper.scala
+++ b/src/main/scala/com/nec/spark/agile/SparkVeMapper.scala
@@ -94,6 +94,13 @@ object SparkVeMapper {
     }
   }
 
+  def replaceNullability(expr: Expression, nonNullColumns: Seq[ExprId]) = {
+    expr.transform{
+      case ar: AttributeReference if(nonNullColumns.contains(ar.exprId)) =>
+        ar.withNullability(false)
+    }
+  }
+
   def replaceReferences(inputs: Seq[Attribute], expression: Expression): Expression =
     expression.transform(referenceReplacer(inputs))
 


### PR DESCRIPTION
This PR will implement 3 things:

1. Removing null checking for all columns that have `nullable=false` as this is not needed at all and apparently significantly reduces perf.
2. A hacky way to try to be smarter than Spark planner. There are situations where spark inlines deserialization and creates `StaticInvoke` plan. We can use fact that we know that `fromString` used in TPCH deserialization will never return null if the input column will not be null and try to transform the plan to return nullability as false. I have no idea if that will not brake anything and it should probably be just used as an indication in TPCH tests.
3. Sorting on CPU ( TO DO).