### PR TITLE
Introduce a simple cache clean-up

### DIFF
--- a/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
+++ b/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
@@ -112,13 +112,18 @@ object SparkCycloneExecutorPlugin extends LazyLogging {
     }
   }
 
-  val cache: scala.collection.mutable.Set[VeColBatch] = scala.collection.mutable.Set.empty
+  @transient val batchCache: scala.collection.mutable.Set[VeColBatch] =
+    scala.collection.mutable.Set.empty
 
   def cleanCache(): Unit = {
-    cache.toList.foreach { colBatch =>
-      cache.remove(colBatch)
+    batchCache.toList.foreach { colBatch =>
+      batchCache.remove(colBatch)
       colBatch.cols.foreach(_.free())
     }
+  }
+
+  def register(cb: VeColBatch): Unit = {
+    batchCache.add(cb)
   }
 
   var CleanUpCache: Boolean = true

--- a/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
+++ b/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
@@ -25,8 +25,7 @@ import org.bytedeco.veoffload.veo_proc_handle
 
 import java.util
 import scala.collection.JavaConverters.mapAsScalaMapConverter
-import com.nec.spark.SparkCycloneExecutorPlugin._
-import com.nec.ve.VeProcess
+import com.nec.ve.{VeColBatch, VeProcess}
 import com.nec.ve.VeProcess.LibraryReference
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.api.plugin.ExecutorPlugin
@@ -37,7 +36,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import scala.util.Try
 
-object SparkCycloneExecutorPlugin {
+object SparkCycloneExecutorPlugin extends LazyLogging {
 
   /** For assumption testing purposes only for now */
   var params: Map[String, String] = Map.empty[String, String]
@@ -113,12 +112,25 @@ object SparkCycloneExecutorPlugin {
     }
   }
 
+  val cache: scala.collection.mutable.Set[VeColBatch] = scala.collection.mutable.Set.empty
+
+  def cleanCache(): Unit = {
+    cache.toList.foreach { colBatch =>
+      cache.remove(colBatch)
+      colBatch.cols.foreach(_.free())
+    }
+  }
+
+  var CleanUpCache: Boolean = true
+
   var libraryStorage: LibraryStorage = _
 }
 
 class SparkCycloneExecutorPlugin extends ExecutorPlugin with Logging {
 
   override def init(ctx: PluginContext, extraConf: util.Map[String, String]): Unit = {
+    import com.nec.spark.SparkCycloneExecutorPlugin._
+
     val resources = ctx.resources()
     SparkCycloneExecutorPlugin.synchronized {
       SparkCycloneExecutorPlugin.libraryStorage = new DriverFetchingLibraryStorage(ctx)
@@ -168,6 +180,11 @@ class SparkCycloneExecutorPlugin extends ExecutorPlugin with Logging {
   }
 
   override def shutdown(): Unit = {
+    if (SparkCycloneExecutorPlugin.CleanUpCache) {
+      SparkCycloneExecutorPlugin.cleanCache()
+    }
+
+    import com.nec.spark.SparkCycloneExecutorPlugin._
     if (closeAutomatically) {
       logInfo(s"Closing process: ${_veo_proc}")
       closeProcAndCtx()

--- a/src/main/scala/com/nec/spark/planning/VeCachedBatchSerializer.scala
+++ b/src/main/scala/com/nec/spark/planning/VeCachedBatchSerializer.scala
@@ -66,6 +66,7 @@ class VeCachedBatchSerializer extends org.apache.spark.sql.columnar.CachedBatchS
     storageLevel: StorageLevel,
     conf: SQLConf
   ): RDD[CachedBatch] = input.map(cb => {
+    println(cb)
     import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
     CachedVeBatch(VeColBatch.fromArrowColumnarBatch(cb))
   })

--- a/src/test/scala/com/nec/tpc/TPCHSqlCSpec.scala
+++ b/src/test/scala/com/nec/tpc/TPCHSqlCSpec.scala
@@ -411,12 +411,14 @@ class TPCHSqlCSpec
       .toList
 
     sparkSession.sql(sql).debugSqlHere { ds =>
-      assert(
+      val resultQuery =
         ds.as[(Double, String, String, Long, String, String, String, String)]
           .collect()
           .toList
-          .sorted === result.sorted
-      )
+          .sorted
+
+      val expected = result.sorted
+      assert(com.nec.testing.ProductListEquivalenceCheck.listEq.areEqual(resultQuery, expected))
     }
   }
   withTpchViews("Query 3", configuration) { sparkSession =>
@@ -467,7 +469,9 @@ class TPCHSqlCSpec
       .toList
 
     sparkSession.sql(sql).debugSqlHere { ds =>
-      assert(ds.as[(Long, Double, String, Long)].collect().toList.sorted === result.sorted)
+      val resultCompute = ds.as[(Long, Double, String, Long)].collect().toList.sorted
+      val expected = result.toList.sorted
+      assert(com.nec.testing.ProductListEquivalenceCheck.listEq.areEqual(resultCompute, expected))
     }
   }
 
@@ -500,13 +504,16 @@ class TPCHSqlCSpec
     """
     sparkSession.sql(sql).debugSqlHere { ds =>
       assert(
-        ds.as[(String, Long)].collect().toList.sorted === List(
-          ("1-URGENT", 10594),
-          ("2-HIGH", 10476),
-          ("3-MEDIUM", 10410),
-          ("4-NOT SPECIFIED", 10556),
-          ("5-LOW", 10487)
-        ).sorted
+        com.nec.testing.ProductListEquivalenceCheck.listEq.areEqual(
+          ds.as[(String, Long)].collect().toList.sorted,
+          List(
+            ("1-URGENT", 10594),
+            ("2-HIGH", 10476),
+            ("3-MEDIUM", 10410),
+            ("4-NOT SPECIFIED", 10556),
+            ("5-LOW", 10487)
+          ).sorted
+        )
       )
     }
   }
@@ -544,13 +551,16 @@ class TPCHSqlCSpec
     """
     sparkSession.sql(sql).debugSqlHere { ds =>
       assert(
-        ds.as[(String, Double)].collect().toList.sorted === List(
-          ("INDONESIA", 5.5502041169699915e7),
-          ("VIETNAM", 5.529508699669991e7),
-          ("CHINA", 5.372449425660001e7),
-          ("INDIA", 5.2035512000199996e7),
-          ("JAPAN", 4.5410175695400015e7)
-        ).sorted
+        com.nec.testing.ProductListEquivalenceCheck.listEq.areEqual(
+          ds.as[(String, Double)].collect().toList.sorted,
+          List(
+            ("INDONESIA", 5.5502041169699915e7),
+            ("VIETNAM", 5.529508699669991e7),
+            ("CHINA", 5.372449425660001e7),
+            ("INDIA", 5.2035512000199996e7),
+            ("JAPAN", 4.5410175695400015e7)
+          ).sorted
+        )
       )
     }
   }

--- a/src/test/scala/com/nec/ve/RDDSpec.scala
+++ b/src/test/scala/com/nec/ve/RDDSpec.scala
@@ -76,7 +76,7 @@ final class RDDSpec extends AnyFreeSpec with SparkAdditions with VeKernelInfra {
       vcbi
         .map(vcb => {
           println(vcb)
-          vcb
+          vcb.veColBatch
         })
         .map(_.toArrowColumnarBatch())
         .map(cb => cb.column(0).getArrowValueVector)

--- a/tests/tpchbench/src/main/scala/sparkcyclone/tpch/TPCHBenchmark.scala
+++ b/tests/tpchbench/src/main/scala/sparkcyclone/tpch/TPCHBenchmark.scala
@@ -306,7 +306,9 @@ object TPCHBenchmark extends SparkSessionWrapper {
       order by l_returnflag, l_linestatus
     """
 
-    sparkSession.sql(sql).limit(1).collect()
+    val ds = sparkSession.sql(sql).limit(1)
+    println(ds.queryExecution.executedPlan)
+    ds.collect()
   }
 
   def query2(sparkSession: SparkSession): Array[_] = {


### PR DESCRIPTION
To remove any data cached on the VE upon Executor shutdown.

Change `  var CleanUpCache: Boolean = true` to `false` in order to disable this in case causes issues.

Also, enabled the rough double matching for some other queries.

