### PR TITLE
Fix String production bug

### DIFF
--- a/src/main/resources/com/nec/arrow/functions/cpp/transfer-definitions.hpp
+++ b/src/main/resources/com/nec/arrow/functions/cpp/transfer-definitions.hpp
@@ -197,9 +197,17 @@ void words_to_varchar_vector(frovedis::words& in, nullable_varchar_vector *out) 
 
     #ifdef DEBUG
         std::cout << utcnanotime().c_str() << " $$ " << "here  " << out->dataSize << std::endl << std::flush;
+        std::cout << utcnanotime().c_str() << " $$ " << "sze1  " << in.starts.size() << std::endl << std::flush;
+        std::cout << utcnanotime().c_str() << " $$ " << "sze2  " << in.lens.size() << std::endl << std::flush;
     #endif
 
-    int lastOffset = in.starts.size() ? (in.starts[in.starts.size() - 1] + in.lens[in.starts.size() - 1]) : 0;
+    int lastOffset;
+    if (in.starts.size() == 0) {
+        lastOffset = 0;
+    } else {
+        int lastEl = in.starts.size() - 1;
+        lastOffset = in.starts[lastEl] + in.lens[lastEl];
+    }
 
     #ifdef DEBUG
         std::cout << utcnanotime().c_str() << " $$ " << "here 2 " << out->dataSize << std::endl << std::flush;

--- a/src/main/scala/com/nec/spark/agile/CExpressionEvaluation.scala
+++ b/src/main/scala/com/nec/spark/agile/CExpressionEvaluation.scala
@@ -173,6 +173,10 @@ object CExpressionEvaluation {
 
   object CodeLines {
 
+    def debugValue(names: String*): CodeLines = {
+      CodeLines.from(s"std::cout << ${names.mkString(" << \" \" << ")} << std::endl << std::flush;")
+    }
+
     def debugHere(implicit fullName: sourcecode.FullName, line: sourcecode.Line): CodeLines = {
       val startdebug: List[String] = List("utcnanotime().c_str()", """" $ """")
       val enddebug: List[String] =

--- a/src/main/scala/com/nec/spark/agile/StringProducer.scala
+++ b/src/main/scala/com/nec/spark/agile/StringProducer.scala
@@ -38,14 +38,15 @@ object StringProducer {
     def inputName: String
   }
 
-  private final case class FrovedisCopyStringProducer(inputName: String)
+  final case class FrovedisCopyStringProducer(inputName: String)
     extends FrovedisStringProducer
     with CopyStringProducer {
+
     def frovedisStarts(outputName: String) = s"${outputName}_starts"
 
     def frovedisLens(outputName: String) = s"${outputName}_lens"
 
-    def wordName(outputName: String) = s"${outputName}_words"
+    def wordName(outputName: String) = s"${outputName}_input_words"
     def newChars(outputName: String) = s"${outputName}_new_chars"
     def newStarts(outputName: String) = s"${outputName}_new_starts"
 
@@ -64,14 +65,21 @@ object StringProducer {
 
     override def complete(outputName: String): CodeLines = CodeLines.from(
       s"""std::vector<size_t> ${newStarts(outputName)};""",
+      CodeLines.debugHere,
       s"""std::vector<int> ${newChars(outputName)} = concat_words(${wordName(
         outputName
       )}, "", ${newStarts(outputName)});""",
+      CodeLines.debugHere,
       s"""${wordName(outputName)}.chars = ${newChars(outputName)};""",
+      CodeLines.debugHere,
       s"""${wordName(outputName)}.starts = ${newStarts(outputName)};""",
+      CodeLines.debugHere,
       s"""${wordName(outputName)}.lens = ${frovedisLens(outputName)};""",
-      s"words_to_varchar_vector(${wordName(outputName)}, ${outputName});"
+      CodeLines.debugHere,
+      s"words_to_varchar_vector(${wordName(outputName)}, ${outputName});",
+      CodeLines.debugHere
     )
+
   }
 
   final case class StringChooser(condition: CExpression, ifTrue: String, otherwise: String)

--- a/src/main/scala/com/nec/spark/agile/StringProducer.scala
+++ b/src/main/scala/com/nec/spark/agile/StringProducer.scala
@@ -65,7 +65,6 @@ object StringProducer {
 
     override def complete(outputName: String): CodeLines = CodeLines.from(
       s"""std::vector<size_t> ${newStarts(outputName)};""",
-      CodeLines.debugHere,
       s"""std::vector<int> ${newChars(outputName)} = frovedis::concat_words(
         ${wordName(outputName)}.chars,
         (const vector<size_t>&)(${frovedisStarts(outputName)}),
@@ -73,15 +72,10 @@ object StringProducer {
         "",
         (vector<size_t>&)(${newStarts(outputName)})
       );""",
-      CodeLines.debugHere,
       s"""${wordName(outputName)}.chars = ${newChars(outputName)};""",
-      CodeLines.debugHere,
       s"""${wordName(outputName)}.starts = ${newStarts(outputName)};""",
-      CodeLines.debugHere,
       s"""${wordName(outputName)}.lens = ${frovedisLens(outputName)};""",
-      CodeLines.debugHere,
-      s"words_to_varchar_vector(${wordName(outputName)}, ${outputName});",
-      CodeLines.debugHere
+      s"words_to_varchar_vector(${wordName(outputName)}, ${outputName});"
     )
 
   }
@@ -130,8 +124,7 @@ object StringProducer {
               s"${tmpCount}++;"
             )
         case frovedisStringProducer: FrovedisStringProducer =>
-          CodeLines
-            .from(CodeLines.debugHere, frovedisStringProducer.produce(outputName))
+          CodeLines.from(frovedisStringProducer.produce(outputName))
       }
     }
 

--- a/src/main/scala/com/nec/spark/agile/StringProducer.scala
+++ b/src/main/scala/com/nec/spark/agile/StringProducer.scala
@@ -66,9 +66,13 @@ object StringProducer {
     override def complete(outputName: String): CodeLines = CodeLines.from(
       s"""std::vector<size_t> ${newStarts(outputName)};""",
       CodeLines.debugHere,
-      s"""std::vector<int> ${newChars(outputName)} = concat_words(${wordName(
-        outputName
-      )}, "", ${newStarts(outputName)});""",
+      s"""std::vector<int> ${newChars(outputName)} = frovedis::concat_words(
+        &${wordName(outputName)}.chars,
+        &(const vector<size_t>)${frovedisStarts(outputName)},
+        &(const vector<size_t>)${frovedisLens(outputName)},
+        "",
+        &${newStarts(outputName)}
+      );""",
       CodeLines.debugHere,
       s"""${wordName(outputName)}.chars = ${newChars(outputName)};""",
       CodeLines.debugHere,

--- a/src/main/scala/com/nec/spark/agile/StringProducer.scala
+++ b/src/main/scala/com/nec/spark/agile/StringProducer.scala
@@ -67,11 +67,11 @@ object StringProducer {
       s"""std::vector<size_t> ${newStarts(outputName)};""",
       CodeLines.debugHere,
       s"""std::vector<int> ${newChars(outputName)} = frovedis::concat_words(
-        &${wordName(outputName)}.chars,
-        &(const vector<size_t>)${frovedisStarts(outputName)},
-        &(const vector<size_t>)${frovedisLens(outputName)},
+        ${wordName(outputName)}.chars,
+        (const vector<size_t>&)(${frovedisStarts(outputName)}),
+        (const vector<size_t>&)(${frovedisLens(outputName)}),
         "",
-        &${newStarts(outputName)}
+        (vector<size_t>&)(${newStarts(outputName)})
       );""",
       CodeLines.debugHere,
       s"""${wordName(outputName)}.chars = ${newChars(outputName)};""",

--- a/src/main/scala/com/nec/spark/agile/StringProducer.scala
+++ b/src/main/scala/com/nec/spark/agile/StringProducer.scala
@@ -21,7 +21,7 @@ object StringProducer {
 
 //  def copyString(inputName: String): StringProducer = ImpCopyStringProducer(inputName)
 
-  private final case class ImpCopyStringProducer(inputName: String)
+  final case class ImpCopyStringProducer(inputName: String)
     extends ImperativeStringProducer
     with CopyStringProducer {
 

--- a/src/test/scala/com/nec/cmake/eval/RealExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/RealExpressionEvaluationSpec.scala
@@ -223,8 +223,8 @@ final class RealExpressionEvaluationSpec extends AnyFreeSpec {
         )
       )
 
-    val expected = List[(String, Double)](("x", 0), ("ax", 3.0), ("yy", 2.0)).sorted
-    assert(result.asInstanceOf[List[(String, Double)]].sorted == expected)
+    val expected = List[(String, Double)](("x", 0), ("ax", 3.0), ("yy", 2.0))
+    assert(result.asInstanceOf[List[(String, Double)]] == expected)
   }
 
   "We can aggregate / group by with NULL input check values" in {

--- a/src/test/scala/com/nec/cmake/functions/WordsCheckSpec.scala
+++ b/src/test/scala/com/nec/cmake/functions/WordsCheckSpec.scala
@@ -7,6 +7,7 @@ import com.nec.cmake.CMakeBuilder
 import com.nec.cmake.functions.ParseCSVSpec.RichVarCharVector
 import com.nec.spark.agile.CExpressionEvaluation.CodeLines
 import com.nec.spark.agile.CFunctionGeneration.{CFunction, CVector}
+import com.nec.spark.agile.StringProducer.FrovedisCopyStringProducer
 import org.scalacheck.{Gen, Prop}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatestplus.scalacheck.Checkers
@@ -45,6 +46,85 @@ final class WordsCheckSpec extends AnyFreeSpec with Checkers {
             outVec.toList == list
           }
         }
+      })
+      check(p)
+    }
+  }
+
+  "we can produce a subset of strings" in {
+    val someString: Gen[String] = Gen.asciiStr
+    val listOfStr = Gen.listOf(someString)
+
+    val prod = FrovedisCopyStringProducer("input_0")
+    val cLib = CMakeBuilder.buildCLogging(
+      cSource = List(
+        TransferDefinitionsSourceCode,
+        "\n\n",
+        CFunction(
+          inputs = List(CVector.varChar("input_0")),
+          outputs = List(CVector.varChar("output_0")),
+          body = CodeLines.from(
+            CodeLines.debugHere,
+            s"int size = input_0->count % 2 == 0 ? (input_0->count) / 2 : ((1 + input_0->count) / 2);",
+            CodeLines.debugValue(""""input_0->count"""", "input_0->count"),
+            CodeLines.debugValue(""""size"""", "size"),
+            prod.init("output_0", "size"),
+            CodeLines.debugHere,
+            "int g = 0;",
+            "for(int i = 0; i < input_0->count; i++) {",
+            CodeLines
+              .from(
+                CodeLines.debugValue(""""i"""", "i"),
+                CodeLines.debugHere,
+                s"if ( g < size && i < input_0->count ) {",
+                CodeLines.debugValue(""""sz"""", "output_0_input_words.starts.size()"),
+                CodeLines.debugValue(""""lsz"""", "output_0_input_words.lens.size()"),
+                CodeLines
+                  .from(CodeLines.debugValue("g"), CodeLines.debugHere, prod.produce("output_0"))
+                  .indented,
+                "}",
+                CodeLines.debugHere,
+                "i++;",
+                "g++;",
+                CodeLines.debugHere
+              )
+              .indented,
+            "}",
+            CodeLines.debugHere,
+            prod.complete("output_0"),
+            CodeLines.debugHere,
+            "return 0;"
+          )
+        ).toCodeLines("test").cCode
+      )
+        .mkString("\n\n"),
+      debug = true
+    )
+
+    val nativeInterface = new CArrowNativeInterface(cLib.toString)
+    WithTestAllocator { implicit allocator =>
+      val p: Prop = Prop.forAll(listOfStr)(list => {
+        val expected = list.zipWithIndex.collect { case (s, idx) if idx % 2 == 0 => s }.toList
+        val r = ArrowVectorBuilders.withArrowStringVector(list) { inVec =>
+          ArrowVectorBuilders.withArrowStringVector(Seq.empty) { outVec =>
+            println(inVec.toList)
+            println(inVec.toList.size)
+            println(inVec)
+            nativeInterface.callFunction(
+              name = "test",
+              inputArguments = List(Some(SupportedVectorWrapper.wrapInput(inVec)), None),
+              outputArguments = List(None, Some(SupportedVectorWrapper.wrapOutput(outVec)))
+            )
+            outVec.toList
+          }
+        }
+
+        if (r != expected)
+          info(
+            s"result => ${r}; expected ${expected} (${r.map(_.length)}; ${expected.map(_.length)})"
+          )
+
+        r == expected
       })
       check(p)
     }

--- a/src/test/scala/com/nec/cmake/functions/WordsCheckSpec.scala
+++ b/src/test/scala/com/nec/cmake/functions/WordsCheckSpec.scala
@@ -1,0 +1,52 @@
+package com.nec.cmake.functions
+
+import com.nec.arrow.ArrowNativeInterface.SupportedVectorWrapper
+import com.nec.arrow.TransferDefinitions.TransferDefinitionsSourceCode
+import com.nec.arrow.{ArrowVectorBuilders, CArrowNativeInterface, WithTestAllocator}
+import com.nec.cmake.CMakeBuilder
+import com.nec.cmake.functions.ParseCSVSpec.RichVarCharVector
+import com.nec.spark.agile.CExpressionEvaluation.CodeLines
+import com.nec.spark.agile.CFunctionGeneration.{CFunction, CVector}
+import org.scalacheck.{Gen, Prop}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatestplus.scalacheck.Checkers
+
+final class WordsCheckSpec extends AnyFreeSpec with Checkers {
+  "it works" in {
+    val someString: Gen[String] = Gen.asciiStr
+    val listOfStr = Gen.listOf(someString)
+
+    val cLib = CMakeBuilder.buildCLogging(
+      List(
+        TransferDefinitionsSourceCode,
+        "\n\n",
+        CFunction(
+          inputs = List(CVector.varChar("input_0")),
+          outputs = List(CVector.varChar("output_0")),
+          body = CodeLines.from(
+            "words_to_varchar_vector(varchar_vector_to_words(input_0), output_0);",
+            "return 0;"
+          )
+        ).toCodeLines("test").cCode
+      )
+        .mkString("\n\n")
+    )
+
+    val nativeInterface = new CArrowNativeInterface(cLib.toString)
+    WithTestAllocator { implicit allocator =>
+      val p: Prop = Prop.forAll(listOfStr)(list => {
+        ArrowVectorBuilders.withArrowStringVector(list) { inVec =>
+          ArrowVectorBuilders.withArrowStringVector(Seq.empty) { outVec =>
+            nativeInterface.callFunction(
+              name = "test",
+              inputArguments = List(Some(SupportedVectorWrapper.wrapInput(inVec)), None),
+              outputArguments = List(None, Some(SupportedVectorWrapper.wrapOutput(outVec)))
+            )
+            outVec.toList == list
+          }
+        }
+      })
+      check(p)
+    }
+  }
+}


### PR DESCRIPTION
Results were being mixed up due to subtle bugs in String production.

The fix was to:
- Create some base checks with ScalaCheck for identity copy
- Create some base checks with ScalaCheck for filtered copy
- Then iterate until these tests pass.