### PR TITLE
Rough outline for SubQuery support

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/VeSubQueryExec.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/VeSubQueryExec.scala
@@ -1,0 +1,31 @@
+package org.apache.spark.sql.execution
+
+import com.nec.spark.planning.SupportsVeColBatch
+import com.nec.ve.VeColBatch
+import org.apache.spark.rdd.RDD
+import org.apache.spark.util.ThreadUtils
+
+import scala.concurrent.duration.Duration
+
+case class VeSubQueryExec(name: String, child: SparkPlan)
+  extends BaseSubqueryExec
+  with UnaryExecNode
+  with SupportsVeColBatch {
+  override def executeVeColumnar(): RDD[VeColBatch] = sys.error("Should not be called directly")
+
+  def executeCollectVe(): VeColBatch = {
+    ThreadUtils.awaitResult(colBatchFuture, Duration.Inf)
+  }
+
+  /** Derived from approach of SubQueryExec */
+  @transient
+  private lazy val colBatchFuture: java.util.concurrent.Future[VeColBatch] = {
+    val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    SQLExecution
+      .withThreadLocalCaptured[VeColBatch](sqlContext.sparkSession, SubqueryExec.executionContext) {
+        SQLExecution.withExecutionId(sqlContext.sparkSession, executionId) {
+          child.asInstanceOf[SupportsVeColBatch].executeVeColumnar().first()
+        }
+      }
+  }
+}


### PR DESCRIPTION
This is for Query 11 & Query 15.

This might not work. We might need to possibly rewrite it into a Join instead, because Spark's way of doing things is a little different.

The issue with Subquery is that it may be used in expressions that are beyond conditions - and for that reason we cannot easily join.

So we may have to actually continue onward with this approach.

Work needed here is significant; will try to create a stronger outline but we should focus on minimizing generation of code that is generic as much as possible first.