### PR TITLE
Add more automation in terms of GitHub actions

### DIFF
--- a/.github/workflows/unittests-cmake.yml
+++ b/.github/workflows/unittests-cmake.yml
@@ -1,4 +1,4 @@
-name: TPC (VE)
+name: Unit tests (CMake)
 
 on:
   workflow_dispatch:
@@ -32,7 +32,7 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
 
       - name: Run Vector Engine Tests
-        run: SBT_OPTS="-Xmx16g" sbt "set debugToHtml := true" "Tpc / testOnly *TPCHVESqlSpec"
+        run: SBT_OPTS="-Xmx16g" sbt "set debugToHtml := true" "CMake / testQuick"
 
       - name: Copying to sparkcyclone.io
         if: always()

--- a/.github/workflows/unittests-ve.yml
+++ b/.github/workflows/unittests-ve.yml
@@ -1,4 +1,4 @@
-name: TPC (VE)
+name: Unit tests (Vector Engine)
 
 on:
   workflow_dispatch:
@@ -32,7 +32,7 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
 
       - name: Run Vector Engine Tests
-        run: SBT_OPTS="-Xmx16g" sbt "set debugToHtml := true" "Tpc / testOnly *TPCHVESqlSpec"
+        run: SBT_OPTS="-Xmx16g" sbt "set debugToHtml := true" "VectorEngine / testQuick"
 
       - name: Copying to sparkcyclone.io
         if: always()

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Unit tests (JVM)
 
 on:
   workflow_dispatch:
@@ -9,7 +9,9 @@ on:
       - verdd
       - 'cit/**'
       - 'ci/**'
-
+  pull_request:
+    types:
+      - ready_for_review
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
- When a PR is ready for review, automatically run tpc, cmake, and vectorengine and plain JVM unit tests.
We should work through Draft PR first

This should catch and expose any issues much more rapidly.

![image](https://user-images.githubusercontent.com/52247468/149588710-475ef1c8-d853-4631-81c2-fce0ef4059ce.png)
