### PR TITLE
Remove copy to sparkcyclone.io step in unit tests.

### DIFF
--- a/.github/workflows/unittests-cmake.yml
+++ b/.github/workflows/unittests-cmake.yml
@@ -32,9 +32,4 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
 
       - name: Run Vector Engine Tests
-        run: SBT_OPTS="-Xmx16g" sbt "set debugToHtml := true" "CMake / testQuick"
-
-      - name: Copying to sparkcyclone.io
-        if: always()
-        run: rsync -r -v target/tpc-html/ egonzalez@xpressai.jp:/var/www/sparkcyclone.io/tpc-html/${{ steps.date.outputs.date }}
-
+        run: SBT_OPTS="-Xmx16g" sbt "CMake / testQuick"

--- a/.github/workflows/unittests-ve.yml
+++ b/.github/workflows/unittests-ve.yml
@@ -32,9 +32,4 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
 
       - name: Run Vector Engine Tests
-        run: SBT_OPTS="-Xmx16g" sbt "set debugToHtml := true" "VectorEngine / testQuick"
-
-      - name: Copying to sparkcyclone.io
-        if: always()
-        run: rsync -r -v target/tpc-html/ egonzalez@xpressai.jp:/var/www/sparkcyclone.io/tpc-html/${{ steps.date.outputs.date }}
-
+        run: SBT_OPTS="-Xmx16g" sbt "VectorEngine / testQuick"


### PR DESCRIPTION
The unit tests don't seem to create a test-html folder so there's nothing to copy.