### PR TITLE
Add utcnanotime() and output with debug messages

### DIFF
--- a/src/main/resources/com/nec/arrow/functions/cpp/transfer-definitions.hpp
+++ b/src/main/resources/com/nec/arrow/functions/cpp/transfer-definitions.hpp
@@ -89,10 +89,18 @@ typedef struct
     int32_t length;
 } non_null_c_bounded_string;
 
-inline void log(std::string msg) {
-    auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+static std::string utcnanotime() {
+    auto now = std::chrono::system_clock::now();
+    auto seconds = std::chrono::system_clock::to_time_t(now);
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count() % 1000000000;
+    char utc[32];
+    strftime(utc, 32, "%FT%T", gmtime(&seconds));
+    snprintf(strchr(utc, 0), 32 - strlen(utc), ".%09ldZ", ns);
+    return utc;
+}
 
-    std::cout << std::ctime(&now) << msg.c_str() << std::endl;
+inline void log(std::string msg) {
+    std::cout << utcnanotime().c_str() << " " << msg.c_str() << std::endl;
 }
 
 inline void set_validity(uint64_t *validityBuffer, int32_t idx, int32_t validity) {

--- a/src/main/scala/com/nec/spark/agile/CExpressionEvaluation.scala
+++ b/src/main/scala/com/nec/spark/agile/CExpressionEvaluation.scala
@@ -157,7 +157,7 @@ object CExpressionEvaluation {
     def debugHere(implicit fullName: sourcecode.FullName, line: sourcecode.Line): CodeLines =
       CodeLines.from(
         "#ifdef DEBUG",
-        s"""std::cout << " $$ " << "${fullName.value} (#${line.value}/#" << __LINE__ << ")" << std::endl << std::flush;""",
+        s"""std::cout << utcnanotime().c_str() << " $$ " << "${fullName.value} (#${line.value}/#" << __LINE__ << ")" << std::endl << std::flush;""",
         "#endif"
       )
 
@@ -166,7 +166,7 @@ object CExpressionEvaluation {
     )(implicit fullName: sourcecode.FullName, line: sourcecode.Line): CodeLines =
       CodeLines.from(
         "#ifdef DEBUG",
-        s"""std::cout << " $$ " << "${fullName.value} (#${line.value})" << """ + what
+        s"""std::cout << utcnanotime().c_str() << " $$ " << "${fullName.value} (#${line.value})" << """ + what
           .map(x => s"""" " << ${x} << " " """)
           .mkString(""" << ";" << """) + """ << std::endl << std::flush;""",
         "#endif"


### PR DESCRIPTION
With this, we get something in the logs to help do a bit of profiling of native code on VE. It produces something like below for query 18. Feel free to adjust the formatting before merging!

```
2021-10-09T00:39:44.520284000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#149)
2021-10-09T00:39:44.636732000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#155)
2021-10-09T00:39:44.651350000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#162)
2021-10-09T00:39:44.669452000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#183)
2021-10-09T00:39:44.762055000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#188)
2021-10-09T00:39:44.762701000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#194)
2021-10-09T00:39:44.764608000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#202)
2021-10-09T00:39:44.765234000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#208)
2021-10-09T00:39:44.765815000Z $ com.nec.spark.agile.StagedGroupBy (#147/#211)
2021-10-09T00:39:44.767717000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#222)
2021-10-09T00:39:44.768342000Z $ com.nec.spark.agile.StagedGroupBy (#92/#227)
2021-10-09T00:39:44.768900000Z $ com.nec.spark.agile.StagedGroupBy (#100/#233)
2021-10-09T00:39:45.120124000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#149)
2021-10-09T00:39:45.233152000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#155)
2021-10-09T00:39:45.247664000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#162)
2021-10-09T00:39:45.266196000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#183)
2021-10-09T00:39:45.358065000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#188)
2021-10-09T00:39:45.358891000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#194)
2021-10-09T00:39:45.360790000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#202)
2021-10-09T00:39:45.361450000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#208)
2021-10-09T00:39:45.362017000Z $ com.nec.spark.agile.StagedGroupBy (#147/#211)
2021-10-09T00:39:45.363864000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#222)
2021-10-09T00:39:45.364459000Z $ com.nec.spark.agile.StagedGroupBy (#92/#227)
2021-10-09T00:39:45.364997000Z $ com.nec.spark.agile.StagedGroupBy (#100/#233)
2021-10-09T00:39:45.667140000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#149)
2021-10-09T00:39:45.778502000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#155)
2021-10-09T00:39:45.792989000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#162)
2021-10-09T00:39:45.811539000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#183)
2021-10-09T00:39:45.903285000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#188)
2021-10-09T00:39:45.904102000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#194)
2021-10-09T00:39:45.905998000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#202)
2021-10-09T00:39:45.906621000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#208)
2021-10-09T00:39:45.907225000Z $ com.nec.spark.agile.StagedGroupBy (#147/#211)
2021-10-09T00:39:45.909089000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#222)
2021-10-09T00:39:45.909705000Z $ com.nec.spark.agile.StagedGroupBy (#92/#227)
2021-10-09T00:39:45.910348000Z $ com.nec.spark.agile.StagedGroupBy (#100/#233)
2021-10-09T00:39:46.154961000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#149)
2021-10-09T00:39:46.267833000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#155)
2021-10-09T00:39:46.282319000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#162)
2021-10-09T00:39:46.300893000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#183)
2021-10-09T00:39:46.392639000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#188)
2021-10-09T00:39:46.393517000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#194)
2021-10-09T00:39:46.395406000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#202)
2021-10-09T00:39:46.396001000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#208)
2021-10-09T00:39:46.396552000Z $ com.nec.spark.agile.StagedGroupBy (#147/#211)
2021-10-09T00:39:46.398394000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#222)
2021-10-09T00:39:46.398977000Z $ com.nec.spark.agile.StagedGroupBy (#92/#227)
2021-10-09T00:39:46.399505000Z $ com.nec.spark.agile.StagedGroupBy (#100/#233)
2021-10-09T00:39:46.621398000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#149)
2021-10-09T00:39:46.733466000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#155)
2021-10-09T00:39:46.747920000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#162)
2021-10-09T00:39:46.766467000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#183)
2021-10-09T00:39:46.858366000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#188)
2021-10-09T00:39:46.859248000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#194)
2021-10-09T00:39:46.861137000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#202)
2021-10-09T00:39:46.861745000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#208)
2021-10-09T00:39:46.862325000Z $ com.nec.spark.agile.StagedGroupBy (#147/#211)
2021-10-09T00:39:46.864169000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#222)
2021-10-09T00:39:46.864927000Z $ com.nec.spark.agile.StagedGroupBy (#92/#227)
2021-10-09T00:39:46.865582000Z $ com.nec.spark.agile.StagedGroupBy (#100/#233)
2021-10-09T00:39:47.028790000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#149)
2021-10-09T00:39:47.103032000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#155)
2021-10-09T00:39:47.112691000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#162)
2021-10-09T00:39:47.125245000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#183)
2021-10-09T00:39:47.184029000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#188)
2021-10-09T00:39:47.184748000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#194)
2021-10-09T00:39:47.186090000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#202)
2021-10-09T00:39:47.186736000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#208)
2021-10-09T00:39:47.187228000Z $ com.nec.spark.agile.StagedGroupBy (#147/#211)
2021-10-09T00:39:47.188517000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#222)
2021-10-09T00:39:47.189165000Z $ com.nec.spark.agile.StagedGroupBy (#92/#227)
2021-10-09T00:39:47.189602000Z $ com.nec.spark.agile.StagedGroupBy (#100/#233)
2021-10-09T00:39:47.263762000Z $ com.nec.spark.agile.StagedGroupBy.performGroupingOnKeys (#223/#267)
2021-10-09T00:39:47.421999000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#272)
2021-10-09T00:39:47.449646000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#279)
2021-10-09T00:39:47.485443000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#300)
2021-10-09T00:39:47.569961000Z $ com.nec.spark.agile.StagedGroupBy.mergeAndProduceAggregatePartialsPerGroup (#247/#305)
2021-10-09T00:39:49.591355000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#149)
2021-10-09T00:39:49.705200000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#155)
2021-10-09T00:39:49.719779000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#162)
2021-10-09T00:39:49.737975000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#183)
2021-10-09T00:39:49.830566000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#188)
2021-10-09T00:39:49.832174000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#194)
2021-10-09T00:39:49.834139000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#202)
2021-10-09T00:39:49.834739000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#208)
2021-10-09T00:39:49.835321000Z $ com.nec.spark.agile.StagedGroupBy (#147/#211)
2021-10-09T00:39:49.837182000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#222)
2021-10-09T00:39:49.837764000Z $ com.nec.spark.agile.StagedGroupBy (#92/#227)
2021-10-09T00:39:49.838318000Z $ com.nec.spark.agile.StagedGroupBy (#100/#233)
2021-10-09T00:39:50.052890000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#149)
2021-10-09T00:39:50.164738000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#155)
2021-10-09T00:39:50.179136000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#162)
2021-10-09T00:39:50.197566000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#183)
2021-10-09T00:39:50.289259000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#188)
2021-10-09T00:39:50.289934000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#194)
2021-10-09T00:39:50.291818000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#202)
2021-10-09T00:39:50.292425000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#208)
2021-10-09T00:39:50.293042000Z $ com.nec.spark.agile.StagedGroupBy (#147/#211)
2021-10-09T00:39:50.294895000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#222)
2021-10-09T00:39:50.295489000Z $ com.nec.spark.agile.StagedGroupBy (#92/#227)
2021-10-09T00:39:50.296012000Z $ com.nec.spark.agile.StagedGroupBy (#100/#233)
2021-10-09T00:39:50.512606000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#149)
2021-10-09T00:39:50.623835000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#155)
2021-10-09T00:39:50.638183000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#162)
2021-10-09T00:39:50.656579000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#183)
2021-10-09T00:39:50.748492000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#188)
2021-10-09T00:39:50.749116000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#194)
2021-10-09T00:39:50.750989000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#202)
2021-10-09T00:39:50.751592000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#208)
2021-10-09T00:39:50.752168000Z $ com.nec.spark.agile.StagedGroupBy (#147/#211)
2021-10-09T00:39:50.754010000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#222)
2021-10-09T00:39:50.754606000Z $ com.nec.spark.agile.StagedGroupBy (#92/#227)
2021-10-09T00:39:50.755156000Z $ com.nec.spark.agile.StagedGroupBy (#100/#233)
2021-10-09T00:39:50.968537000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#149)
2021-10-09T00:39:51.079747000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#155)
2021-10-09T00:39:51.094137000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#162)
2021-10-09T00:39:51.112525000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#183)
2021-10-09T00:39:51.204242000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#188)
2021-10-09T00:39:51.205005000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#194)
2021-10-09T00:39:51.206860000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#202)
2021-10-09T00:39:51.207440000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#208)
2021-10-09T00:39:51.207990000Z $ com.nec.spark.agile.StagedGroupBy (#147/#211)
2021-10-09T00:39:51.209812000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#222)
2021-10-09T00:39:51.210392000Z $ com.nec.spark.agile.StagedGroupBy (#92/#227)
2021-10-09T00:39:51.210913000Z $ com.nec.spark.agile.StagedGroupBy (#100/#233)
2021-10-09T00:39:51.431478000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#149)
2021-10-09T00:39:51.544197000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#155)
2021-10-09T00:39:51.558653000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#162)
2021-10-09T00:39:51.577132000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#183)
2021-10-09T00:39:51.668933000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#188)
2021-10-09T00:39:51.669545000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#194)
2021-10-09T00:39:51.671424000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#202)
2021-10-09T00:39:51.672050000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#208)
2021-10-09T00:39:51.672614000Z $ com.nec.spark.agile.StagedGroupBy (#147/#211)
2021-10-09T00:39:51.674472000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#222)
2021-10-09T00:39:51.675077000Z $ com.nec.spark.agile.StagedGroupBy (#92/#227)
2021-10-09T00:39:51.675616000Z $ com.nec.spark.agile.StagedGroupBy (#100/#233)
2021-10-09T00:39:51.846907000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#149)
2021-10-09T00:39:51.919778000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#155)
2021-10-09T00:39:51.930433000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#162)
2021-10-09T00:39:51.943021000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#183)
2021-10-09T00:39:52.001631000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#188)
2021-10-09T00:39:52.002502000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#194)
2021-10-09T00:39:52.003957000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#202)
2021-10-09T00:39:52.004553000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#208)
2021-10-09T00:39:52.005122000Z $ com.nec.spark.agile.StagedGroupBy (#147/#211)
2021-10-09T00:39:52.006520000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#222)
2021-10-09T00:39:52.007128000Z $ com.nec.spark.agile.StagedGroupBy (#92/#227)
2021-10-09T00:39:52.007667000Z $ com.nec.spark.agile.StagedGroupBy (#100/#233)
2021-10-09T00:39:52.083416000Z $ com.nec.spark.agile.StagedGroupBy.performGroupingOnKeys (#223/#267)
2021-10-09T00:39:52.241833000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#272)
2021-10-09T00:39:52.269460000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#279)
2021-10-09T00:39:52.304180000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#300)
2021-10-09T00:39:52.388749000Z $ com.nec.spark.agile.StagedGroupBy.mergeAndProduceAggregatePartialsPerGroup (#247/#305)
2021-10-09T00:40:56.169685000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#161)
2021-10-09T00:40:56.170285000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#183)
2021-10-09T00:40:56.170825000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#190)
2021-10-09T00:40:56.171370000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#253)
2021-10-09T00:40:56.171906000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#258)
2021-10-09T00:40:56.172423000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.setup (#40/#261)
2021-10-09T00:40:56.172967000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.setup (#40/#274)
2021-10-09T00:40:56.173481000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#284)
2021-10-09T00:40:56.174006000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#289)
2021-10-09T00:40:56.174534000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#312)
2021-10-09T00:40:56.175071000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#328)
2021-10-09T00:40:56.175581000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#59/#333)
2021-10-09T00:40:56.176122000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#68/#344)
2021-10-09T00:40:56.176639000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#59/#360)
2021-10-09T00:40:56.177174000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#68/#371)
2021-10-09T00:40:56.177687000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#382)
2021-10-09T00:40:56.178203000Z $ com.nec.spark.agile.StagedGroupBy (#129/#385)
2021-10-09T00:40:56.178693000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.setup (#40/#388)
2021-10-09T00:40:56.179219000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#397)
2021-10-09T00:40:56.179749000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#59/#408)
2021-10-09T00:40:56.180263000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#68/#419)
2021-10-09T00:40:56.180752000Z $ com.nec.spark.agile.StagedGroupBy (#147/#426)
2021-10-09T00:40:56.181223000Z $ com.nec.spark.agile.StagedGroupBy (#147/#437)
2021-10-09T00:40:56.181693000Z $ com.nec.spark.agile.StagedGroupBy (#129/#448)

...

2021-10-09T00:41:01.926327000Z $ com.nec.spark.agile.StagedGroupBy (#147/#426)
2021-10-09T00:41:01.926707000Z $ com.nec.spark.agile.StagedGroupBy (#147/#437)
2021-10-09T00:41:01.927090000Z $ com.nec.spark.agile.StagedGroupBy (#129/#448)
2021-10-09T00:41:01.927473000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.setup (#40/#451)
2021-10-09T00:41:01.927872000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#460)
2021-10-09T00:41:01.928288000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#59/#471)
2021-10-09T00:41:01.928694000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#68/#482)
2021-10-09T00:41:01.929094000Z $ com.nec.spark.agile.StagedGroupBy (#147/#489)
2021-10-09T00:41:01.929467000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#500)
2021-10-09T00:41:01.929879000Z $ com.nec.spark.agile.StagedGroupBy (#92/#505)
2021-10-09T00:41:01.930256000Z $ com.nec.spark.agile.StagedGroupBy (#100/#511)
2021-10-09T00:41:01.949351000Z $ com.nec.spark.agile.StagedGroupBy.performGrouping (#208/#161)
2021-10-09T00:41:01.949771000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#183)
2021-10-09T00:41:01.950192000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#190)
2021-10-09T00:41:01.950594000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#253)
2021-10-09T00:41:01.951008000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#312/#258)
2021-10-09T00:41:01.951400000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.setup (#40/#261)
2021-10-09T00:41:01.951793000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.setup (#40/#274)
2021-10-09T00:41:01.952187000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#330/#284)
2021-10-09T00:41:01.952578000Z $ com.nec.spark.agile.StagedGroupBy.computeGroupingKeysPerGroup (#344/#328)
2021-10-09T00:41:01.953007000Z $ com.nec.spark.agile.StagedGroupBy.computeProjectionsPerGroup (#122/#382)
2021-10-09T00:41:01.953397000Z $ com.nec.spark.agile.StagedGroupBy (#129/#385)
2021-10-09T00:41:01.953769000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.setup (#40/#388)
2021-10-09T00:41:01.954162000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#59/#408)
2021-10-09T00:41:01.954562000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#68/#419)
2021-10-09T00:41:01.954975000Z $ com.nec.spark.agile.StagedGroupBy (#147/#426)
2021-10-09T00:41:01.955346000Z $ com.nec.spark.agile.StagedGroupBy (#147/#437)
2021-10-09T00:41:01.955719000Z $ com.nec.spark.agile.StagedGroupBy (#129/#448)
2021-10-09T00:41:01.956100000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.setup (#40/#451)
2021-10-09T00:41:01.956488000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#59/#471)
2021-10-09T00:41:01.956891000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#68/#482)
2021-10-09T00:41:01.957288000Z $ com.nec.spark.agile.StagedGroupBy (#147/#489)
2021-10-09T00:41:01.957659000Z $ com.nec.spark.agile.StagedGroupBy.computeAggregatePartialsPerGroup (#85/#500)
2021-10-09T00:41:01.958060000Z $ com.nec.spark.agile.StagedGroupBy (#92/#505)
2021-10-09T00:41:01.958431000Z $ com.nec.spark.agile.StagedGroupBy (#100/#511)
2021-10-09T00:41:01.960294000Z $ com.nec.spark.agile.StagedGroupBy.performGroupingOnKeys (#223/#557)
2021-10-09T00:41:01.960721000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#442/#578)
2021-10-09T00:41:01.961148000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#457/#585)
2021-10-09T00:41:01.961634000Z $ com.nec.spark.agile.StagedGroupBy.GroupingCodeGenerator.identifyGroups (#487/#648)
2021-10-09T00:41:01.962049000Z $ com.nec.spark.agile.StagedGroupBy.mergeAndProduceAggregatePartialsPerGroup (#247/#653)
2021-10-09T00:41:01.962481000Z $ com.nec.spark.agile.StagedGroupBy (#280/#685)
2021-10-09T00:41:01.962847000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.setup (#40/#688)
2021-10-09T00:41:01.963232000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.963655000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.964062000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.964461000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.964868000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.965281000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.965681000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.966112000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.966511000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.966917000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.967326000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.967724000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.968121000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.968521000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.968933000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.969327000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.969724000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.970144000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.970545000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.970961000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.971363000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.971756000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.972169000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.972564000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.972965000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.973359000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.973756000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.974151000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.974544000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.974953000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.975346000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.975735000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.976151000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.976540000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.976937000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.977331000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.977722000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.978111000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.978507000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.978906000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.979296000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.979684000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.980091000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.980484000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.980883000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.981283000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.981665000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.982056000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.982481000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.982854000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.983268000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.983675000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.984058000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.984468000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.984880000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.985262000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.985676000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#697)
2021-10-09T00:41:01.986065000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#59/#708)
2021-10-09T00:41:01.986449000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#68/#719)
2021-10-09T00:41:01.986848000Z $ com.nec.spark.agile.StagedGroupBy (#280/#750)
2021-10-09T00:41:01.987206000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.setup (#40/#753)
2021-10-09T00:41:01.987587000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.987983000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.988374000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.988764000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.989152000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.989567000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.989958000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.990347000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.990746000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.991158000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.991551000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.991953000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.992350000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.992749000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.993146000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.993547000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.993949000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.994338000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.994733000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.995115000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.995496000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.995909000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.996304000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.996694000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.997095000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.997501000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.997900000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.998293000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.998694000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.999089000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.999492000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:01.999899000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.000288000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.000692000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.001085000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.001476000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.001868000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.002258000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.002651000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.003046000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.003430000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.003826000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.004214000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.004604000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.005074000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.005475000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.005861000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.006257000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.006646000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.007042000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.007442000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.007830000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.008219000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.008614000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.009007000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.009391000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.009782000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.forEach (#50/#762)
2021-10-09T00:41:02.010165000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#59/#773)
2021-10-09T00:41:02.010559000Z $ com.nec.spark.agile.StringProducer.FilteringProducer.complete (#68/#784)
```