### PR TITLE
Run TPC tests on the VE, and report them in this GitHub action

### DIFF
--- a/.github/workflows/tpc.yml
+++ b/.github/workflows/tpc.yml
@@ -1,0 +1,26 @@
+name: TPC (VE)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Check User
+        run: whoami
+        
+      - name: Check Path
+        run: pwd
+        
+      - name: Check Access to VE
+        run: /opt/nec/ve/bin/vecmd info
+
+      - name: Branch Ref
+        run: echo ${GITHUB_REF#refs/heads/}
+
+      - name: Run Vector Engine Tests
+        run: sbt "set debugToHtml := true" "Tpc / testOnly *TPCHVESqlSpec"

--- a/.github/workflows/tpc.yml
+++ b/.github/workflows/tpc.yml
@@ -22,5 +22,11 @@ jobs:
       - name: Branch Ref
         run: echo ${GITHUB_REF#refs/heads/}
 
+      - name: Generate TPC-H Data
+        run: pushd src/test/resources/dbgen/ && make && ./dbgen && popd
+
       - name: Run Vector Engine Tests
         run: sbt "set debugToHtml := true" "Tpc / testOnly *TPCHVESqlSpec"
+
+      - name: Copying to sparkcyclone.io
+        run: rsync -r -v target/tpc-html egonzalez@xpressai.jp:/var/www/sparkcyclone.io/tpc-html/`date +"%Y%m%d%H%M%S"`

--- a/src/test/scala/com/nec/spark/agile/SparkSanityTests.scala
+++ b/src/test/scala/com/nec/spark/agile/SparkSanityTests.scala
@@ -36,6 +36,7 @@ final class SparkSanityTests
   with Matchers {
 
   "It is not launched by default" in withSpark(identity) { _ =>
+    markup("<b>yes</b>")
     assert(!SparkCycloneDriverPlugin.launched, "Expect the driver to have not been launched")
     assert(
       !SparkCycloneExecutorPlugin.launched && SparkCycloneExecutorPlugin.params.isEmpty,


### PR DESCRIPTION
This is so that we would be able to consistently review the whole stack of things, including plans and such.

![image](https://user-images.githubusercontent.com/52247468/142943994-8c420b7e-306c-4868-aa92-103afe9aaf15.png)

The output is located in `target/test-html`.

