### PR TITLE
Add FailFast option

### DIFF
--- a/.github/workflows/benchmark-collector-all.yml
+++ b/.github/workflows/benchmark-collector-all.yml
@@ -2,6 +2,7 @@
 name: "TPC-H Central All-Runner"
 env:
   INPUT_extra: "${{ github.event.inputs.extra }}"
+  INPUT_fail-fast: "${{ github.event.inputs.fail-fast }}"
   INPUT_pass-through-project: "${{ github.event.inputs.pass-through-project }}"
   INPUT_scale: "${{ github.event.inputs.scale }}"
   INPUT_serializer: "${{ github.event.inputs.serializer }}"
@@ -13,6 +14,10 @@ env:
       extra:
         type: "input"
         description: "Extra command line arguments to add to Spark"
+      fail-fast:
+        type: "boolean"
+        description: "Fail Fast"
+        default: "true"
       pass-through-project:
         type: "boolean"
         description: "Pass through in projection"

--- a/.github/workflows/benchmark-collector.yml
+++ b/.github/workflows/benchmark-collector.yml
@@ -2,6 +2,7 @@
 name: "TPC-H Central runner"
 env:
   INPUT_extra: "${{ github.event.inputs.extra }}"
+  INPUT_fail-fast: "${{ github.event.inputs.fail-fast }}"
   INPUT_pass-through-project: "${{ github.event.inputs.pass-through-project }}"
   INPUT_query: "${{ github.event.inputs.query }}"
   INPUT_scale: "${{ github.event.inputs.scale }}"
@@ -14,6 +15,10 @@ env:
       extra:
         type: "input"
         description: "Extra command line arguments to add to Spark"
+      fail-fast:
+        type: "boolean"
+        description: "Fail Fast"
+        default: "true"
       pass-through-project:
         type: "boolean"
         description: "Pass through in projection"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,22 +11,14 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
-
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      
-      - name: Check User
-        run: whoami
-        
-      - name: Check Path
-        run: pwd
-        
-      - name: Check Access to VE
-        run: /opt/nec/ve/bin/vecmd info
-
-      - name: Branch Ref
-        run: echo ${GITHUB_REF#refs/heads/}
-
+      - name: Coursier cache
+        uses: coursier/cache-action@v6
+      - uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: temurin
       - name: Run unit tests in the key projects
-        run: sbt test "tpcbench-run / test" "tracing / test"
+        run: sbt -v test "tpcbench-run / test" "tracing / test"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
       - main
       - verdd
       - 'cit/**'
+      - 'ci/**'
 
 jobs:
   build:

--- a/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
+++ b/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
@@ -20,7 +20,7 @@
 package com.nec.spark
 
 import com.nec.arrow.VeArrowNativeInterface
-import com.nec.ve.VeColBatch.VeColVectorSource
+import com.nec.ve.VeColBatch.{VeColVector, VeColVectorSource}
 import org.bytedeco.veoffload.global.veo
 import org.bytedeco.veoffload.veo_proc_handle
 
@@ -70,7 +70,7 @@ object SparkCycloneExecutorPlugin extends LazyLogging {
    *
    * *
    */
-  var closeAutomatically: Boolean = false
+  var CloseAutomatically: Boolean = true
   def closeProcAndCtx(): Unit = {
     if (_veo_proc != null) {
       veo.veo_proc_destroy(_veo_proc)
@@ -118,15 +118,29 @@ object SparkCycloneExecutorPlugin extends LazyLogging {
   @transient val batchCache: scala.collection.mutable.Set[VeColBatch] =
     scala.collection.mutable.Set.empty
 
+  @transient val colCache: scala.collection.mutable.Set[VeColVector] =
+    scala.collection.mutable.Set.empty
+
   def cleanCache(): Unit = {
     batchCache.toList.foreach { colBatch =>
       batchCache.remove(colBatch)
-      colBatch.cols.foreach(_.free())
+      colBatch.cols.foreach(freeCol)
+    }
+  }
+
+  def freeCol(col: VeColVector): Unit = {
+    if (colCache.contains(col)) {
+      logger.debug(s"Freeing column ${col}... in ${source}")
+      colCache.remove(col)
+      col.free()
+    } else {
+      logger.warn(s"Trying to free a free column ${col} in ${source}")
     }
   }
 
   def register(cb: VeColBatch): Unit = {
     batchCache.add(cb)
+    cb.cols.foreach(colCache.add)
   }
 
   var CleanUpCache: Boolean = true
@@ -182,7 +196,7 @@ class SparkCycloneExecutorPlugin extends ExecutorPlugin with Logging {
     }
 
     import com.nec.spark.SparkCycloneExecutorPlugin._
-    if (closeAutomatically) {
+    if (CloseAutomatically) {
       logInfo(s"Closing process: ${_veo_proc}")
       closeProcAndCtx()
     }

--- a/src/main/scala/com/nec/spark/planning/SupportsVeColBatch.scala
+++ b/src/main/scala/com/nec/spark/planning/SupportsVeColBatch.scala
@@ -1,5 +1,6 @@
 package com.nec.spark.planning
 
+import com.nec.spark.SparkCycloneExecutorPlugin.cleanUpIfNotCached
 import com.nec.spark.planning.SupportsVeColBatch.DataCleanup
 import com.nec.ve.VeColBatch.VeColVectorSource
 import com.nec.ve.{VeColBatch, VeProcess}
@@ -10,7 +11,9 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 object SupportsVeColBatch {
   sealed trait DataCleanup {
-    def cleanup(veColBatch: VeColBatch)(implicit veProcess: VeProcess, processId: VeColVectorSource): Unit
+    def cleanup(
+      veColBatch: VeColBatch
+    )(implicit veProcess: VeProcess, processId: VeColVectorSource): Unit
   }
   object DataCleanup {
     case object NoCleanup extends DataCleanup {
@@ -22,7 +25,7 @@ object SupportsVeColBatch {
       override def cleanup(
         veColBatch: VeColBatch
       )(implicit veProcess: VeProcess, processId: VeColVectorSource): Unit =
-        veColBatch.cols.filter(_.source == processId).foreach(_.free())
+        cleanUpIfNotCached(veColBatch)
     }
 
   }

--- a/src/main/scala/com/nec/spark/planning/VeCachedBatchSerializer.scala
+++ b/src/main/scala/com/nec/spark/planning/VeCachedBatchSerializer.scala
@@ -61,8 +61,6 @@ class VeCachedBatchSerializer extends org.apache.spark.sql.columnar.CachedBatchS
       VeColBatchConverters.getNumRows(input.sparkContext, conf)
     )
     .map { ui =>
-      if (!ui.isReferenced) SparkCycloneExecutorPlugin.register(ui.veColBatch)
-
       CachedVeBatch(ui.veColBatch)
     }
 

--- a/src/main/scala/com/nec/spark/planning/VeColColumnarVector.scala
+++ b/src/main/scala/com/nec/spark/planning/VeColColumnarVector.scala
@@ -1,5 +1,7 @@
 package com.nec.spark.planning
 
+import com.nec.spark.SparkCycloneExecutorPlugin
+import com.nec.spark.SparkCycloneExecutorPlugin.source
 import com.nec.ve.VeColBatch.VeColVector
 import org.apache.spark.sql.types.{DataType, Decimal}
 import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarArray, ColumnarMap}
@@ -15,7 +17,7 @@ final class VeColColumnarVector(val veColVector: VeColVector, dataType: DataType
   extends ColumnVector(dataType) {
   import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
 
-  override def close(): Unit = veColVector.free()
+  override def close(): Unit = SparkCycloneExecutorPlugin.freeCol(veColVector)
 
   override def hasNull: Boolean = VeColColumnarVector.unsupported()
 

--- a/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
+++ b/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
@@ -3,13 +3,15 @@ package com.nec.spark.planning
 import org.apache.spark.SparkConf
 
 final case class VeRewriteStrategyOptions(
-                                           aggregateOnVe: Boolean,
-                                           enableVeSorting: Boolean,
-                                           projectOnVe: Boolean,
-                                           filterOnVe: Boolean,
-                                           exchangeOnVe: Boolean,
-                                           passThroughProject: Boolean
-)
+  aggregateOnVe: Boolean,
+  enableVeSorting: Boolean,
+  projectOnVe: Boolean,
+  filterOnVe: Boolean,
+  exchangeOnVe: Boolean,
+  passThroughProject: Boolean,
+  failFast: Boolean
+) {}
+
 object VeRewriteStrategyOptions {
   //noinspection MapGetOrElseBoolean
   def fromConfig(sparkConf: SparkConf): VeRewriteStrategyOptions = {
@@ -37,7 +39,11 @@ object VeRewriteStrategyOptions {
       passThroughProject = sparkConf
         .getOption(key = "spark.com.nec.spark.pass-through-project")
         .map(_.toBoolean)
-        .getOrElse(default.passThroughProject)
+        .getOrElse(default.passThroughProject),
+      failFast = sparkConf
+        .getOption(key = "spark.com.nec.spark.fail-fast")
+        .map(_.toBoolean)
+        .getOrElse(default.failFast)
     )
   }
 
@@ -48,6 +54,7 @@ object VeRewriteStrategyOptions {
       filterOnVe = true,
       aggregateOnVe = true,
       exchangeOnVe = true,
-      passThroughProject = false
+      passThroughProject = false,
+      failFast = false
     )
 }

--- a/src/main/scala/com/nec/spark/planning/plans/VectorEngineToSparkPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VectorEngineToSparkPlan.scala
@@ -2,6 +2,7 @@ package com.nec.spark.planning.plans
 
 import com.nec.cmake.ScalaTcpDebug
 import com.nec.spark.SparkCycloneExecutorPlugin
+import com.nec.spark.SparkCycloneExecutorPlugin.cleanUpIfNotCached
 import com.nec.spark.planning.ArrowBatchToUnsafeRows.mapBatchToRow
 import com.nec.spark.planning.{SupportsVeColBatch, Tracer}
 import com.nec.ve.VeKernelCompiler.VeCompilerConfig
@@ -54,8 +55,7 @@ case class VectorEngineToSparkPlan(override val child: SparkPlan)
                   val res = veColBatch.toArrowColumnarBatch()
                   logger.debug(s"Finished mapping ${veColBatch}")
                   res
-                }
-                finally veColBatch.cols.foreach(_.free())
+                } finally cleanUpIfNotCached(veColBatch)
               }
           }
       }

--- a/src/main/scala/com/nec/ve/VeColBatch.scala
+++ b/src/main/scala/com/nec/ve/VeColBatch.scala
@@ -348,8 +348,13 @@ object VeColBatch {
       case other => sys.error(s"Not supported for conversion to arrow vector: $other")
     }
 
-    def free()(implicit veProcess: VeProcess): Unit =
+    def free()(implicit veProcess: VeProcess, veColVectorSource: VeColVectorSource): Unit = {
+      require(
+        veColVectorSource == source,
+        s"Intended to `free` in ${source}, but got ${veColVectorSource} context."
+      )
       (containerLocation :: bufferLocations).foreach(veProcess.free)
+    }
 
   }
 

--- a/src/test/scala/com/nec/spark/BenchTestingPossibilities.scala
+++ b/src/test/scala/com/nec/spark/BenchTestingPossibilities.scala
@@ -229,8 +229,6 @@ object BenchTestingPossibilities extends LazyLogging {
 
 final class BenchTestingPossibilities extends AnyFreeSpec with BenchTestAdditions {
 
-  VERewriteStrategy.failFast = true
-
   /** TODO We could also generate Spark plan details from here for easy cross-referencing, as well as codegen */
   BenchTestingPossibilities.possibilities.filter(_.testingTarget.isPlainSpark).foreach(runTestCase)
 

--- a/src/test/scala/com/nec/spark/SparkAdditions.scala
+++ b/src/test/scala/com/nec/spark/SparkAdditions.scala
@@ -55,10 +55,10 @@ trait SparkAdditions {
   protected def withSparkSession2[T](
     configure: SparkSession.Builder => SparkSession.Builder
   )(f: SparkSession => T): T = {
-    VERewriteStrategy.failFast = true
     val conf = new SparkConf()
     conf.setMaster("local")
     conf.setAppName("local-test")
+    conf.set("spark.com.nec.spark.fail-fast", "true")
     // conf.set("spark.ui.enabled", "false")
     val sparkSession = configure(SparkSession.builder().config(conf)).getOrCreate()
     try f(sparkSession)

--- a/src/test/scala/com/nec/tpc/TPCHSqlCSpec.scala
+++ b/src/test/scala/com/nec/tpc/TPCHSqlCSpec.scala
@@ -242,7 +242,7 @@ abstract class TPCHSqlCSpec
   def withTpchViews[T](
     appName: String,
     configure: SparkSession.Builder => SparkSession.Builder,
-    ignore: Boolean = false
+    ignore: Boolean = true
   )(f: SparkSession => T): Unit =
     if (ignore) { appName ignore {} }
     else {

--- a/src/test/scala/com/nec/tpc/TPCHSqlCSpec.scala
+++ b/src/test/scala/com/nec/tpc/TPCHSqlCSpec.scala
@@ -242,7 +242,7 @@ abstract class TPCHSqlCSpec
   def withTpchViews[T](
     appName: String,
     configure: SparkSession.Builder => SparkSession.Builder,
-    ignore: Boolean = true
+    ignore: Boolean = false
   )(f: SparkSession => T): Unit =
     if (ignore) { appName ignore {} }
     else {

--- a/src/test/scala/com/nec/tpc/TPCHVESqlSpec.scala
+++ b/src/test/scala/com/nec/tpc/TPCHVESqlSpec.scala
@@ -20,7 +20,7 @@
 package com.nec.tpc
 
 import com.nec.spark.LocalVeoExtension.compilerRule
-import com.nec.spark.planning.{VERewriteStrategy, VeColumnarRule}
+import com.nec.spark.planning.{VERewriteStrategy, VeColumnarRule, VeRewriteStrategyOptions}
 import com.nec.spark.{AuroraSqlPlugin, SparkCycloneExecutorPlugin}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf.{CODEGEN_FALLBACK, WHOLESTAGE_CODEGEN_ENABLED}
@@ -35,7 +35,7 @@ object TPCHVESqlSpec {
       .config(key = WHOLESTAGE_CODEGEN_ENABLED.key, value = false)
       .config(key = "spark.sql.codegen.comments", value = true)
       .config(
-        key = "spark.sql.cache.serializer?",
+        key = "spark.sql.cache.serializer",
         value = "com.nec.spark.planning.VeCachedBatchSerializer"
       )
       .config(key = "spark.ui.enabled", value = true)
@@ -44,8 +44,7 @@ object TPCHVESqlSpec {
       .config(key = "spark.plugins", value = classOf[AuroraSqlPlugin].getCanonicalName)
       .withExtensions { sse =>
         sse.injectPlannerStrategy(_ => {
-          VERewriteStrategy.failFast = false
-          new VERewriteStrategy()
+          new VERewriteStrategy(VeRewriteStrategyOptions.default.copy(failFast = true))
         })
         sse.injectColumnar(compilerRule)
         sse.injectColumnar(_ => new VeColumnarRule)

--- a/src/test/scala/com/nec/tpc/TPCHVESqlSpec.scala
+++ b/src/test/scala/com/nec/tpc/TPCHVESqlSpec.scala
@@ -20,6 +20,7 @@
 package com.nec.tpc
 
 import com.nec.spark.LocalVeoExtension.compilerRule
+import com.nec.spark.SparkCycloneExecutorPlugin.CloseAutomatically
 import com.nec.spark.planning.{VERewriteStrategy, VeColumnarRule, VeRewriteStrategyOptions}
 import com.nec.spark.{AuroraSqlPlugin, SparkCycloneExecutorPlugin}
 import org.apache.spark.sql.SparkSession
@@ -64,8 +65,8 @@ final class TPCHVESqlSpec extends TPCHSqlCSpec with TimeLimitedTests {
   }
 
   override protected def beforeAll(configMap: ConfigMap): Unit = {
-
-    //SparkCycloneExecutorPlugin._veo_proc = veo.veo_proc_create(-1)
+    // reuse the process
+    CloseAutomatically = false
 
     val dbGenFile = new File("src/test/resources/dbgen/dbgen")
     if (!dbGenFile.exists()) {

--- a/src/test/scala/com/nec/tpc/TPCHVESqlSpec.scala
+++ b/src/test/scala/com/nec/tpc/TPCHVESqlSpec.scala
@@ -37,12 +37,11 @@ object TPCHVESqlSpec {
       .config(key = WHOLESTAGE_CODEGEN_ENABLED.key, value = false)
       .config(key = "spark.sql.codegen.comments", value = true)
       .config(
-        key = "spark.sql.cache.serializer?",
+        key = "spark.sql.cache.serializer",
         value = "com.nec.spark.planning.VeCachedBatchSerializer"
       )
       .config(key = "spark.ui.enabled", value = true)
       .config(key = "com.nec.spark.ve.columnBatchSize", value = "500000")
-      .config(key = "spark.com.nec.spark.ncc.debug", value = "false")
       .config(key = "spark.plugins", value = classOf[AuroraSqlPlugin].getCanonicalName)
       .withExtensions { sse =>
         sse.injectPlannerStrategy(_ => {

--- a/src/test/scala/com/nec/tpc/TPCHVESqlSpec.scala
+++ b/src/test/scala/com/nec/tpc/TPCHVESqlSpec.scala
@@ -25,6 +25,8 @@ import com.nec.spark.{AuroraSqlPlugin, SparkCycloneExecutorPlugin}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf.{CODEGEN_FALLBACK, WHOLESTAGE_CODEGEN_ENABLED}
 import org.scalatest.ConfigMap
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.{Minutes, Span}
 
 import java.io.File
 
@@ -53,9 +55,7 @@ object TPCHVESqlSpec {
 
 }
 
-final class TPCHVESqlSpec extends TPCHSqlCSpec {
-
-  private var initialized = false
+final class TPCHVESqlSpec extends TPCHSqlCSpec with TimeLimitedTests {
 
   override def configuration: SparkSession.Builder => SparkSession.Builder =
     TPCHVESqlSpec.VeConfiguration
@@ -80,5 +80,7 @@ final class TPCHVESqlSpec extends TPCHSqlCSpec {
 
     super.beforeAll(configMap)
   }
+
+  override def timeLimit: Span = Span(5, Minutes)
 
 }

--- a/src/test/scala/com/nec/tpc/TPCHVESqlSpec.scala
+++ b/src/test/scala/com/nec/tpc/TPCHVESqlSpec.scala
@@ -37,7 +37,7 @@ object TPCHVESqlSpec {
       .config(key = WHOLESTAGE_CODEGEN_ENABLED.key, value = false)
       .config(key = "spark.sql.codegen.comments", value = true)
       .config(
-        key = "spark.sql.cache.serializer",
+        key = "spark.sql.cache.serializer?",
         value = "com.nec.spark.planning.VeCachedBatchSerializer"
       )
       .config(key = "spark.ui.enabled", value = true)

--- a/src/test/scala/com/nec/ve/RDDSpec.scala
+++ b/src/test/scala/com/nec/ve/RDDSpec.scala
@@ -30,7 +30,7 @@ final class RDDSpec extends AnyFreeSpec with SparkAdditions with VeKernelInfra {
   "A dataset from ColumnarBatches can be read via the carrier columnar vector" in withSparkSession2(
     DynamicVeSqlExpressionEvaluationSpec.VeConfiguration
   ) { sparkSession =>
-    implicit val source = VeColVectorSource(
+    implicit val source: VeColVectorSource = VeColVectorSource(
       s"Process ${SparkCycloneExecutorPlugin._veo_proc}, executor ${SparkEnv.get.executorId}"
     )
 
@@ -175,6 +175,7 @@ object RDDSpec {
               finally arrowVec.close()
             })
             .flatMap(veColVector => {
+              import SparkCycloneExecutorPlugin.source
               try {
                 val ref = veProc.loadLibrary(java.nio.file.Paths.get(pathStr))
 

--- a/tpcbench-run/src/main/scala/sc/GitHubInput.scala
+++ b/tpcbench-run/src/main/scala/sc/GitHubInput.scala
@@ -19,7 +19,8 @@ object GitHubInput {
     "serializer" -> OnOrOff("Use Serializer", default = true),
     "ve-log-debug" -> OnOrOff("Debug VE logs", default = false),
     "extra" -> Input("Extra command line arguments to add to Spark"),
-    "pass-through-project" -> OnOrOff("Pass through in projection", default = false)
+    "pass-through-project" -> OnOrOff("Pass through in projection", default = false),
+    "fail-fast" -> OnOrOff("Fail Fast", default = true)
   )
 
   final case class Choice(description: String, default: Option[String], options: List[String])

--- a/tpcbench-run/src/main/scala/sc/RunOptions.scala
+++ b/tpcbench-run/src/main/scala/sc/RunOptions.scala
@@ -31,6 +31,7 @@ final case class RunOptions(
   projectOnVe: Boolean,
   filterOnVe: Boolean,
   passThroughProject: Boolean,
+  failFast: Boolean,
   exchangeOnVe: Boolean
 ) {
 
@@ -62,7 +63,8 @@ final case class RunOptions(
       ("spark.com.nec.spark.pass-through-project", passThroughProject),
       ("spark.com.nec.spark.project-on-ve", projectOnVe),
       ("spark.com.nec.spark.filter-on-ve", filterOnVe),
-      ("spark.com.nec.spark.exchange-on-ve", exchangeOnVe)
+      ("spark.com.nec.spark.exchange-on-ve", exchangeOnVe),
+      ("spark.com.nec.spark.fail-fast", failFast)
     ).map { case (k, v) => (k, v.toString) }
   }
 
@@ -84,6 +86,7 @@ final case class RunOptions(
       case ("serializer", v)                               => copy(serializerOn = v == "on" || v == "true")
       case ("ve-log-debug", v)                             => copy(veLogDebug = v == "on" || v == "true")
       case ("pass-through-project", v)                     => copy(passThroughProject = v == "on")
+      case ("fail-fast", v)                                => copy(failFast = v == "on")
       case ("kernel-directory", newkd)                     => copy(kernelDirectory = Some(newkd))
     }
   }
@@ -216,7 +219,8 @@ object RunOptions {
     exchangeOnVe = true,
     codeDebug = false,
     useCyclone = true,
-    passThroughProject = false
+    passThroughProject = false,
+    failFast = true
   )
 
   lazy val Log4jFile: java.nio.file.Path = {

--- a/tpcbench-run/src/main/scala/sc/RunOptions.scala
+++ b/tpcbench-run/src/main/scala/sc/RunOptions.scala
@@ -85,8 +85,8 @@ final case class RunOptions(
       case ("extra", e)                                    => includeExtra(e)
       case ("serializer", v)                               => copy(serializerOn = v == "on" || v == "true")
       case ("ve-log-debug", v)                             => copy(veLogDebug = v == "on" || v == "true")
-      case ("pass-through-project", v)                     => copy(passThroughProject = v == "on")
-      case ("fail-fast", v)                                => copy(failFast = v == "on")
+      case ("pass-through-project", v)                     => copy(passThroughProject = v == "on" || v == "true")
+      case ("fail-fast", v)                                => copy(failFast = v == "on" || v == "true")
       case ("kernel-directory", newkd)                     => copy(kernelDirectory = Some(newkd))
     }
   }


### PR DESCRIPTION
- By default, in the plugin it is false
- When running in GitHub flows, it is `true`
- When running TPC correctness tests, it is `true`
- Fix issues with regards to caching correctness and clean-up correctness. We were sometimes trying to reuse cached data that got free'd.