### PR TITLE
Add try/catch to TPCHBenchmark.

### DIFF
--- a/tests/tpchbench/src/main/scala/sparkcyclone/tpch/TPCHBenchmark.scala
+++ b/tests/tpchbench/src/main/scala/sparkcyclone/tpch/TPCHBenchmark.scala
@@ -270,8 +270,12 @@ object TPCHBenchmark extends SparkSessionWrapper {
     }
 
     queries.foreach { case (query, i) =>
-      if (!toSkip.contains(i)) {
+      try {
         benchmark(i, query)
+      } catch {
+        case e: Exception =>
+          println(s"Error executing query $i")
+          e.printStackTrace()
       }
     }
   }


### PR DESCRIPTION
So we can get a clearer picture of how many queries are affected by a change.