### PR TITLE
Rename varchar size to dataSize.

### DIFF
--- a/src/main/java/com/nec/arrow/ArrowTransferStructures.java
+++ b/src/main/java/com/nec/arrow/ArrowTransferStructures.java
@@ -174,12 +174,12 @@ public interface ArrowTransferStructures extends Library {
         }
     }
 
-    @Structure.FieldOrder({"data", "offsets", "validityBuffer", "size", "count"})
+    @Structure.FieldOrder({"data", "offsets", "validityBuffer", "dataSize", "count"})
     class nullable_varchar_vector extends Structure {
         public long data;
         public long offsets;
         public long validityBuffer;
-        public Integer size;
+        public Integer dataSize;
         public Integer count;
         /* 24 + 8 = 32 bytes in size */
 

--- a/src/main/resources/com/nec/arrow/functions/cpp/transfer-definitions.hpp
+++ b/src/main/resources/com/nec/arrow/functions/cpp/transfer-definitions.hpp
@@ -74,7 +74,7 @@ typedef struct
 {
     char *data;
     int32_t *offsets;
-    int32_t size;
+    int32_t dataSize;
     int32_t count;
 } non_null_varchar_vector;
 
@@ -83,7 +83,7 @@ typedef struct
     char *data;
     int32_t *offsets;
     uint64_t *validityBuffer;
-    int32_t size;
+    int32_t dataSize;
     int32_t count;
 } nullable_varchar_vector;
 
@@ -167,11 +167,11 @@ frovedis::words data_offsets_to_words(const char *data, const int32_t *offsets, 
 }
 
 frovedis::words varchar_vector_to_words(const non_null_varchar_vector *v) {
-    return data_offsets_to_words(v->data, v->offsets, v->size, v->count);
+    return data_offsets_to_words(v->data, v->offsets, v->dataSize, v->count);
 }
 
 frovedis::words varchar_vector_to_words(const nullable_varchar_vector *v) {
-    return data_offsets_to_words(v->data, v->offsets, v->size, v->count);
+    return data_offsets_to_words(v->data, v->offsets, v->dataSize, v->count);
 }
 
 void words_to_varchar_vector(frovedis::words& in, nullable_varchar_vector *out) {
@@ -183,9 +183,9 @@ void words_to_varchar_vector(frovedis::words& in, nullable_varchar_vector *out) 
     #ifdef DEBUG
         std::cout << utcnanotime().c_str() << " $$ " << "words_to_varchar_vector out->count " << out->count << std::endl << std::flush;
     #endif
-    out->size = in.chars.size();
+    out->dataSize = in.chars.size();
     #ifdef DEBUG
-        std::cout << utcnanotime().c_str() << " $$ " << "words_to_varchar_vector out->size " << out->size << std::endl << std::flush;
+        std::cout << utcnanotime().c_str() << " $$ " << "words_to_varchar_vector out->dataSize " << out->dataSize << std::endl << std::flush;
     #endif
 
     out->offsets = (int32_t *)malloc((in.starts.size() + 1) * sizeof(int32_t));
@@ -198,7 +198,7 @@ void words_to_varchar_vector(frovedis::words& in, nullable_varchar_vector *out) 
         std::cout << utcnanotime().c_str() << " $$ " << "words_to_varchar_vector out->offsets[0] " << out->offsets[0] << std::endl << std::flush;
     #endif
 
-    out->data = (char *)malloc(out->size * sizeof(char));
+    out->data = (char *)malloc(out->dataSize * sizeof(char));
     frovedis::int_to_char(in.chars.data(), in.chars.size(), out->data);
     #ifdef DEBUG
         std::cout << utcnanotime().c_str() << " $$ " << "words_to_varchar_vector out->data[0] " << out->data[0] << std::endl << std::flush;

--- a/src/main/scala/com/nec/arrow/ArrowInterfaces.scala
+++ b/src/main/scala/com/nec/arrow/ArrowInterfaces.scala
@@ -44,7 +44,7 @@ object ArrowInterfaces {
     vc.validityBuffer =
       varCharVector.getValidityBuffer.nioBuffer().asInstanceOf[DirectBuffer].address()
     vc.count = varCharVector.getValueCount
-    vc.size = varCharVector.sizeOfValueBuffer()
+    vc.dataSize = varCharVector.sizeOfValueBuffer()
     vc
   }
 
@@ -261,14 +261,14 @@ object ArrowInterfaces {
     if ( input.count < 1 ) {
       return
     }
-    varCharVector.allocateNew(input.size.toLong, input.count)
+    varCharVector.allocateNew(input.dataSize.toLong, input.count)
     varCharVector.setValueCount(input.count)
     getUnsafe.copyMemory(
       input.validityBuffer,
       varCharVector.getValidityBufferAddress,
       Math.ceil(input.count / 64.0).toInt * 8
     )
-    getUnsafe.copyMemory(input.data, varCharVector.getDataBufferAddress, input.size.toLong)
+    getUnsafe.copyMemory(input.data, varCharVector.getDataBufferAddress, input.dataSize.toLong)
     getUnsafe.copyMemory(input.offsets, varCharVector.getOffsetBufferAddress, 4 * (input.count + 1))
   }
 

--- a/src/main/scala/com/nec/arrow/VeArrowTransfers.scala
+++ b/src/main/scala/com/nec/arrow/VeArrowTransfers.scala
@@ -312,7 +312,7 @@ object VeArrowTransfers extends LazyLogging {
 
     val vcvr = new nullable_varchar_vector()
     vcvr.count = varcharVector.getValueCount
-    vcvr.size = varcharVector.getOffsetBuffer.getInt(4 * vcvr.count)
+    vcvr.dataSize = varcharVector.getOffsetBuffer.getInt(4 * vcvr.count)
     vcvr.data = copyBufferToVe(proc, varcharVector.getDataBuffer.nioBuffer())(cleanup)
     vcvr.offsets = copyBufferToVe(proc, varcharVector.getOffsetBuffer.nioBuffer())(cleanup)
     vcvr
@@ -489,7 +489,7 @@ object VeArrowTransfers extends LazyLogging {
 
     /** Get data size */
     val dataSize = byteBuffer.getInt(24)
-    vec.size = dataSize
+    vec.dataSize = dataSize
 
     /** Get data count */
     val dataCount = byteBuffer.getInt(28)
@@ -594,7 +594,7 @@ object VeArrowTransfers extends LazyLogging {
     v_bb.putLong(8, varchar_vector.offsets)
     v_bb.putLong(16, varchar_vector.validityBuffer)
     v_bb.order(ByteOrder.LITTLE_ENDIAN)
-    v_bb.putInt(24, varchar_vector.size)
+    v_bb.putInt(24, varchar_vector.dataSize)
     v_bb.putInt(28, varchar_vector.count)
     v_bb
   }


### PR DESCRIPTION
Prevents JNA from thinking we want to map the JNA struct size.