### PR TITLE
Restore the optimized flags used in Frovedis in Makefile

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/Makefile
+++ b/src/main/resources/com/nec/cyclone/cpp/Makefile
@@ -1,5 +1,16 @@
 NCC = $(shell ls /opt/nec/ve/bin/ncc 2>/dev/null || echo gcc)
-NCC_OPTS = -xc++
+NCC_OPTS = -xc++ \
+	-O4 \
+	-shared \
+	-fpic \
+	-pthread \
+	-fno-defer-inline-template-instantiation \
+	-finline-functions \
+	-finline-max-depth=10 \
+	-msched-block \
+	-pthread \
+	-report-all \
+	-fdiag-vector=2
 ALL = cyclone.so
 all: $(ALL)
 .PHONY: clean
@@ -56,7 +67,7 @@ SOURCES = cyclone.cc \
 	frovedis/text/words.cc \
 	
 cyclone-ve.so: $(DEPS)
-	$(NCC) $(NCC_OPTS) -shared -fpic -pthread -o cyclone-ve.so $(SOURCES)
+	$(NCC) $(NCC_OPTS) -o cyclone-ve.so $(SOURCES)
 
 clean:
 	rm -f cyclone-ve.so


### PR DESCRIPTION
If we don't use the same aggressive optimizations and inlining used in Frovedis the performance will suffer due to us being very loose with the code we use and generate.  We want the compiler to do as much of the work as possible for us.