### PR TITLE
wip

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/cyclone.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone.cc
@@ -230,3 +230,13 @@ std::vector<size_t> filter_words_dict(frovedis::words &input_words, frovedis::wo
 
     return new_indices;
 }
+
+void debug_nullable_varchar_vector(const nullable_varchar_vector *v) {
+    std::cout << "[ ";
+    for (auto i = 0; i < v->count; i++) {
+        if (check_valid(v->validityBuffer, i)) {
+            std::cout << std::string(v->data + v->offsets[i], v->offsets[i+1] - v->offsets[i]) << ", ";
+        }
+    }
+    std::cout << "]\n";
+}

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone.hpp
@@ -64,3 +64,4 @@ std::vector<size_t> idx_to_std(nullable_int_vector *idx);
 void print_indices(std::vector<size_t> vec);
 frovedis::words filter_words(frovedis::words &in_words, std::vector<size_t> to_select);
 std::vector<size_t> filter_words_dict(frovedis::words &input_words, frovedis::words &filtering_set);
+void debug_nullable_varchar_vector(const nullable_varchar_vector *v);

--- a/src/main/scala/com/nec/spark/agile/GroupingCodeGenerator.scala
+++ b/src/main/scala/com/nec/spark/agile/GroupingCodeGenerator.scala
@@ -59,7 +59,7 @@ final case class GroupingCodeGenerator(
           "}"
         )
       },
-      CodeLines.debugHere,
+      // CodeLines.debugHere,
       s"for ( long i = 0; i < ${count}; i++ ) {",
       CodeLines
         .from(
@@ -74,7 +74,7 @@ final case class GroupingCodeGenerator(
         )
         .indented,
       s"}",
-      CodeLines.debugHere,
+      // CodeLines.debugHere,
       tupleTypes.zipWithIndex.reverse.collect { case (t, idx) =>
         CodeLines.from(
           s"{",
@@ -102,7 +102,7 @@ final case class GroupingCodeGenerator(
         )
         .indented,
       s"}",
-      CodeLines.debugHere,
+      // CodeLines.debugHere,
       s"std::vector<size_t> ${groupsIndicesName} = frovedis::set_separate(${groupingVecName});",
       s"int ${groupsCountOutName} = ${groupsIndicesName}.size() - 1;"
     )

--- a/src/main/scala/com/nec/spark/agile/groupby/GroupByPartialGenerator.scala
+++ b/src/main/scala/com/nec/spark/agile/groupby/GroupByPartialGenerator.scala
@@ -70,19 +70,18 @@ final case class GroupByPartialGenerator(
         TcpDebug.conditional.createSock,
         CodeLines
           .from(
-            performGrouping(count = s"${inputs.head.name}->count")
-              .time("Grouping"),
-            stringVectorComputations.map(_.computeVector).time("Compute String vectors"),
-            computeGroupingKeysPerGroup.block.time("Compute grouping keys per group"),
+            performGrouping(count = s"${inputs.head.name}->count")//.time("Grouping"),
+            stringVectorComputations.map(_.computeVector),//.time("Compute String vectors"),
+            computeGroupingKeysPerGroup.block,//.time("Compute grouping keys per group"),
             computedProjections.map { case (sp, e) =>
-              computeProjectionsPerGroup(sp, e).time(s"Compute projection ${sp.name}")
+              computeProjectionsPerGroup(sp, e)//.time(s"Compute projection ${sp.name}")
             },
             computedAggregates.map { case (a, ag) =>
-              computeAggregatePartialsPerGroup(a, ag).time(s"Compute aggregate ${a.name}")
+              computeAggregatePartialsPerGroup(a, ag)//.time(s"Compute aggregate ${a.name}")
             },
-            stringVectorComputations.map(_.deallocData).time("Compute String vectors")
-          )
-          .time("Execution of Partial"),
+            stringVectorComputations.map(_.deallocData)//.time("Compute String vectors")
+          ),
+          //.time("Execution of Partial"),
         TcpDebug.conditional.close
       )
     )

--- a/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
+++ b/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
@@ -413,6 +413,8 @@ final case class VERewriteStrategy(
               )
             }.toList
 
+          println(s"GROUPING EXPRESSIONS: ${groupingExpressions}")
+
           val referenceReplacer =
             SparkExpressionToCExpression.referenceReplacer(
               prefix = InputPrefix,

--- a/src/test/scala/com/nec/spark/SparkAdditions.scala
+++ b/src/test/scala/com/nec/spark/SparkAdditions.scala
@@ -59,6 +59,8 @@ trait SparkAdditions {
     conf.setMaster("local")
     conf.setAppName("local-test")
     conf.set("spark.com.nec.spark.fail-fast", "true")
+    conf.set("spark.com.nec.spark.kernel.directory", "/home/bm/SparkCyclone/work")
+    conf.set("spark.com.nec.spark.ncc.debug", "1")
     // conf.set("spark.ui.enabled", "false")
     val sparkSession = configure(SparkSession.builder().config(conf)).getOrCreate()
     try f(sparkSession)

--- a/src/test/scala/com/nec/tpc/TPCHSqlCSpec.scala
+++ b/src/test/scala/com/nec/tpc/TPCHSqlCSpec.scala
@@ -1435,6 +1435,68 @@ abstract class TPCHSqlCSpec
     }
   }
 
+
+
+
+
+
+
+
+  withTpchViews("Query 221", configuration) { sparkSession =>
+    import sparkSession.implicits._
+    val nation = "SAUDI ARABIA"
+
+    val sql = s"""
+      select
+        s_name,
+        count(*) as numwait
+      from
+        supplier,
+        lineitem l1,
+        orders,
+        nation
+      where
+        s_suppkey = l1.l_suppkey
+        and s_nationkey = n_nationkey
+        and o_orderkey = l1.l_orderkey
+        and o_orderstatus = 'F'
+        and l1.l_receiptdate > l1.l_commitdate
+        and n_name = '$nation'
+        and l1.l_shipdate between date '1995-01-01' and date '1996-01-01'
+      group by
+        s_name
+      order by
+        numwait desc,
+        s_name
+    """
+
+    val resultSchema = StructType(
+      Seq(StructField("_0", DataTypes.StringType), StructField("_1", DataTypes.LongType))
+    )
+
+    val result = sparkSession.read
+      .schema(resultSchema)
+      .csv(resultsDir + "Query21.csv")
+      .as[(String, Long)]
+      .collect()
+      .toList
+
+    sparkSession.sql(sql).debugSqlHere { ds =>
+      ds.as[(String, Long)].collect.foreach { x =>
+        println(s"${x}")
+      }
+    }
+  }
+
+
+
+
+
+
+
+
+
+
   withTpchViews("Query 22", configuration) { sparkSession =>
     import sparkSession.implicits._
     val items = Seq("'13'", "'31'", "'23'", "'29'", "'30'", "'18'", "'17'")


### PR DESCRIPTION
Testing with a simpler version of Q21:

```
    val sql = s"""
      select
        s_name,
        l_orderkey
      from
        supplier,
        lineitem l1,
        orders,
        nation
      where
        s_suppkey = l1.l_suppkey
        and s_nationkey = n_nationkey
        and o_orderkey = l1.l_orderkey
        and o_orderstatus = 'F'
        and l1.l_receiptdate > l1.l_commitdate
        and n_name = '$nation'
        and l1.l_shipdate between date '1995-01-01' and date '1996-01-01'
      order by
        s_name
    """

    sparkSession.sql(sql).debugSqlHere { ds =>
      val results = ds.as[(String, Long)].collect
      println(s"NUM RESULTS: ${results.size}")
    }
```

Both the JVM and VE runs return 9487 results, so either the group by is not working as expected or the subclause

```
        and exists (
          select *
          from
            lineitem l2
          where
            l2.l_orderkey = l1.l_orderkey
            and l2.l_suppkey <> l1.l_suppkey
        )
        and not exists (
          select *
          from
            lineitem l3
          where
            l3.l_orderkey = l1.l_orderkey
            and l3.l_suppkey <> l1.l_suppkey
            and l3.l_receiptdate > l3.l_commitdate
        )
```

is not working as expected.