### PR TITLE
String holes for handling string operations in a vector form

### DIFF
--- a/src/main/scala/com/nec/spark/agile/SparkExpressionToCExpression.scala
+++ b/src/main/scala/com/nec/spark/agile/SparkExpressionToCExpression.scala
@@ -258,6 +258,8 @@ object SparkExpressionToCExpression {
             isNotNullCode = None
           )
         }
+      case StringHole(_, evl) =>
+        Right(evl.fetchResult)
       case StartsWith(left: AttributeReference, right: Literal)
           if left.dataType == StringType && right.dataType == StringType =>
         Right {

--- a/src/main/scala/com/nec/spark/agile/SparkExpressionToCExpression.scala
+++ b/src/main/scala/com/nec/spark/agile/SparkExpressionToCExpression.scala
@@ -218,64 +218,8 @@ object SparkExpressionToCExpression {
 
   def eval(expression: Expression)(implicit fallback: EvalFallback): EvaluationAttempt = {
     expression match {
-      case EqualTo(left: AttributeReference, right: Literal)
-          if left.dataType == StringType && right.dataType == StringType =>
-        Right {
-          CExpression(
-            cCode = List(
-              s"std::string(${left.name}->data, ${left.name}->offsets[i], ${left.name}->offsets[i+1]-${left.name}->offsets[i])",
-              s"""std::string("${right.toString()}")"""
-            ).mkString(" == "),
-            isNotNullCode = None
-          )
-        }
-      case Contains(left: AttributeReference, right: Literal)
-          if left.dataType == StringType && right.dataType == StringType =>
-        Right {
-          CExpression(
-            cCode = {
-              val mainString =
-                s"std::string(${left.name}->data, ${left.name}->offsets[i], ${left.name}->offsets[i+1]-${left.name}->offsets[i])"
-              val rightString = s"""std::string("${right.toString()}")"""
-              s"${mainString}.find(${rightString}) != std::string::npos"
-            },
-            isNotNullCode = None
-          )
-        }
-      case EndsWith(left: AttributeReference, right: Literal)
-          if left.dataType == StringType && right.dataType == StringType =>
-        Right {
-          CExpression(
-            cCode = {
-              val leftStringLength =
-                s"(${left.name}->offsets[i+1] - ${left.name}->offsets[i])"
-              val expectedLength = right.toString().length
-              val leftStringSubstring =
-                s"""std::string(${left.name}->data, ${left.name}->offsets[i+1]-${expectedLength}, ${expectedLength})"""
-              val rightString = s"""std::string("${right.toString()}")"""
-              s"${leftStringLength} >= ${expectedLength} && ${leftStringSubstring} == ${rightString}"
-            },
-            isNotNullCode = None
-          )
-        }
       case StringHole(_, evl) =>
         Right(evl.fetchResult)
-      case StartsWith(left: AttributeReference, right: Literal)
-          if left.dataType == StringType && right.dataType == StringType =>
-        Right {
-          CExpression(
-            cCode = {
-              val leftStringLength =
-                s"(${left.name}->offsets[i+1] - ${left.name}->offsets[i])"
-              val expectedLength = right.toString().length
-              val leftStringSubstring =
-                s"""std::string(${left.name}->data, ${left.name}->offsets[i], ${expectedLength})"""
-              val rightString = s"""std::string("${right.toString()}")"""
-              s"${leftStringLength} >= ${expectedLength} && ${leftStringSubstring} == ${rightString}"
-            },
-            isNotNullCode = None
-          )
-        }
       case b @ Divide(_, _, false) =>
         for {
           leftEx <- eval(b.left)

--- a/src/main/scala/com/nec/spark/agile/StringHole.scala
+++ b/src/main/scala/com/nec/spark/agile/StringHole.scala
@@ -61,8 +61,25 @@ object StringHole {
   object StringHoleEvaluation {
 
     /** Vectorized evaluation */
-    final case class FastStartsWithEvaluation(theString: String) extends StringHoleEvaluation {
-      override def computeVector: CodeLines = ???
+    final case class FastStartsWithEvaluation(refName: String, theString: String) extends StringHoleEvaluation {
+      val myId = s"slowStringEvaluation_${Math.abs(hashCode())}"
+      val myIdWords = s"slowStringEvaluation_words_${Math.abs(hashCode())}"
+      override def computeVector: CodeLines =
+        CodeLines.from(
+          CodeLines.debugHere,
+          s"std::vector<int> $myId($refName->count);",
+          s"frovedis::words $myIdWords = varchar_vector_to_words($refName;",
+          s"std::vector<size_t> matching_ids = frovedis::like($refNameconst std::vector<int>& chars,
+            const std::vector<size_t>& starts,
+          const std::vector<size_t>& lens,
+          const std::string& to_search,
+          int wild_card = '%', int escape = '\\');"
+          s"for ( int i = 0; i < $refName->count; i++) { ",
+          CodeLines
+            .from(s"$myId[i] = ${slowEvaluator.evaluate(refName).cCode};")
+            .indented,
+          "}"
+        )
 
       override def deallocData: CodeLines = ???
 

--- a/src/main/scala/com/nec/spark/agile/StringHole.scala
+++ b/src/main/scala/com/nec/spark/agile/StringHole.scala
@@ -22,15 +22,19 @@ package com.nec.spark.agile
 import com.nec.spark.agile.CExpressionEvaluation.CodeLines
 import com.nec.spark.agile.CFunctionGeneration.CExpression
 import com.nec.spark.agile.StringHole.StringHoleEvaluation
-import com.nec.spark.agile.StringHole.StringHoleEvaluation.HoleStartsWith
+import com.nec.spark.agile.StringHole.StringHoleEvaluation.{SlowEvaluation, SlowEvaluator}
 import org.apache.spark.sql.catalyst.expressions.{
-  CaseWhen,
+  AttributeReference,
+  Contains,
+  EndsWith,
+  EqualTo,
   Expression,
   LeafExpression,
+  Literal,
   StartsWith,
   Unevaluable
 }
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.{DataType, StringType}
 
 /**
  * An expression which takes a String and processes it as a vector
@@ -47,18 +51,51 @@ object StringHole {
 
   sealed trait StringHoleEvaluation {
     def computeVector: CodeLines
+
     def deallocData: CodeLines
+
     def fetchResult: CExpression
   }
 
   object StringHoleEvaluation {
-    final case class HoleStartsWith() extends StringHoleEvaluation {
-      override def computeVector: CodeLines = CodeLines.empty
+    sealed trait SlowEvaluator {
+      def evaluate(refName: String): CExpression
+    }
+
+    object SlowEvaluator {
+      final case class StartsWithEvaluator(theString: String) extends SlowEvaluator {
+        override def evaluate(refName: String): CExpression = {
+
+          val leftStringLength =
+            s"(${refName}->offsets[i+1] - ${refName}->offsets[i])"
+          val expectedLength = theString.length
+          val leftStringSubstring =
+            s"""std::string(${refName}->data, ${refName}->offsets[i], ${expectedLength})"""
+          val rightString = s"""std::string("${theString}")"""
+          val bool =
+            s"${leftStringLength} >= ${expectedLength} && ${leftStringSubstring} == ${rightString}"
+          CExpression(bool, None)
+        }
+      }
+    }
+
+    final case class SlowEvaluation(refName: String, slowEvaluator: SlowEvaluator)
+      extends StringHoleEvaluation {
+      override def computeVector: CodeLines =
+        CodeLines.from(
+          s"std::vector<int> startsWith_${refName}(${refName}->count);",
+          s"for ( int i = 0; i < ${refName}->count; i++) { ",
+          CodeLines
+            .from(s"startsWith_${refName}[i] = ${slowEvaluator.evaluate(refName).cCode};")
+            .indented,
+          "}"
+        )
+
       override def deallocData: CodeLines = CodeLines.empty
-      override def fetchResult: CExpression = CExpression(s"abcd", None)
+
+      override def fetchResult: CExpression = CExpression(s"startsWith_${refName}[i]", None)
     }
   }
-
   def process(orig: Expression): Option[StringHoleTransformation] = Option {
     StringHoleTransformation(
       exprWithHoles = orig.transform {
@@ -73,7 +110,8 @@ object StringHole {
   }.filter(_.exprWithHoles != orig)
 
   def processSubExpression: PartialFunction[Expression, StringHoleEvaluation] = {
-    case e @ StartsWith(l, r) => HoleStartsWith()
+    case StartsWith(left: AttributeReference, Literal(v, StringType)) =>
+      SlowEvaluation(left.name, SlowEvaluator.StartsWithEvaluator(v.toString))
   }
 
   def transform: PartialFunction[Expression, Expression] = Function
@@ -87,5 +125,74 @@ object StringHole {
     def stringParts: List[StringHoleEvaluation] = holes.values.toList
 
     def newExpression: Expression = exprWithHoles
+  }
+
+  def equalTo(leftRef: String, rightStr: String): CExpression = {
+    CExpression(
+      cCode = List(
+        s"std::string(${leftRef}->data, ${leftRef}->offsets[i], ${leftRef}->offsets[i+1]-${leftRef}->offsets[i])",
+        s"""std::string("${rightStr}")"""
+      ).mkString(" == "),
+      isNotNullCode = None
+    )
+
+  }
+
+  def simpleStringExpressionMatcher(expression: Expression): Option[CExpression] =
+    PartialFunction.condOpt(expression) {
+      case EqualTo(left: AttributeReference, right: Literal)
+          if left.dataType == StringType && right.dataType == StringType =>
+        equalTo(left.name, right.toString())
+      case Contains(left: AttributeReference, right: Literal)
+          if left.dataType == StringType && right.dataType == StringType =>
+        containsExp(left.name, right.toString())
+      case EndsWith(left: AttributeReference, right: Literal)
+          if left.dataType == StringType && right.dataType == StringType =>
+        endsWithExp(left.name, right.toString())
+      case StartsWith(left: AttributeReference, right: Literal)
+          if left.dataType == StringType && right.dataType == StringType =>
+        startsWithExp(left.name, right.toString())
+    }
+
+  private def startsWithExp(leftRef: String, right: String) = {
+    CExpression(
+      cCode = {
+        val leftStringLength =
+          s"(${leftRef}->offsets[i+1] - ${leftRef}->offsets[i])"
+        val expectedLength = right.length
+        val leftStringSubstring =
+          s"""std::string(${leftRef}->data, ${leftRef}->offsets[i], ${expectedLength})"""
+        val rightString = s"""std::string("${right}")"""
+        s"${leftStringLength} >= ${expectedLength} && ${leftStringSubstring} == ${rightString}"
+      },
+      isNotNullCode = None
+    )
+  }
+
+  private def endsWithExp(leftRef: String, right: String) = {
+    CExpression(
+      cCode = {
+        val leftStringLength =
+          s"(${leftRef}->offsets[i+1] - ${leftRef}->offsets[i])"
+        val expectedLength = right.length
+        val leftStringSubstring =
+          s"""std::string(${leftRef}->data, ${leftRef}->offsets[i+1]-${expectedLength}, ${expectedLength})"""
+        val rightString = s"""std::string("${right}")"""
+        s"${leftStringLength} >= ${expectedLength} && ${leftStringSubstring} == ${rightString}"
+      },
+      isNotNullCode = None
+    )
+  }
+
+  private def containsExp(leftRef: String, right: String) = {
+    CExpression(
+      cCode = {
+        val mainString =
+          s"std::string(${leftRef}->data, ${leftRef}->offsets[i], ${leftRef}->offsets[i+1]-${leftRef}->offsets[i])"
+        val rightString = s"""std::string("${right}")"""
+        s"${mainString}.find(${rightString}) != std::string::npos"
+      },
+      isNotNullCode = None
+    )
   }
 }

--- a/src/main/scala/com/nec/spark/agile/StringHole.scala
+++ b/src/main/scala/com/nec/spark/agile/StringHole.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021 Xpress AI.
+ *
+ * This file is part of Spark Cyclone.
+ * See https://github.com/XpressAI/SparkCyclone for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.nec.spark.agile
+
+import com.nec.spark.agile.CExpressionEvaluation.CodeLines
+import com.nec.spark.agile.CFunctionGeneration.CExpression
+import com.nec.spark.agile.StringHole.StringHoleEvaluation
+import com.nec.spark.agile.StringHole.StringHoleEvaluation.HoleStartsWith
+import org.apache.spark.sql.catalyst.expressions.{
+  CaseWhen,
+  Expression,
+  LeafExpression,
+  StartsWith,
+  Unevaluable
+}
+import org.apache.spark.sql.types.DataType
+
+/**
+ * An expression which takes a String and processes it as a vector
+ */
+final case class StringHole(originalExpression: Expression, evaluation: StringHoleEvaluation)
+  extends LeafExpression
+  with Unevaluable {
+  override def nullable: Boolean = originalExpression.nullable
+
+  override def dataType: DataType = originalExpression.dataType
+}
+
+object StringHole {
+
+  sealed trait StringHoleEvaluation {
+    def computeVector: CodeLines
+    def deallocData: CodeLines
+    def fetchResult: CExpression
+  }
+
+  object StringHoleEvaluation {
+    final case class HoleStartsWith() extends StringHoleEvaluation {
+      override def computeVector: CodeLines = CodeLines.empty
+      override def deallocData: CodeLines = CodeLines.empty
+      override def fetchResult: CExpression = CExpression(s"abcd", None)
+    }
+  }
+
+  def process(orig: Expression): Option[StringHoleTransformation] = Option {
+    StringHoleTransformation(
+      exprWithHoles = orig.transform {
+        case exp if processSubExpression.isDefinedAt(exp) =>
+          StringHole(exp, processSubExpression.apply(exp))
+      },
+      holes = orig.collect {
+        case exp if processSubExpression.isDefinedAt(exp) =>
+          StringHole(exp, processSubExpression.apply(exp)) -> processSubExpression.apply(exp)
+      }.toMap
+    )
+  }.filter(_.exprWithHoles != orig)
+
+  def processSubExpression: PartialFunction[Expression, StringHoleEvaluation] = {
+    case e @ StartsWith(l, r) => HoleStartsWith()
+  }
+
+  def transform: PartialFunction[Expression, Expression] = Function
+    .unlift(process)
+    .andThen(_.newExpression)
+
+  final case class StringHoleTransformation(
+    exprWithHoles: Expression,
+    holes: Map[StringHole, StringHoleEvaluation]
+  ) {
+    def stringParts: List[StringHoleEvaluation] = Nil
+
+    def newExpression: Expression = exprWithHoles
+  }
+}

--- a/src/main/scala/com/nec/spark/agile/StringHole.scala
+++ b/src/main/scala/com/nec/spark/agile/StringHole.scala
@@ -75,6 +75,7 @@ object StringHole {
       val myId = s"slowStringEvaluation_${Math.abs(hashCode())}"
       override def computeVector: CodeLines =
         CodeLines.from(
+          CodeLines.debugHere,
           s"std::vector<int> $myId($refName->count);",
           s"for ( int i = 0; i < $refName->count; i++) { ",
           CodeLines
@@ -190,7 +191,7 @@ object StringHole {
         startsWithExp(left.name, right.toString())
     }
 
-  private def startsWithExp(leftRef: String, right: String): CExpression = {
+  private def startsWithExp(leftRef: String, right: String): CExpression =
     CExpression(
       cCode = {
         val leftStringLength =
@@ -203,9 +204,8 @@ object StringHole {
       },
       isNotNullCode = None
     )
-  }
 
-  private def endsWithExp(leftRef: String, right: String) = {
+  private def endsWithExp(leftRef: String, right: String): CExpression =
     CExpression(
       cCode = {
         val leftStringLength =
@@ -218,9 +218,8 @@ object StringHole {
       },
       isNotNullCode = None
     )
-  }
 
-  private def containsExp(leftRef: String, right: String) = {
+  private def containsExp(leftRef: String, right: String): CExpression =
     CExpression(
       cCode = {
         val mainString =
@@ -230,5 +229,4 @@ object StringHole {
       },
       isNotNullCode = None
     )
-  }
 }

--- a/src/main/scala/com/nec/spark/agile/StringHole.scala
+++ b/src/main/scala/com/nec/spark/agile/StringHole.scala
@@ -65,7 +65,6 @@ object StringHole {
     object SlowEvaluator {
       final case class StartsWithEvaluator(theString: String) extends SlowEvaluator {
         override def evaluate(refName: String): CExpression = {
-
           val leftStringLength =
             s"(${refName}->offsets[i+1] - ${refName}->offsets[i])"
           val expectedLength = theString.length
@@ -76,6 +75,18 @@ object StringHole {
             s"${leftStringLength} >= ${expectedLength} && ${leftStringSubstring} == ${rightString}"
           CExpression(bool, None)
         }
+      }
+      final case class EndsWithEvaluator(theString: String) extends SlowEvaluator {
+        override def evaluate(refName: String): CExpression =
+          endsWithExp(refName, theString)
+      }
+      final case class ContainsEvaluator(theString: String) extends SlowEvaluator {
+        override def evaluate(refName: String): CExpression =
+          containsExp(refName, theString)
+      }
+      final case class EqualsEvaluator(theString: String) extends SlowEvaluator {
+        override def evaluate(refName: String): CExpression =
+          equalTo(refName, theString)
       }
     }
 

--- a/src/main/scala/com/nec/spark/agile/StringHole.scala
+++ b/src/main/scala/com/nec/spark/agile/StringHole.scala
@@ -84,7 +84,7 @@ object StringHole {
     exprWithHoles: Expression,
     holes: Map[StringHole, StringHoleEvaluation]
   ) {
-    def stringParts: List[StringHoleEvaluation] = Nil
+    def stringParts: List[StringHoleEvaluation] = holes.values.toList
 
     def newExpression: Expression = exprWithHoles
   }

--- a/src/main/scala/com/nec/spark/agile/groupby/ConvertNamedExpression.scala
+++ b/src/main/scala/com/nec/spark/agile/groupby/ConvertNamedExpression.scala
@@ -102,7 +102,7 @@ object ConvertNamedExpression {
         ).map(r => Right(r))
     }
 
-  private def mapNamedStagedProjection(
+  def mapNamedStagedProjection(
     namedExpression: NamedExpression,
     idx: Int,
     childAttributes: Seq[Attribute]
@@ -124,7 +124,7 @@ object ConvertNamedExpression {
     }
   }
 
-  private def computeIndexedAggregate(
+  def computeIndexedAggregate(
     aggregateExpression: NamedExpression,
     index: Int,
     referenceReplacer: PartialFunction[Expression, Expression]

--- a/src/main/scala/com/nec/spark/agile/groupby/ConvertNamedExpression.scala
+++ b/src/main/scala/com/nec/spark/agile/groupby/ConvertNamedExpression.scala
@@ -106,7 +106,7 @@ object ConvertNamedExpression {
     namedExpression: NamedExpression,
     idx: Int,
     childAttributes: Seq[Attribute]
-  ): Either[String, (StagedProjection, Expression)] = {
+  ): Either[String, (StagedProjection, Expression)] =
     namedExpression match {
       case ar: AttributeReference if childAttributes.toList.exists(_.exprId == ar.exprId) =>
         Right(
@@ -122,7 +122,6 @@ object ConvertNamedExpression {
       case other =>
         Left(s"Unexpected aggregate expression: ${other}, type ${other.getClass}")
     }
-  }
 
   def computeIndexedAggregate(
     aggregateExpression: NamedExpression,

--- a/src/main/scala/com/nec/spark/agile/groupby/GroupByPartialGenerator.scala
+++ b/src/main/scala/com/nec/spark/agile/groupby/GroupByPartialGenerator.scala
@@ -62,7 +62,10 @@ final case class GroupByPartialGenerator(
     )
   }
 
-  def createPartial(inputs: List[CVector]): CFunction =
+  def createPartial(inputs: List[CVector]): CFunction = {
+
+    println(stringVectorComputations)
+
     CFunction(
       inputs = inputs,
       outputs = partialOutputs,
@@ -86,6 +89,7 @@ final case class GroupByPartialGenerator(
         TcpDebug.conditional.close
       )
     )
+  }
 
   def computeProjectionsPerGroup(
     stagedProjection: StagedProjection,

--- a/src/main/scala/com/nec/spark/agile/groupby/GroupByPartialGenerator.scala
+++ b/src/main/scala/com/nec/spark/agile/groupby/GroupByPartialGenerator.scala
@@ -62,10 +62,7 @@ final case class GroupByPartialGenerator(
     )
   }
 
-  def createPartial(inputs: List[CVector]): CFunction = {
-
-    println(stringVectorComputations)
-
+  def createPartial(inputs: List[CVector]): CFunction =
     CFunction(
       inputs = inputs,
       outputs = partialOutputs,
@@ -89,7 +86,6 @@ final case class GroupByPartialGenerator(
         TcpDebug.conditional.close
       )
     )
-  }
 
   def computeProjectionsPerGroup(
     stagedProjection: StagedProjection,

--- a/src/main/scala/com/nec/spark/planning/TransformUtil.scala
+++ b/src/main/scala/com/nec/spark/planning/TransformUtil.scala
@@ -1,0 +1,10 @@
+package com.nec.spark.planning
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, NamedExpression}
+
+object TransformUtil {
+  implicit final class RichTreeNode(namedExpression: NamedExpression) {
+    def transformSelf(rule: PartialFunction[Expression, Expression]): NamedExpression =
+      namedExpression.transform(rule).asInstanceOf[NamedExpression]
+  }
+}

--- a/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
+++ b/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
@@ -148,7 +148,7 @@ final case class VERewriteStrategy(
           }.toList
 
           val stringHoledAggregateExpressions = aggregateExpressions.map(namedExpression =>
-            namedExpression.transformSelf(StringHole.transform)
+            namedExpression.transformSelf(referenceReplacer).transformSelf(StringHole.transform)
           )
 
           val evaluationPlanE: Either[String, NativeAggregationEvaluationPlan] = for {
@@ -223,8 +223,6 @@ final case class VERewriteStrategy(
             } ++ aggregates.flatMap { case (sa, exp) =>
               StringHole.process(exp.transform(referenceReplacer))
             }
-            _ = println(s"GOt holes ==> ${stringHoles}")
-
             computedProjections <- projections.map { case (sp, p) =>
               ConvertNamedExpression
                 .doProj(p.transform(referenceReplacer).transform(StringHole.transform))

--- a/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
+++ b/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
@@ -151,7 +151,7 @@ final case class VERewriteStrategy(
             namedExpression.transformSelf(referenceReplacer).transformSelf(StringHole.transform)
           )
 
-          val evaluationPlanE: Either[String, NativeAggregationEvaluationPlan] = for {
+          val evaluationPlanE: Either[String, SparkPlan] = for {
             projections <- stringHoledAggregateExpressions.zipWithIndex
               .map { case (ne, i) =>
                 ConvertNamedExpression

--- a/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
+++ b/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
@@ -239,7 +239,7 @@ final case class VERewriteStrategy(
               ),
               computedGroupingKeys = computedGroupingKeys,
               computedProjections = computedProjections,
-              stringVectorComputations = stringHoles.flatMap(_.stringParts)
+              stringVectorComputations = stringHoles.flatMap(_.stringParts).distinct
             )
             partialCFunction = groupByPartialGenerator.createPartial(inputs = inputsList)
             _ <-
@@ -253,7 +253,7 @@ final case class VERewriteStrategy(
               groupByPartialGenerator.createFull(inputs = inputsList)
           } yield {
             options.preShufflePartitions match {
-              case Some(n) if(groupingExpressions.size > 0)=>
+              case Some(n) if groupingExpressions.nonEmpty =>
                 ArrowColumnarToRowPlan(
                   NativeAggregationEvaluationPlan(
                     outputExpressions = aggregateExpressions,

--- a/src/test/scala/com/nec/cmake/eval/OldUnifiedGroupByFunctionGeneration.scala
+++ b/src/test/scala/com/nec/cmake/eval/OldUnifiedGroupByFunctionGeneration.scala
@@ -119,7 +119,12 @@ final case class OldUnifiedGroupByFunctionGeneration(
           )
           .sequence
         ca <- stagedGroupBy.aggregations.map(sa => computeAggregate(sa).map(c => sa -> c)).sequence
-      } yield GroupByPartialGenerator(GroupByPartialToFinalGenerator(stagedGroupBy, ca), gks, cpr)
+      } yield GroupByPartialGenerator(
+        finalGenerator = GroupByPartialToFinalGenerator(stagedGroupBy, ca),
+        computedGroupingKeys = gks,
+        computedProjections = cpr,
+        stringVectorComputations = Nil
+      )
         .createPartial(inputs = veDataTransformation.inputs)
     }
       .fold(sys.error, identity)

--- a/src/test/scala/com/nec/cmake/eval/StringHoleEvaluationSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/StringHoleEvaluationSpec.scala
@@ -63,7 +63,7 @@ final class StringHoleEvaluationSpec extends AnyFreeSpec {
     )
   }
 
-  "Fast evaluator filters strings as expected for StartsWith" in {
+  "Fast evaluator filters strings as expected for StartsWith" ignore {
     val testedList = list.map(str => if (str.startsWith("test")) 1 else 0)
 
     expect(

--- a/src/test/scala/com/nec/cmake/eval/StringHoleEvaluationSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/StringHoleEvaluationSpec.scala
@@ -1,5 +1,6 @@
 package com.nec.cmake.eval
 
+import com.eed3si9n.expecty.Expecty.expect
 import com.nec.arrow.ArrowNativeInterface.SupportedVectorWrapper
 import com.nec.arrow.TransferDefinitions.TransferDefinitionsSourceCode
 import com.nec.arrow.{ArrowVectorBuilders, CArrowNativeInterface, WithTestAllocator}
@@ -13,10 +14,61 @@ import com.nec.spark.agile.groupby.GroupByOutline
 import org.scalatest.freespec.AnyFreeSpec
 
 final class StringHoleEvaluationSpec extends AnyFreeSpec {
-  "It filters strings as expected" in {
-    val startsWithHole = StringHole.StringHoleEvaluation.SlowEvaluation(
+
+  val list = List("this", "test", "is defi", "nitely", "tested")
+
+  "It filters strings as expected for StartsWith" in {
+    val testedList = list.map(str => if (str.startsWith("test")) 1 else 0)
+
+    expect(
+      StringHoleEvaluationSpec.executeSlowEvaluator(
+        input = list,
+        slowEvaluator = SlowEvaluator.StartsWithEvaluator("test")
+      ) == testedList
+    )
+  }
+
+  "It filters strings as expected for EndsWith" in {
+    val testedList = list.map(str => if (str.endsWith("d")) 1 else 0)
+
+    expect(
+      StringHoleEvaluationSpec.executeSlowEvaluator(
+        input = list,
+        slowEvaluator = SlowEvaluator.EndsWithEvaluator("d")
+      ) == testedList
+    )
+  }
+
+  "It filters strings as expected for Contains" in {
+    val testedList = list.map(str => if (str.contains("s")) 1 else 0)
+
+    expect(
+      StringHoleEvaluationSpec.executeSlowEvaluator(
+        input = list,
+        slowEvaluator = SlowEvaluator.ContainsEvaluator("s")
+      ) == testedList
+    )
+  }
+
+  "It filters strings as expected for Equals" in {
+    val testedList = list.map(str => if (str == "test") 1 else 0)
+
+    expect(
+      StringHoleEvaluationSpec.executeSlowEvaluator(
+        input = list,
+        slowEvaluator = SlowEvaluator.EqualsEvaluator("test")
+      ) == testedList
+    )
+  }
+
+}
+
+object StringHoleEvaluationSpec {
+  def executeSlowEvaluator(input: List[String], slowEvaluator: SlowEvaluator): List[Int] = {
+
+    val hole = StringHole.StringHoleEvaluation.SlowEvaluation(
       refName = "strings",
-      slowEvaluator = SlowEvaluator.StartsWithEvaluator("test")
+      slowEvaluator = slowEvaluator
     )
 
     val cLib = CMakeBuilder.buildCLogging(
@@ -27,15 +79,15 @@ final class StringHoleEvaluationSpec extends AnyFreeSpec {
           inputs = List(CVector.varChar("strings")),
           outputs = List(CVector.int("bools")),
           body = CodeLines.from(
-            startsWithHole.computeVector,
+            hole.computeVector,
             GroupByOutline
               .initializeScalarVector(VeScalarType.veNullableInt, "bools", "strings->count"),
             CodeLines.from(
               "for ( int i = 0; i < strings->count; i++ ) { ",
-              GroupByOutline.storeTo("bools", startsWithHole.fetchResult, "i").indented,
+              GroupByOutline.storeTo("bools", hole.fetchResult, "i").indented,
               "}"
             ),
-            startsWithHole.deallocData,
+            hole.deallocData,
             "return 0;"
           )
         ).toCodeLines("test").cCode
@@ -45,16 +97,14 @@ final class StringHoleEvaluationSpec extends AnyFreeSpec {
 
     val nativeInterface = new CArrowNativeInterface(cLib.toString)
     WithTestAllocator { implicit allocator =>
-      val list = List("this", "test", "is defi", "nitely", "tested")
-      val testedList = list.map(str => if (str.startsWith("test")) 1 else 0)
-      ArrowVectorBuilders.withArrowStringVector(list) { inVec =>
+      ArrowVectorBuilders.withArrowStringVector(input) { inVec =>
         ArrowVectorBuilders.withDirectIntVector(Seq.empty) { outVec =>
           nativeInterface.callFunction(
             name = "test",
             inputArguments = List(Some(SupportedVectorWrapper.wrapInput(inVec)), None),
             outputArguments = List(None, Some(SupportedVectorWrapper.wrapOutput(outVec)))
           )
-          assert(outVec.toList == testedList)
+          outVec.toList
         }
       }
     }

--- a/src/test/scala/com/nec/cmake/eval/StringHoleEvaluationSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/StringHoleEvaluationSpec.scala
@@ -11,7 +11,7 @@ import com.nec.spark.agile.CFunctionGeneration.{CFunction, CVector, VeScalarType
 import com.nec.spark.agile.StringHole
 import com.nec.spark.agile.StringHole.StringHoleEvaluation
 import com.nec.spark.agile.StringHole.StringHoleEvaluation.SlowEvaluator.SlowEvaluator
-import com.nec.spark.agile.StringHole.StringHoleEvaluation.{FastStartsWithEvaluation, SlowEvaluator}
+import com.nec.spark.agile.StringHole.StringHoleEvaluation.{LikeStringHoleEvaluation, SlowEvaluator}
 import com.nec.spark.agile.groupby.GroupByOutline
 import org.scalatest.freespec.AnyFreeSpec
 
@@ -69,7 +69,7 @@ final class StringHoleEvaluationSpec extends AnyFreeSpec {
     expect(
       StringHoleEvaluationSpec.executeHoleEvaluation(
         input = list,
-        stringHoleEvaluation = FastStartsWithEvaluation(refName = "strings", theString = "test")
+        stringHoleEvaluation = LikeStringHoleEvaluation(refName = "strings", likeString = "test%")
       ) == testedList
     )
   }

--- a/src/test/scala/com/nec/cmake/eval/StringHoleEvaluationSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/StringHoleEvaluationSpec.scala
@@ -63,7 +63,7 @@ final class StringHoleEvaluationSpec extends AnyFreeSpec {
     )
   }
 
-  "Fast evaluator filters strings as expected for StartsWith" ignore {
+  "Fast evaluator filters strings as expected for StartsWith" in {
     val testedList = list.map(str => if (str.startsWith("test")) 1 else 0)
 
     expect(

--- a/src/test/scala/com/nec/cmake/eval/StringHoleEvaluationSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/StringHoleEvaluationSpec.scala
@@ -1,0 +1,63 @@
+package com.nec.cmake.eval
+
+import com.nec.arrow.ArrowNativeInterface.SupportedVectorWrapper
+import com.nec.arrow.TransferDefinitions.TransferDefinitionsSourceCode
+import com.nec.arrow.{ArrowVectorBuilders, CArrowNativeInterface, WithTestAllocator}
+import com.nec.cmake.CMakeBuilder
+import com.nec.cmake.functions.ParseCSVSpec.RichIntVector
+import com.nec.spark.agile.CExpressionEvaluation.CodeLines
+import com.nec.spark.agile.CFunctionGeneration.{CFunction, CVector, VeScalarType}
+import com.nec.spark.agile.StringHole
+import com.nec.spark.agile.StringHole.StringHoleEvaluation.SlowEvaluator
+import com.nec.spark.agile.groupby.GroupByOutline
+import org.scalatest.freespec.AnyFreeSpec
+
+final class StringHoleEvaluationSpec extends AnyFreeSpec {
+  "It filters strings as expected" in {
+    val startsWithHole = StringHole.StringHoleEvaluation.SlowEvaluation(
+      refName = "strings",
+      slowEvaluator = SlowEvaluator.StartsWithEvaluator("test")
+    )
+
+    val cLib = CMakeBuilder.buildCLogging(
+      List(
+        TransferDefinitionsSourceCode,
+        "\n\n",
+        CFunction(
+          inputs = List(CVector.varChar("strings")),
+          outputs = List(CVector.int("bools")),
+          body = CodeLines.from(
+            startsWithHole.computeVector,
+            GroupByOutline
+              .initializeScalarVector(VeScalarType.veNullableInt, "bools", "strings->count"),
+            CodeLines.from(
+              "for ( int i = 0; i < strings->count; i++ ) { ",
+              GroupByOutline.storeTo("bools", startsWithHole.fetchResult, "i").indented,
+              "}"
+            ),
+            startsWithHole.deallocData,
+            "return 0;"
+          )
+        ).toCodeLines("test").cCode
+      )
+        .mkString("\n\n")
+    )
+
+    val nativeInterface = new CArrowNativeInterface(cLib.toString)
+    WithTestAllocator { implicit allocator =>
+      val list = List("this", "test", "is defi", "nitely", "tested")
+      val testedList = list.map(str => if (str.startsWith("test")) 1 else 0)
+      ArrowVectorBuilders.withArrowStringVector(list) { inVec =>
+        ArrowVectorBuilders.withDirectIntVector(Seq.empty) { outVec =>
+          nativeInterface.callFunction(
+            name = "test",
+            inputArguments = List(Some(SupportedVectorWrapper.wrapInput(inVec)), None),
+            outputArguments = List(None, Some(SupportedVectorWrapper.wrapOutput(outVec)))
+          )
+          assert(outVec.toList == testedList)
+        }
+      }
+    }
+  }
+
+}

--- a/src/test/scala/com/nec/cmake/eval/StringHoleEvaluationSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/StringHoleEvaluationSpec.scala
@@ -69,7 +69,7 @@ final class StringHoleEvaluationSpec extends AnyFreeSpec {
     expect(
       StringHoleEvaluationSpec.executeHoleEvaluation(
         input = list,
-        stringHoleEvaluation = FastStartsWithEvaluation("test")
+        stringHoleEvaluation = FastStartsWithEvaluation(refName = "strings", theString = "test")
       ) == testedList
     )
   }

--- a/src/test/scala/com/nec/cmake/functions/IncludeTCPDebugSpec.scala
+++ b/src/test/scala/com/nec/cmake/functions/IncludeTCPDebugSpec.scala
@@ -34,8 +34,6 @@ final class IncludeTCPDebugSpec extends AnyFreeSpec {
         "}"
       )
 
-      println(code.cCode)
-
       CMakeBuilder.buildC(code.cCode, debug = true)
     }
   }

--- a/src/test/scala/com/nec/cmake/functions/WordsCheckSpec.scala
+++ b/src/test/scala/com/nec/cmake/functions/WordsCheckSpec.scala
@@ -107,9 +107,6 @@ final class WordsCheckSpec extends AnyFreeSpec with Checkers {
         val expected = list.zipWithIndex.collect { case (s, idx) if idx % 2 == 0 => s }.toList
         val r = ArrowVectorBuilders.withArrowStringVector(list) { inVec =>
           ArrowVectorBuilders.withArrowStringVector(Seq.empty) { outVec =>
-            println(inVec.toList)
-            println(inVec.toList.size)
-            println(inVec)
             nativeInterface.callFunction(
               name = "test",
               inputArguments = List(Some(SupportedVectorWrapper.wrapInput(inVec)), None),

--- a/src/test/scala/com/nec/spark/agile/StringHoleSpec.scala
+++ b/src/test/scala/com/nec/spark/agile/StringHoleSpec.scala
@@ -28,17 +28,11 @@ import org.scalatest.freespec.AnyFreeSpec
 
 final class StringHoleSpec extends AnyFreeSpec {
   "It detects a StartsWith in CASE WHEN" in {
-    val y: Option[StringHoleTransformation] = StringHole.process(
-      CaseWhen(
-        Seq(
-          StartsWith(
-            AttributeReference("test", StringType, nullable = false)(),
-            Literal("x")
-          ) -> Literal(1)
-        ),
-        None
-      )
-    )
+
+    val aref = AttributeReference("test", StringType, nullable = false)()
+
+    val y: Option[StringHoleTransformation] =
+      StringHole.process(CaseWhen(Seq(StartsWith(aref, Literal("x")) -> Literal(1)), None))
 
     val x = y.get
 
@@ -46,7 +40,7 @@ final class StringHoleSpec extends AnyFreeSpec {
       x.newExpression == CaseWhen(
         Seq(
           StringHole(
-            StartsWith(AttributeReference("test", StringType, nullable = false)(), Literal("x")),
+            StartsWith(aref, Literal("x")),
             StringHoleEvaluation.HoleStartsWith()
           ) -> Literal(1)
         ),

--- a/src/test/scala/com/nec/spark/agile/StringHoleSpec.scala
+++ b/src/test/scala/com/nec/spark/agile/StringHoleSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 Xpress AI.
+ *
+ * This file is part of Spark Cyclone.
+ * See https://github.com/XpressAI/SparkCyclone for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.nec.spark.agile
+
+import com.eed3si9n.expecty.Expecty.expect
+import com.nec.spark.agile.StringHole.StringHoleEvaluation.HoleStartsWith
+import com.nec.spark.agile.StringHole.{StringHoleEvaluation, StringHoleTransformation}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, CaseWhen, Literal, StartsWith}
+import org.apache.spark.sql.types.StringType
+import org.scalatest.freespec.AnyFreeSpec
+
+final class StringHoleSpec extends AnyFreeSpec {
+  "It detects a StartsWith in CASE WHEN" in {
+    val y: Option[StringHoleTransformation] = StringHole.process(
+      CaseWhen(
+        Seq(
+          StartsWith(
+            AttributeReference("test", StringType, nullable = false)(),
+            Literal("x")
+          ) -> Literal(1)
+        ),
+        None
+      )
+    )
+
+    val x = y.get
+
+    expect(
+      x.newExpression == CaseWhen(
+        Seq(
+          StringHole(
+            StartsWith(AttributeReference("test", StringType, nullable = false)(), Literal("x")),
+            StringHoleEvaluation.HoleStartsWith()
+          ) -> Literal(1)
+        ),
+        None
+      ),
+      x.stringParts == List(HoleStartsWith())
+    )
+
+  }
+}

--- a/src/test/scala/com/nec/spark/agile/StringHoleSpec.scala
+++ b/src/test/scala/com/nec/spark/agile/StringHoleSpec.scala
@@ -20,7 +20,7 @@
 package com.nec.spark.agile
 
 import com.eed3si9n.expecty.Expecty.expect
-import com.nec.spark.agile.StringHole.StringHoleEvaluation.HoleStartsWith
+import com.nec.spark.agile.StringHole.StringHoleEvaluation.SlowEvaluator
 import com.nec.spark.agile.StringHole.{StringHoleEvaluation, StringHoleTransformation}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, CaseWhen, Literal, StartsWith}
 import org.apache.spark.sql.types.StringType
@@ -36,17 +36,14 @@ final class StringHoleSpec extends AnyFreeSpec {
 
     val x = y.get
 
+    val evaluation =
+      StringHoleEvaluation.SlowEvaluation("test", SlowEvaluator.StartsWithEvaluator("x"))
     expect(
       x.newExpression == CaseWhen(
-        Seq(
-          StringHole(
-            StartsWith(aref, Literal("x")),
-            StringHoleEvaluation.HoleStartsWith()
-          ) -> Literal(1)
-        ),
+        Seq(StringHole(StartsWith(aref, Literal("x")), evaluation) -> Literal(1)),
         None
       ),
-      x.stringParts == List(HoleStartsWith())
+      x.stringParts == List(evaluation)
     )
 
   }

--- a/src/test/scala/com/nec/spark/agile/groupby/ConvertNamedExpressionSpec.scala
+++ b/src/test/scala/com/nec/spark/agile/groupby/ConvertNamedExpressionSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Xpress AI.
+ *
+ * This file is part of Spark Cyclone.
+ * See https://github.com/XpressAI/SparkCyclone for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.nec.spark.agile.groupby
+
+import com.nec.spark.agile.SparkExpressionToCExpression.EvalFallback
+import org.scalatest.freespec.AnyFreeSpec
+
+final class ConvertNamedExpressionSpec extends AnyFreeSpec {
+  "It works" in {
+    assert(
+      ConvertNamedExpression
+        .mapNamedExp(
+          namedExpression = ???,
+          idx = ???,
+          referenceReplacer = ???,
+          childAttributes = ???
+        )(EvalFallback.noOp)
+        .isRight
+    )
+  }
+}

--- a/src/test/scala/com/nec/spark/agile/groupby/ConvertNamedExpressionSpec.scala
+++ b/src/test/scala/com/nec/spark/agile/groupby/ConvertNamedExpressionSpec.scala
@@ -24,7 +24,6 @@ import org.scalatest.freespec.AnyFreeSpec
 import ConvertNamedExpression._
 import com.nec.spark.agile.CFunctionGeneration.VeScalarType
 import com.nec.spark.agile.groupby.GroupByOutline.StagedProjection
-import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{
   Alias,
   Attribute,

--- a/src/test/scala/com/nec/spark/agile/groupby/ConvertNamedExpressionSpec.scala
+++ b/src/test/scala/com/nec/spark/agile/groupby/ConvertNamedExpressionSpec.scala
@@ -67,4 +67,8 @@ final class ConvertNamedExpressionSpec extends AnyFreeSpec {
       assert(result.isLeft)
     }
   }
+
+  "For indexed aggregate" - {
+    // not worth testing this as there's little complexity in this method for indexedAggregate
+  }
 }

--- a/tests/tpchbench/src/main/scala/sparkcyclone/tpch/TPCHBenchmark.scala
+++ b/tests/tpchbench/src/main/scala/sparkcyclone/tpch/TPCHBenchmark.scala
@@ -35,7 +35,6 @@ case class Customer(
   c_comment: String
 )
 
-
 case class Lineitem(
   l_orderkey: Long,
   l_partkey: Long,
@@ -55,12 +54,7 @@ case class Lineitem(
   l_comment: String
 )
 
-case class Nation(
-  n_nationkey: Long,
-  n_name: String,
-  n_regionkey: Long,
-  n_comment: String
-)
+case class Nation(n_nationkey: Long, n_name: String, n_regionkey: Long, n_comment: String)
 
 case class Order(
   o_orderkey: Long,
@@ -94,11 +88,7 @@ case class Partsupp(
   ps_comment: String
 )
 
-case class Region(
-  r_regionkey: Long,
-  r_name: String,
-  r_comment: String
-)
+case class Region(r_regionkey: Long, r_name: String, r_comment: String)
 
 case class Supplier(
   s_suppkey: Long,
@@ -117,35 +107,123 @@ object TPCHBenchmark extends SparkSessionWrapper {
     val sc = sparkSession.sparkContext
 
     val dfMap = Map(
-      "customer" -> sc.textFile(inputDir + "/customer.tbl*").map(_.split('|')).map(p =>
-        Customer(p(0).trim.toLong, p(1).trim, p(2).trim, p(3).trim.toLong, p(4).trim, p(5).trim.toDouble, p(6).trim, p(7).trim)).toDF(),
-
-      "lineitem" -> sc.textFile(inputDir + "/lineitem.tbl*").map(_.split('|')).map(p =>
-        Lineitem(p(0).trim.toLong, p(1).trim.toLong, p(2).trim.toLong, p(3).trim.toLong, p(4).trim.toDouble, p(5).trim.toDouble, p(6).trim.toDouble, p(7).trim.toDouble, p(8).trim, p(9).trim, p(10).trim, p(11).trim, p(12).trim, p(13).trim, p(14).trim, p(15).trim)).toDF(),
-
-      "nation" -> sc.textFile(inputDir + "/nation.tbl*").map(_.split('|')).map(p =>
-        Nation(p(0).trim.toLong, p(1).trim, p(2).trim.toLong, p(3).trim)).toDF(),
-
-      "region" -> sc.textFile(inputDir + "/region.tbl*").map(_.split('|')).map(p =>
-        Region(p(0).trim.toLong, p(1).trim, p(2).trim)).toDF(),
-
-      "orders" -> sc.textFile(inputDir + "/orders.tbl*").map(_.split('|')).map(p =>
-        Order(p(0).trim.toLong, p(1).trim.toLong, p(2).trim, p(3).trim.toDouble, p(4).trim, p(5).trim, p(6).trim, p(7).trim.toLong, p(8).trim)).toDF(),
-
-      "part" -> sc.textFile(inputDir + "/part.tbl*").map(_.split('|')).map(p =>
-        Part(p(0).trim.toLong, p(1).trim, p(2).trim, p(3).trim, p(4).trim, p(5).trim.toLong, p(6).trim, p(7).trim.toDouble, p(8).trim)).toDF(),
-
-      "partsupp" -> sc.textFile(inputDir + "/partsupp.tbl*").map(_.split('|')).map(p =>
-        Partsupp(p(0).trim.toLong, p(1).trim.toLong, p(2).trim.toLong, p(3).trim.toDouble, p(4).trim)).toDF(),
-
-      "supplier" -> sc.textFile(inputDir + "/supplier.tbl*").map(_.split('|')).map(p =>
-        Supplier(p(0).trim.toLong, p(1).trim, p(2).trim, p(3).trim.toLong, p(4).trim, p(5).trim.toDouble, p(6).trim)).toDF()
+      "customer" -> sc
+        .textFile(inputDir + "/customer.tbl*")
+        .map(_.split('|'))
+        .map(p =>
+          Customer(
+            p(0).trim.toLong,
+            p(1).trim,
+            p(2).trim,
+            p(3).trim.toLong,
+            p(4).trim,
+            p(5).trim.toDouble,
+            p(6).trim,
+            p(7).trim
+          )
+        )
+        .toDF(),
+      "lineitem" -> sc
+        .textFile(inputDir + "/lineitem.tbl*")
+        .map(_.split('|'))
+        .map(p =>
+          Lineitem(
+            p(0).trim.toLong,
+            p(1).trim.toLong,
+            p(2).trim.toLong,
+            p(3).trim.toLong,
+            p(4).trim.toDouble,
+            p(5).trim.toDouble,
+            p(6).trim.toDouble,
+            p(7).trim.toDouble,
+            p(8).trim,
+            p(9).trim,
+            p(10).trim,
+            p(11).trim,
+            p(12).trim,
+            p(13).trim,
+            p(14).trim,
+            p(15).trim
+          )
+        )
+        .toDF(),
+      "nation" -> sc
+        .textFile(inputDir + "/nation.tbl*")
+        .map(_.split('|'))
+        .map(p => Nation(p(0).trim.toLong, p(1).trim, p(2).trim.toLong, p(3).trim))
+        .toDF(),
+      "region" -> sc
+        .textFile(inputDir + "/region.tbl*")
+        .map(_.split('|'))
+        .map(p => Region(p(0).trim.toLong, p(1).trim, p(2).trim))
+        .toDF(),
+      "orders" -> sc
+        .textFile(inputDir + "/orders.tbl*")
+        .map(_.split('|'))
+        .map(p =>
+          Order(
+            p(0).trim.toLong,
+            p(1).trim.toLong,
+            p(2).trim,
+            p(3).trim.toDouble,
+            p(4).trim,
+            p(5).trim,
+            p(6).trim,
+            p(7).trim.toLong,
+            p(8).trim
+          )
+        )
+        .toDF(),
+      "part" -> sc
+        .textFile(inputDir + "/part.tbl*")
+        .map(_.split('|'))
+        .map(p =>
+          Part(
+            p(0).trim.toLong,
+            p(1).trim,
+            p(2).trim,
+            p(3).trim,
+            p(4).trim,
+            p(5).trim.toLong,
+            p(6).trim,
+            p(7).trim.toDouble,
+            p(8).trim
+          )
+        )
+        .toDF(),
+      "partsupp" -> sc
+        .textFile(inputDir + "/partsupp.tbl*")
+        .map(_.split('|'))
+        .map(p =>
+          Partsupp(
+            p(0).trim.toLong,
+            p(1).trim.toLong,
+            p(2).trim.toLong,
+            p(3).trim.toDouble,
+            p(4).trim
+          )
+        )
+        .toDF(),
+      "supplier" -> sc
+        .textFile(inputDir + "/supplier.tbl*")
+        .map(_.split('|'))
+        .map(p =>
+          Supplier(
+            p(0).trim.toLong,
+            p(1).trim,
+            p(2).trim,
+            p(3).trim.toLong,
+            p(4).trim,
+            p(5).trim.toDouble,
+            p(6).trim
+          )
+        )
+        .toDF()
     )
 
-    dfMap.foreach {
-      case (key, value) =>
-        value.createOrReplaceTempView(key)
-        sparkSession.sql("CACHE TABLE " + key)
+    dfMap.foreach { case (key, value) =>
+      value.createOrReplaceTempView(key)
+      sparkSession.sql("CACHE TABLE " + key)
     }
   }
 
@@ -189,11 +267,10 @@ object TPCHBenchmark extends SparkSessionWrapper {
       Set[Int]()
     }
 
-    queries.foreach {
-      case (query, i) =>
-        if (!toSkip.contains(i)) {
-          benchmark(i, query)
-        }
+    queries.foreach { case (query, i) =>
+      if (!toSkip.contains(i)) {
+        benchmark(i, query)
+      }
     }
   }
 
@@ -203,7 +280,7 @@ object TPCHBenchmark extends SparkSessionWrapper {
     val res = f(sparkSession)
     val end = System.nanoTime()
     println(s"Result returned ${res.length} records.")
-    println(s"Query${i} elapsed: ${(end - start).toDouble / 1e9 } s" )
+    println(s"Query${i} elapsed: ${(end - start).toDouble / 1e9} s")
     res.take(10).foreach(println)
   }
 


### PR DESCRIPTION
This framework allows us to handle String expressions in a vector form, and does it in a fast way for LIKE-like operations.

Generated code for the fast version (on by default):

```c++
std::vector<int> slowStringEvaluation_1359651405(input_0->count);
frovedis::words slowStringEvaluation_words_1359651405 = varchar_vector_to_words(input_0);
std::vector<size_t> slowStringEvaluation_matching_ids_1359651405 = frovedis::like(slowStringEvaluation_words_1359651405.chars,(const vector<size_t>&)(slowStringEvaluation_words_1359651405.starts),
(const vector<size_t>&)(slowStringEvaluation_words_1359651405.lens),
"%e%");

for ( int i = 0; i < input_0->count; i++) { 
  slowStringEvaluation_1359651405[i] = 0;
}
for(int i = 0; i < slowStringEvaluation_matching_ids_1359651405.size(); i++) {
  slowStringEvaluation_1359651405[slowStringEvaluation_matching_ids_1359651405[i]] = 1;
}

```