### PR TITLE
Cache tables for TPC-H benchmark on load

### DIFF
--- a/tests/tpchbench/src/main/scala/aurora4spark/tpch/TPCHBenchmark.scala
+++ b/tests/tpchbench/src/main/scala/aurora4spark/tpch/TPCHBenchmark.scala
@@ -125,7 +125,9 @@ object TPCHBenchmark extends SparkSessionWrapper {
     )
 
     dfMap.foreach {
-      case (key, value) => value.cache().createOrReplaceTempView(key)
+      case (key, value) =>
+        value.createOrReplaceTempView(key)
+        sparkSession.sql("CACHE TABLE " + key)
     }
   }
 


### PR DESCRIPTION
By caching all data early before running the queries, we get more meaningful results.
This is what it looks like with this change on aurora05:

run_cpu.sh
```
Query1 elapsed: 3.102733264 s
Query2 elapsed: 5.819555697 s
Query3 elapsed: 1.812884597 s
Query4 elapsed: 1.55826617 s
Query5 elapsed: 2.767101261 s
Query6 elapsed: 0.857487036 s
Query7 elapsed: 2.899496085 s
Query8 elapsed: 2.425673366 s
Query9 elapsed: 6.802344987 s
Query10 elapsed: 5.306065891 s
Query11 elapsed: 1.644466738 s
Query12 elapsed: 1.822211626 s
Query13 elapsed: 2.532887671 s
Query14 elapsed: 0.931574346 s
Query15 elapsed: 2.299179268 s
Query16 elapsed: 8.515612302 s
Query17 elapsed: 1.42867511 s
Query18 elapsed: 1.917265678 s
Query19 elapsed: 0.835802397 s
Query20 elapsed: 2.089437348 s
Query21 elapsed: 2.454180361 s
Query22 elapsed: 1.771846946 s
```

run_ve.sh
```
Query1 elapsed: 16.044918525 s
Query2 elapsed: 8.04296441 s
Query3 elapsed: 12.780158698 s
Query4 elapsed: 7.720335221 s
Query5 elapsed: 10.529079825 s
Query6 elapsed: 7.268559854 s
Query7 elapsed: 14.573169091 s
Query8 elapsed: 8.278983535 s
Query9 elapsed: 14.780530187 s
Query10 elapsed: 718.484076508 s
Query11 elapsed: 8.489670778 s
Query12 elapsed: 53.299324969 s
Query13 elapsed: 10.194698578 s
Query14 elapsed: 179.551589159 s
Query15 elapsed: 19.105388907 s
Query16 elapsed: 91.900569403 s
Query17 elapsed: 11.920041321 s
Query18 elapsed: 20.509868483 s
Query19 elapsed: 4.424525477 s
Query20 elapsed: 11.879984452 s
Query21 elapsed: 11.684695087 s
Query22 elapsed: 9.227527032 s
```