### PR TITLE
Amplify batches

### DIFF
--- a/src/main/scala/com/nec/arrow/ArrowEncodingSettings.scala
+++ b/src/main/scala/com/nec/arrow/ArrowEncodingSettings.scala
@@ -4,7 +4,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.sql.internal.SQLConf
 
 /** This is done as [[SqlConf]] cannot be serialized. */
-final case class ArrowEncodingSettings(timezone: String, numRows: Int)
+final case class ArrowEncodingSettings(timezone: String, numRows: Int, batchSizeTargetBytes: Int)
 
 object ArrowEncodingSettings {
   def fromConf(conf: SQLConf)(implicit sparkContext: SparkContext): ArrowEncodingSettings =
@@ -17,6 +17,14 @@ object ArrowEncodingSettings {
       numRows = sparkContext.getConf
         .getOption("com.nec.spark.ve.columnBatchSize")
         .map(_.toInt)
-        .getOrElse(conf.columnBatchSize)
+        .getOrElse(conf.columnBatchSize),
+      batchSizeTargetBytes = sparkContext.getConf
+        .getOption("com.nec.spark.ve.targetBatchSizeKb")
+        .map(_.toInt)
+        .map(_ * 1024)
+        .getOrElse(DefaultTargetBatchSize)
     )
+
+  // 64M
+  private val DefaultTargetBatchSize: Int = 64 * 1024 * 1024
 }

--- a/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
+++ b/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
@@ -49,7 +49,7 @@ object VeRewriteStrategyOptions {
       joinOnVe = sparkConf
         .getOption(key = "spark.com.nec.spark.join-on-ve")
         .map(_.toBoolean)
-        .getOrElse(default.joinOnVe)
+        .getOrElse(default.joinOnVe),
       amplifyBatches = sparkConf
         .getOption(key = "spark.com.nec.spark.amplify-batches")
         .map(_.toBoolean)
@@ -66,7 +66,7 @@ object VeRewriteStrategyOptions {
       exchangeOnVe = true,
       passThroughProject = false,
       failFast = false,
-      joinOnVe = false
+      joinOnVe = false,
       amplifyBatches = true
     )
 }

--- a/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
+++ b/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
@@ -10,7 +10,8 @@ final case class VeRewriteStrategyOptions(
   exchangeOnVe: Boolean,
   passThroughProject: Boolean,
   failFast: Boolean,
-  joinOnVe: Boolean
+  joinOnVe: Boolean,
+  amplifyBatches: Boolean
 ) {}
 
 object VeRewriteStrategyOptions {
@@ -49,6 +50,10 @@ object VeRewriteStrategyOptions {
         .getOption(key = "spark.com.nec.spark.join-on-ve")
         .map(_.toBoolean)
         .getOrElse(default.joinOnVe)
+      amplifyBatches = sparkConf
+        .getOption(key = "spark.com.nec.spark.amplify-batches")
+        .map(_.toBoolean)
+        .getOrElse(default.amplifyBatches)
     )
   }
 
@@ -62,5 +67,6 @@ object VeRewriteStrategyOptions {
       passThroughProject = false,
       failFast = false,
       joinOnVe = false
+      amplifyBatches = true
     )
 }

--- a/src/main/scala/com/nec/spark/planning/plans/VeAmplifyBatchesPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VeAmplifyBatchesPlan.scala
@@ -1,0 +1,65 @@
+package com.nec.spark.planning.plans
+
+import com.nec.arrow.ArrowEncodingSettings
+import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
+import com.nec.spark.planning.{PlanCallsVeFunction, SupportsVeColBatch, VeFunction}
+import com.nec.ve.VeColBatch
+import com.nec.ve.VeColBatch.VeBatchOfBatches
+import com.nec.ve.VeProcess.OriginalCallingContext
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+
+case class VeAmplifyBatchesPlan(amplifyFunction: VeFunction, child: SparkPlan)
+  extends UnaryExecNode
+  with SupportsVeColBatch
+  with LazyLogging
+  with PlanCallsVeFunction {
+
+  require(
+    output.size == amplifyFunction.results.size,
+    s"Expected output size ${output.size} to match flatten function results size, but got ${amplifyFunction.results.size}"
+  )
+
+  private val encodingSettings = ArrowEncodingSettings.fromConf(conf)(sparkContext)
+
+  override def executeVeColumnar(): RDD[VeColBatch] = child
+    .asInstanceOf[SupportsVeColBatch]
+    .executeVeColumnar()
+    .mapPartitions { veColBatches =>
+      withVeLibrary { libRefExchange =>
+        import com.nec.util.BatchAmplifier.Implicits._
+        veColBatches
+          .amplify(limit = encodingSettings.batchSizeTargetBytes, f = _.totalBufferSize)
+          .map { inputBatches =>
+            import OriginalCallingContext.Automatic._
+            try {
+              val res =
+                VeColBatch.fromList(
+                  veProcess.executeMultiIn(
+                    libraryReference = libRefExchange,
+                    functionName = amplifyFunction.functionName,
+                    batches = VeBatchOfBatches.fromVeColBatches(inputBatches.toList),
+                    results = amplifyFunction.namedResults
+                  )
+                )
+              logger.debug(
+                s"Transformed input, got ${res}; produced a batch of size ${res.totalBufferSize} bytes"
+              )
+              res
+            } finally {
+              inputBatches
+                .foreach(child.asInstanceOf[SupportsVeColBatch].dataCleanup.cleanup)
+            }
+          }
+      }
+    }
+
+  override def output: Seq[Attribute] = child.output
+
+  override def veFunction: VeFunction = amplifyFunction
+
+  override def updateVeFunction(f: VeFunction => VeFunction): SparkPlan =
+    copy(amplifyFunction = f(amplifyFunction))
+}

--- a/src/main/scala/com/nec/util/BatchAmplifier.scala
+++ b/src/main/scala/com/nec/util/BatchAmplifier.scala
@@ -1,0 +1,40 @@
+package com.nec.util
+
+object BatchAmplifier {
+  def amplify[T](i: Iterator[T])(limit: Int, f: T => Int): Iterator[Vector[T]] = {
+    val buffer = scala.collection.mutable.Buffer.empty[T]
+    var accumulated: Int = 0
+    new scala.Iterator[Vector[T]] {
+      override def hasNext: Boolean = {
+        var hasNext = i.hasNext
+        if (!hasNext && buffer.nonEmpty) {
+          true
+        } else {
+          while (accumulated < limit && hasNext) {
+            val item = i.next()
+            buffer.append(item)
+            accumulated += f(item)
+            hasNext = i.hasNext
+          }
+          accumulated = 0
+          buffer.nonEmpty
+        }
+      }
+      override def next(): Vector[T] = {
+        if (buffer.isEmpty) throw new NoSuchElementException(s"Cannot produce an element")
+        else {
+          val res = buffer.toVector
+          buffer.clear()
+          res
+        }
+      }
+    }
+  }
+
+  object Implicits {
+    final implicit class RichIterator[T](i: Iterator[T]) {
+      def amplify(limit: Int, f: T => Int): Iterator[Vector[T]] =
+        BatchAmplifier.amplify(i)(limit, f)
+    }
+  }
+}

--- a/src/main/scala/com/nec/ve/VeProcess.scala
+++ b/src/main/scala/com/nec/ve/VeProcess.scala
@@ -63,7 +63,10 @@ trait VeProcess {
 
 object VeProcess {
 
-  final case class OriginalCallingContext(fullName: sourcecode.FullName, line: sourcecode.Line)
+  final case class OriginalCallingContext(fullName: sourcecode.FullName, line: sourcecode.Line) {
+    def renderString: String = s"${fullName.value}#${line.value}"
+  }
+
   object OriginalCallingContext {
     def make(implicit
       fullName: sourcecode.FullName,

--- a/src/main/scala/com/nec/ve/colvector/VeColBatch.scala
+++ b/src/main/scala/com/nec/ve/colvector/VeColBatch.scala
@@ -39,6 +39,8 @@ final case class VeColBatch(underlying: GenericColBatch[VeColVector]) {
     cb.setNumRows(underlying.numRows)
     cb
   }
+
+  def totalBufferSize: Int = underlying.cols.flatMap(_.underlying.bufferSizes).sum
 }
 
 object VeColBatch {

--- a/src/test/scala/com/nec/cache/SparkInternalRowsToArrowColumnarBatchesTest.scala
+++ b/src/test/scala/com/nec/cache/SparkInternalRowsToArrowColumnarBatchesTest.scala
@@ -1,0 +1,53 @@
+package com.nec.cache
+
+import com.nec.arrow.{ArrowEncodingSettings, WithTestAllocator}
+import com.nec.spark.planning.CEvaluationPlan.HasFieldVector.RichColumnVector
+import org.apache.arrow.vector.types.FloatingPointPrecision
+import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.scalatest.freespec.AnyFreeSpec
+
+final class SparkInternalRowsToArrowColumnarBatchesTest extends AnyFreeSpec {
+  "It works" in {
+    implicit val arrowEncodingSettings: ArrowEncodingSettings =
+      ArrowEncodingSettings("UTC", 3, 10)
+    import scala.collection.JavaConverters._
+    import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+    val result = WithTestAllocator { implicit ta =>
+      SparkInternalRowsToArrowColumnarBatches
+        .apply(
+          Iterator(
+            new GenericInternalRow(Array[Any](1, 1.0d)),
+            new GenericInternalRow(Array[Any](2, 3.0d))
+          ),
+          new Schema(
+            List(
+              new Field(
+                "test",
+                new FieldType(false, new ArrowType.Int(8 * 4, true), null),
+                List.empty.asJava
+              ),
+              new Field(
+                "test2",
+                new FieldType(
+                  false,
+                  new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE),
+                  null
+                ),
+                List.empty.asJava
+              )
+            ).asJava
+          ),
+          completeInSpark = false
+        )
+        .map { colBatch =>
+          (0 until colBatch
+            .numCols()).map(idx => colBatch.column(idx).getArrowValueVector.toString).toList
+        }
+        .toList
+    }
+
+    assert(result == List(List("[1, 2]", "[1.0, 3.0]")))
+  }
+}

--- a/src/test/scala/com/nec/util/BatchAmplifierSpec.scala
+++ b/src/test/scala/com/nec/util/BatchAmplifierSpec.scala
@@ -1,0 +1,24 @@
+package com.nec.util
+
+import org.scalatest.freespec.AnyFreeSpec
+
+final class BatchAmplifierSpec extends AnyFreeSpec {
+
+  def amplifyInt(l: List[Int]): List[Vector[Int]] =
+    BatchAmplifier.amplify[Int](l.iterator)(5, i => i).toList
+
+  "It passes through an empty set" in {
+    assert(amplifyInt(List.empty).isEmpty)
+  }
+
+  "It aggregates 1 item only" in {
+    assert(amplifyInt(List(1)) == List(List(1)))
+  }
+  "It aggregates just slightly over the limit of 5" in {
+    assert(amplifyInt(List(1, 2, 3, 4, 6, 1, 3)) == List(List(1, 2, 3), List(4, 6), List(1, 3)))
+  }
+  "It aggregates just slightly over the limit of 5 (2)" in {
+    assert(amplifyInt(List(1, 2, 3, 4, 6, 1)) == List(List(1, 2, 3), List(4, 6), List(1)))
+  }
+
+}

--- a/src/test/scala/com/nec/ve/DualModeVESpec.scala
+++ b/src/test/scala/com/nec/ve/DualModeVESpec.scala
@@ -81,7 +81,8 @@ final class DualModeVESpec
     val result = inputRdd
       .mapPartitions { iteratorRows =>
         implicit val rootAllocator: RootAllocator = new RootAllocator()
-        implicit val arrowEncodingSettings = ArrowEncodingSettings("UTC", 3)
+        implicit val arrowEncodingSettings: ArrowEncodingSettings =
+          ArrowEncodingSettings("UTC", 3, 10)
         unwrapPossiblyDualToVeColBatches(
           possiblyDualModeInternalRows = iteratorRows,
           arrowSchema =


### PR DESCRIPTION
This gathers sequences of small input batches and fuses them to pass into the next rows. It is intended to reduce the overall number of calls to the VE, and process significantly larger batches.

- Add new customization say that a target batch is 64MB in size.
- Spark Internal Row --> Arrow conversion to use this mechanism (relevant for caching)
- `VeAmplifyBatchesPlan` to apply a similar approach. This to use `BatchAmplifier` which is a generic way to transform an iterator to an iterator of batches that get as close to a target limit as possible.
- Add `SparkInternalRowsToArrowColumnarBatchesTest` test to validate the spark converter just in case.