### PR TITLE
Improvements in benchmark runner

### DIFF
--- a/.github/workflows/benchmark-collector.yml
+++ b/.github/workflows/benchmark-collector.yml
@@ -60,11 +60,7 @@ jobs:
         run: sbt "tpcbench-run/run --query=${{ github.event.inputs.query }} --scale=${{ github.event.inputs.scale }}"
         if: success()
 
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
-
       - name: Copying to sparkcyclone.io
         if: always()
-        run: rsync -r -v tpcbench-run/target/tpc-html/ egonzalez@xpressai.jp:/var/www/sparkcyclone.io/tpc-html/b-${{ steps.date.outputs.date }}
+        run: rsync -r -v tpcbench-run/target/tpc-html/ egonzalez@xpressai.jp:/var/www/sparkcyclone.io/tpc-html/summary
 

--- a/.github/workflows/benchmark-collector.yml
+++ b/.github/workflows/benchmark-collector.yml
@@ -36,6 +36,7 @@ on:
           - 20
           - 21
           - 22
+          - all
 
 jobs:
   build:

--- a/.github/workflows/benchmark-collector.yml
+++ b/.github/workflows/benchmark-collector.yml
@@ -9,13 +9,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Check User
         run: whoami
-        
+
       - name: Check Path
         run: pwd
-        
+
       - name: Check Access to VE
         run: /opt/nec/ve/bin/vecmd info
 
@@ -25,4 +25,12 @@ jobs:
       - name: Run TPC-H@1
         run: sbt tpcbench-run/run
         if: success()
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
+
+      - name: Copying to sparkcyclone.io
+        if: always()
+        run: rsync -r -v tpcbench-run/target/tpc-html/ egonzalez@xpressai.jp:/var/www/sparkcyclone.io/tpc-html/b-${{ steps.date.outputs.date }}
 

--- a/build.sbt
+++ b/build.sbt
@@ -388,8 +388,8 @@ lazy val `tpcbench-run` = project
   .settings(
     libraryDependencies ++= Seq(
       "org.xerial" % "sqlite-jdbc" % "3.36.0.3",
-      "org.tpolecat" %% "doobie-core" % "1.0.0-M5",
-      "org.tpolecat" %% "doobie-hikari" % "1.0.0-M5",
+      "org.tpolecat" %% "doobie-core" % "1.0.0-RC1",
+      "org.tpolecat" %% "doobie-hikari" % "1.0.0-RC1",
       "org.scalatest" %% "scalatest" % "3.2.10" % Test,
       "io.circe" %% "circe-literal" % "0.14.1",
       "io.circe" %% "circe-generic" % "0.14.1",
@@ -399,6 +399,7 @@ lazy val `tpcbench-run` = project
       "org.http4s" %% "http4s-dsl" % "0.23.7",
       "org.apache.commons" % "commons-lang3" % "3.10",
       "org.http4s" %% "http4s-blaze-client" % "0.23.7",
+      "com.lihaoyi" %% "scalatags" % "0.11.0",
       "com.eed3si9n.expecty" %% "expecty" % "0.15.4" % Test
     ),
     reStart / envVars += "PACKAGE" -> (tpchbench / Compile / _root_.sbt.Keys.`package`).value.absolutePath,

--- a/tpcbench-run/src/main/scala/sc/RunDatabase.scala
+++ b/tpcbench-run/src/main/scala/sc/RunDatabase.scala
@@ -108,8 +108,6 @@ object RunDatabase {
           `class` := "pure-table-striped pure-table pure-table-horizontal",
           thead(tr(columns.map(col => th(col)))),
           tbody(data.map { row =>
-            println(row.lift(columns.indexOf("succeeded")))
-
             tr(
               if (row(columns.indexOf("succeeded")).contains("false")) (`class` := "failed")
               else (),

--- a/tpcbench-run/src/main/scala/sc/RunDatabase.scala
+++ b/tpcbench-run/src/main/scala/sc/RunDatabase.scala
@@ -105,7 +105,7 @@ object RunDatabase {
       ),
       body(
         table(
-          `class` := "pure-table-striped pure-table pure-table-horizontal",
+          `class` := "pure-table pure-table-horizontal",
           thead(tr(columns.map(col => th(col)))),
           tbody(data.map { row =>
             tr(

--- a/tpcbench-run/src/main/scala/sc/RunDatabase.scala
+++ b/tpcbench-run/src/main/scala/sc/RunDatabase.scala
@@ -129,7 +129,27 @@ object RunDatabase {
             tr(row.zip(columns).map {
               case (None, _)                       => td()
               case (Some(value), cn @ "timestamp") => td(`class` := cn, pre(value.toString))
-              case (Some(value), cn)               => td(`class` := cn, value.toString)
+              case (Some(value), cn @ "gitCommitSha") =>
+                td(
+                  `class` := cn,
+                  pre(
+                    a(
+                      target := "_blank",
+                      href := s"https://github.com/XpressAI/SparkCyclone/commit/${value}",
+                      s"${value}"
+                    )
+                  )
+                )
+              case (Some(value), cn) if value.toString.startsWith("http") =>
+                td(
+                  `class` := cn,
+                  a(
+                    href := value.toString,
+                    target := "_blank",
+                    value.toString.replaceAllLiterally("http://", "")
+                  )
+                )
+              case (Some(value), cn) => td(`class` := cn, value.toString)
             })
           })
         )

--- a/tpcbench-run/src/main/scala/sc/RunDatabase.scala
+++ b/tpcbench-run/src/main/scala/sc/RunDatabase.scala
@@ -132,7 +132,7 @@ object RunDatabase {
           thead(tr(columns.map(col => th(col)))),
           tbody(data.map { row =>
             tr(
-              if (row(columns.indexOf("succeeded")).contains("false")) (`class` := "failed")
+              if (row.lift(columns.indexOf("succeeded")).contains("false")) (`class` := "failed")
               else (),
               row.zip(columns).map {
                 case (None, _)                       => td()

--- a/tpcbench-run/src/main/scala/sc/RunDatabase.scala
+++ b/tpcbench-run/src/main/scala/sc/RunDatabase.scala
@@ -99,7 +99,7 @@ object RunDatabase {
         raw("""<style>body {font-size:0.8em; }
               |td {vertical-align:top; }
               |.failed td {
-              |background: rgb(255,240,240);
+              |background: rgb(255,240,240) !important;
               |}
               |</style>""".stripMargin)
       ),

--- a/tpcbench-run/src/main/scala/sc/RunDatabase.scala
+++ b/tpcbench-run/src/main/scala/sc/RunDatabase.scala
@@ -129,39 +129,37 @@ object RunDatabase {
       body(
         table(
           `class` := "pure-table-striped pure-table pure-table-horizontal",
-          thead(
-            tr(
-              if (data(columns.indexOf("succeeded")).contains("false")) (`class` := "failed")
-              else (),
-              columns.map(col => th(col))
-            )
-          ),
+          thead(tr(columns.map(col => th(col)))),
           tbody(data.map { row =>
-            tr(row.zip(columns).map {
-              case (None, _)                       => td()
-              case (Some(value), cn @ "timestamp") => td(`class` := cn, pre(value.toString))
-              case (Some(value), cn @ "gitCommitSha") =>
-                td(
-                  `class` := cn,
-                  pre(
-                    a(
-                      target := "_blank",
-                      href := s"https://github.com/XpressAI/SparkCyclone/commit/${value}",
-                      s"${value}"
+            tr(
+              if (row(columns.indexOf("succeeded")).contains("false")) (`class` := "failed")
+              else (),
+              row.zip(columns).map {
+                case (None, _)                       => td()
+                case (Some(value), cn @ "timestamp") => td(`class` := cn, pre(value.toString))
+                case (Some(value), cn @ "gitCommitSha") =>
+                  td(
+                    `class` := cn,
+                    pre(
+                      a(
+                        target := "_blank",
+                        href := s"https://github.com/XpressAI/SparkCyclone/commit/${value}",
+                        s"${value}"
+                      )
                     )
                   )
-                )
-              case (Some(value), cn) if value.toString.startsWith("http") =>
-                td(
-                  `class` := cn,
-                  a(
-                    href := value.toString,
-                    target := "_blank",
-                    value.toString.replaceAllLiterally("http://", "")
+                case (Some(value), cn) if value.toString.startsWith("http") =>
+                  td(
+                    `class` := cn,
+                    a(
+                      href := value.toString,
+                      target := "_blank",
+                      value.toString.replaceAllLiterally("http://", "")
+                    )
                   )
-                )
-              case (Some(value), cn) => td(`class` := cn, value.toString)
-            })
+                case (Some(value), cn) => td(`class` := cn, value.toString)
+              }
+            )
           })
         )
       )

--- a/tpcbench-run/src/main/scala/sc/RunDatabase.scala
+++ b/tpcbench-run/src/main/scala/sc/RunDatabase.scala
@@ -119,15 +119,23 @@ object RunDatabase {
           """<link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/pure-min.css" integrity="sha384-Uu6IeWbM+gzNVXJcM9XV3SohHtmWE+3VGi496jvgX1jyvDTXfdK+rfZc8C1Aehk5" crossorigin="anonymous">"""
         ),
         raw("""<meta name="viewport" content="width=device-width, initial-scale=1">"""),
-        raw(
-          """<style>body {font-size:0.8em; }
-            |td {vertical-align:top; }
-            |</style>""".stripMargin)
+        raw("""<style>body {font-size:0.8em; }
+              |td {vertical-align:top; }
+              |.failed td {
+              |background: rgb(255,240,240);
+              |}
+              |</style>""".stripMargin)
       ),
       body(
         table(
           `class` := "pure-table-striped pure-table pure-table-horizontal",
-          thead(tr(columns.map(col => th(col)))),
+          thead(
+            tr(
+              if (data(columns.indexOf("succeeded")).contains("false")) (`class` := "failed")
+              else (),
+              columns.map(col => th(col))
+            )
+          ),
           tbody(data.map { row =>
             tr(row.zip(columns).map {
               case (None, _)                       => td()

--- a/tpcbench-run/src/main/scala/sc/RunDatabase.scala
+++ b/tpcbench-run/src/main/scala/sc/RunDatabase.scala
@@ -113,14 +113,23 @@ object RunDatabase {
   final case class ResultsInfo(columns: List[String], data: List[List[AnyRef]]) {
     import _root_.scalatags.Text.all._
     def toTable: Text.TypedTag[String] = html(
-      head(tag("title")("TPC Bench results")),
+      head(
+        tag("title")("TPC Bench results"),
+        raw(
+          """<link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/pure-min.css" integrity="sha384-Uu6IeWbM+gzNVXJcM9XV3SohHtmWE+3VGi496jvgX1jyvDTXfdK+rfZc8C1Aehk5" crossorigin="anonymous">"""
+        ),
+        raw("""<meta name="viewport" content="width=device-width, initial-scale=1">"""),
+        raw("""<style>body {font-size:0.8em; }</style>""".stripMargin)
+      ),
       body(
         table(
+          `class` := "pure-table-striped pure-table pure-table-horizontal",
           thead(tr(columns.map(col => th(col)))),
           tbody(data.map { row =>
-            tr(row.map {
-              case None        => td()
-              case Some(value) => td(value.toString)
+            tr(row.zip(columns).map {
+              case (None, _)                       => td()
+              case (Some(value), cn @ "timestamp") => td(`class` := cn, pre(value.toString))
+              case (Some(value), cn)               => td(`class` := cn, value.toString)
             })
           })
         )

--- a/tpcbench-run/src/main/scala/sc/RunDatabase.scala
+++ b/tpcbench-run/src/main/scala/sc/RunDatabase.scala
@@ -119,7 +119,10 @@ object RunDatabase {
           """<link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/pure-min.css" integrity="sha384-Uu6IeWbM+gzNVXJcM9XV3SohHtmWE+3VGi496jvgX1jyvDTXfdK+rfZc8C1Aehk5" crossorigin="anonymous">"""
         ),
         raw("""<meta name="viewport" content="width=device-width, initial-scale=1">"""),
-        raw("""<style>body {font-size:0.8em; }</style>""".stripMargin)
+        raw(
+          """<style>body {font-size:0.8em; }
+            |td {vertical-align:top; }
+            |</style>""".stripMargin)
       ),
       body(
         table(

--- a/tpcbench-run/src/main/scala/sc/RunDatabase.scala
+++ b/tpcbench-run/src/main/scala/sc/RunDatabase.scala
@@ -71,7 +71,7 @@ final case class RunDatabase(transactor: Transactor[IO], uri: String) {
     try {
       val statement = connection.createStatement()
       statement.setQueryTimeout(30)
-      val rs = statement.executeQuery("select * from run_result")
+      val rs = statement.executeQuery("select * from run_result order by timestamp desc")
       val cols = (1 to rs.getMetaData.getColumnCount)
         .map(idx => rs.getMetaData.getColumnLabel(idx))
         .toList

--- a/tpcbench-run/src/main/scala/sc/RunDatabase.scala
+++ b/tpcbench-run/src/main/scala/sc/RunDatabase.scala
@@ -158,7 +158,7 @@ object RunDatabase {
 
     def save: IO[Path] = IO
       .blocking {
-        val absPth = Paths.get("tpcbench-run/target/tpc-html/index.html").toAbsolutePath
+        val absPth = Paths.get("target/tpc-html/index.html").toAbsolutePath
         Files.createDirectories(absPth.getParent)
         Files.write(absPth, toTable.render.getBytes("UTF-8"))
       }

--- a/tpcbench-run/src/main/scala/sc/RunOptions.scala
+++ b/tpcbench-run/src/main/scala/sc/RunOptions.scala
@@ -191,11 +191,16 @@ object RunOptions {
   )
 
   lazy val Log4jFile: java.nio.file.Path = {
-    val tempFile = Files.createTempFile(
-      "log4j",
-      ".properties",
-      PosixFilePermissions.asFileAttribute(PosixPermissions)
-    )
+    val tempFile = {
+      if (scala.util.Properties.isWin)
+        Files.createTempFile("log4j", ".properties")
+      else
+        Files.createTempFile(
+          "log4j",
+          ".properties",
+          PosixFilePermissions.asFileAttribute(PosixPermissions)
+        )
+    }
     Files
       .write(
         tempFile,

--- a/tpcbench-run/src/main/scala/sc/RunOptions.scala
+++ b/tpcbench-run/src/main/scala/sc/RunOptions.scala
@@ -54,13 +54,13 @@ final case class RunOptions(
         k -> v
       }
       .collect {
-        case ("query", nqn)              => copy(queryNo = nqn.toInt)
-        case ("cyclone", nqn)            => copy(useCyclone = nqn == "on")
-        case ("scale", newScale)         => copy(scale = newScale)
-        case ("name", newName)           => copy(name = Some(newName))
-        case ("serializer", v)           => copy(serializerOn = v == "on")
-        case ("ve-log-debug", v)         => copy(veLogDebug = v == "on")
-        case ("kernel-directory", newkd) => copy(kernelDirectory = Some(newkd))
+        case ("query", nqn) if nqn.forall(Character.isDigit) => copy(queryNo = nqn.toInt)
+        case ("cyclone", nqn)                                => copy(useCyclone = nqn == "on")
+        case ("scale", newScale)                             => copy(scale = newScale)
+        case ("name", newName)                               => copy(name = Some(newName))
+        case ("serializer", v)                               => copy(serializerOn = v == "on")
+        case ("ve-log-debug", v)                             => copy(veLogDebug = v == "on")
+        case ("kernel-directory", newkd)                     => copy(kernelDirectory = Some(newkd))
       }
       .orElse {
         val extraStr = "--extra="

--- a/tpcbench-run/src/test/scala/sc/TpcBenchSpec.scala
+++ b/tpcbench-run/src/test/scala/sc/TpcBenchSpec.scala
@@ -45,7 +45,8 @@ final class TpcBenchSpec extends AnyFreeSpec {
     assert(res.columns.contains("aggregateOnVe"))
     assert(res.data.nonEmpty)
   }
-  "We can save results into a file" in {
+
+  "We can save results into a file" ignore {
     val path = rd.fetchResults.flatMap(_.save).unsafeRunSync()
     info(s"Path saved => ${path}")
   }

--- a/tpcbench-run/src/test/scala/sc/TpcBenchSpec.scala
+++ b/tpcbench-run/src/test/scala/sc/TpcBenchSpec.scala
@@ -45,4 +45,8 @@ final class TpcBenchSpec extends AnyFreeSpec {
     assert(res.columns.contains("aggregateOnVe"))
     assert(res.data.nonEmpty)
   }
+  "We can save results into a file" in {
+    val path = rd.fetchResults.flatMap(_.save).unsafeRunSync()
+    info(s"Path saved => ${path}")
+  }
 }

--- a/tpcbench-run/src/test/scala/sc/TpcBenchSpec.scala
+++ b/tpcbench-run/src/test/scala/sc/TpcBenchSpec.scala
@@ -31,7 +31,7 @@ final class TpcBenchSpec extends AnyFreeSpec {
     (rd.initialize *> rd.insert(
       RunOptions.default,
       RunResult(
-        succeeded = true,
+        succeeded = false,
         wallTime = 1,
         queryTime = 123,
         traceResults = "KK",
@@ -46,7 +46,7 @@ final class TpcBenchSpec extends AnyFreeSpec {
     assert(res.data.nonEmpty)
   }
 
-  "We can save results into a file" ignore {
+  "We can save results into a file" in {
     val path = rd.fetchResults.flatMap(_.save).unsafeRunSync()
     info(s"Path saved => ${path}")
   }


### PR DESCRIPTION
- Support `all`
- Save into an HTML file available at `/tpc-html/`summary/` on the website.