### PR TITLE
Compile all the codes in 1 file

### DIFF
--- a/src/main/scala/com/nec/spark/LocalVeoExtension.scala
+++ b/src/main/scala/com/nec/spark/LocalVeoExtension.scala
@@ -20,12 +20,7 @@
 package com.nec.spark
 
 import com.nec.spark.LocalVeoExtension.compilerRule
-import com.nec.spark.planning.{
-  ParallelCompilationColumnarRule,
-  VERewriteStrategy,
-  VeColumnarRule,
-  VeRewriteStrategyOptions
-}
+import com.nec.spark.planning.{CombinedCompilationColumnarRule, ParallelCompilationColumnarRule, VERewriteStrategy, VeColumnarRule, VeRewriteStrategyOptions}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.ColumnarRule
@@ -34,7 +29,8 @@ import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
 object LocalVeoExtension extends LazyLogging {
   var _enabled = true
 
-  def compilerRule(sparkSession: SparkSession): ColumnarRule = ParallelCompilationColumnarRule
+//  def compilerRule(sparkSession: SparkSession): ColumnarRule = ParallelCompilationColumnarRule
+  def compilerRule(sparkSession: SparkSession): ColumnarRule = CombinedCompilationColumnarRule
 }
 
 final class LocalVeoExtension extends (SparkSessionExtensions => Unit) with Logging {

--- a/src/main/scala/com/nec/spark/agile/CExpressionEvaluation.scala
+++ b/src/main/scala/com/nec/spark/agile/CExpressionEvaluation.scala
@@ -181,6 +181,7 @@ object CExpressionEvaluation {
   }
 
   object CodeLines {
+    def parse(sourceCode: String): CodeLines = CodeLines.from(sourceCode.split("\\r?\\n").toList)
 
     def debugValue(names: String*): CodeLines =
       TcpDebug.conditionOn("DEBUG")(

--- a/src/main/scala/com/nec/spark/agile/CodeStructure.scala
+++ b/src/main/scala/com/nec/spark/agile/CodeStructure.scala
@@ -1,0 +1,61 @@
+package com.nec.spark.agile
+
+import com.nec.spark.agile.CExpressionEvaluation.CodeLines
+import com.nec.spark.agile.CodeStructure.CodeSection
+
+final case class CodeStructure(sections: List[CodeSection])
+
+object CodeStructure {
+
+  def combine(list: List[CodeStructure]): CodeLines = {
+    CodeLines.from(
+      list
+        .flatMap(_.sections)
+        .sortBy {
+          case CodeSection.Header(_)    => 1
+          case CodeSection.NonHeader(_) => 2
+        }
+        .distinct
+        .map(_.codeLines)
+    )
+  }
+
+  val empty: CodeStructure = CodeStructure(sections = Nil)
+  sealed trait CodeSection {
+    def codeLines: CodeLines
+  }
+  object CodeSection {
+    final case class Header(codeLines: CodeLines) extends CodeSection
+
+    final case class NonHeader(codeLines: CodeLines) extends CodeSection
+  }
+
+  /** General code stucture parser: assumes that headers at the top and the rest of things happen after headers finish. */
+
+  def from(codeLines: CodeLines): CodeStructure = {
+    var lookingForHeader = true
+    val foundParts = scala.collection.mutable.Buffer.empty[CodeSection]
+    var remaining = codeLines.lines.dropWhile(_.trim.isEmpty)
+
+    while (remaining.nonEmpty) {
+      if (lookingForHeader) {
+        if (remaining.head.startsWith("#if")) {
+          val remainingBits = remaining.dropWhile(str => !str.startsWith("#endif"))
+          val headerBits = remaining.takeWhile(str => !str.startsWith("#endif"))
+          remaining = remainingBits.tail
+          foundParts.append(CodeSection.Header(CodeLines.from(headerBits, remainingBits.take(1))))
+        } else if (remaining.head.startsWith("#")) {
+          foundParts.append(CodeSection.Header(CodeLines.from(remaining.head)))
+          remaining = remaining.drop(1)
+        } else {
+          lookingForHeader = false
+        }
+      } else {
+        foundParts.append(CodeSection.NonHeader(CodeLines.from(remaining)))
+        remaining = Nil
+      }
+    }
+
+    CodeStructure(sections = foundParts.toList)
+  }
+}

--- a/src/main/scala/com/nec/spark/planning/CombinedCompilationColumnarRule.scala
+++ b/src/main/scala/com/nec/spark/planning/CombinedCompilationColumnarRule.scala
@@ -1,0 +1,63 @@
+package com.nec.spark.planning
+
+import com.nec.spark.SparkCycloneDriverPlugin
+import com.nec.spark.agile.CExpressionEvaluation.CodeLines
+import com.nec.spark.agile.CodeStructure
+import com.nec.spark.planning.PlanCallsVeFunction.UncompiledPlan
+import com.nec.spark.planning.VeFunction.VeFunctionStatus
+import com.nec.spark.planning.VeFunction.VeFunctionStatus.SourceCode
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
+
+import java.nio.file.Path
+import java.time.Instant
+
+object CombinedCompilationColumnarRule extends ColumnarRule with LazyLogging {
+  override def preColumnarTransitions: Rule[SparkPlan] = { plan =>
+    val uncompiledOnes = plan.collect { case UncompiledPlan(plan) =>
+      plan
+    }
+    if (uncompiledOnes.nonEmpty) {
+      val preMatchStart = Instant.now()
+      logger.info(s"Found an uncompiled plan - proceeding.")
+
+      logger.debug(s"Found ${uncompiledOnes.length} plans uncompiled")
+      val compilationStart = Instant.now()
+
+      val uncompiledCodes = uncompiledOnes
+        .map(_.sparkPlan.veFunction)
+        .collect { case VeFunction(sc@SourceCode(_), _, _) =>
+          sc
+        }
+        .toSet
+
+      logger.info(s"Found ${uncompiledCodes.size} codes uncompiled")
+
+      val combined = CodeStructure.combine(uncompiledCodes.toList.map { sourceCode =>
+        CodeStructure.from(CodeLines.parse(sourceCode.sourceCode))
+      })
+
+      val compiledPath: Path = SparkCycloneDriverPlugin.currentCompiler.forCode(combined.cCode)
+
+      logger.info(s"Compiled all the code")
+
+      val result = plan.transformUp { case UncompiledPlan(plan) =>
+        plan.sparkPlan.updateVeFunction {
+          case f@VeFunction(source@SourceCode(_), _, _) =>
+            f.copy(veFunctionStatus = VeFunctionStatus.Compiled(compiledPath.toString))
+          case other => other
+        }
+      }
+
+      val compilationEnd = Instant.now()
+      val timeTaken = java.time.Duration.between(compilationStart, compilationEnd)
+      val timeTakenMatch = java.time.Duration.between(preMatchStart, compilationEnd)
+      logger.info(
+        s"Took ${timeTaken} to transform functions to compiled status (total: ${timeTakenMatch})."
+      )
+      logger.info(s"Compilation time: ${timeTakenMatch}")
+      result
+    } else plan
+  }
+}

--- a/src/test/scala/com/nec/cmake/functions/CombineSourcesSpec.scala
+++ b/src/test/scala/com/nec/cmake/functions/CombineSourcesSpec.scala
@@ -1,0 +1,63 @@
+package com.nec.cmake.functions
+
+import com.nec.spark.agile.CExpressionEvaluation.CodeLines
+import com.nec.spark.agile.CodeStructure
+import com.nec.spark.agile.CodeStructure.CodeSection.{Header, NonHeader}
+import org.scalatest.freespec.AnyFreeSpec
+
+object CombineSourcesSpec {}
+
+final class CombineSourcesSpec extends AnyFreeSpec {
+  "Simple include is parsed" in {
+    assert(
+      CodeStructure.from(CodeLines.from("#include x")) == CodeStructure(
+        List(Header(CodeLines.from("#include x")))
+      )
+    )
+  }
+  "Simple include is parsed with some headroom in front" in {
+    assert(
+      CodeStructure.from(CodeLines.from("", "#include x")) == CodeStructure(
+        List(Header(CodeLines.from("#include x")))
+      )
+    )
+  }
+  "Simple ifdef section is parsed" in {
+    assert(
+      CodeStructure.from(CodeLines.from("#ifdef x", "y", "#endif")) == CodeStructure(
+        List(Header(CodeLines.from("#ifdef x", "y", "#endif")))
+      )
+    )
+  }
+  "Simple code is parsed" in {
+    assert(
+      CodeStructure.from(CodeLines.from("x")) == CodeStructure(List(NonHeader(CodeLines.from("x"))))
+    )
+  }
+  "Combination of include and code is parsed" in {
+    assert(
+      CodeStructure.from(CodeLines.from("#include x", "x")) == CodeStructure(
+        List(Header(CodeLines.from("#include x")), NonHeader(CodeLines.from("x")))
+      )
+    )
+  }
+
+  "CodeLines can parse from set of lines" in {
+    assert(CodeLines.parse("x\ny\r\nz") == CodeLines.from("x", "y", "z"))
+  }
+
+  "Final combination is parsed" in {
+    val setOps =
+      """#include "frovedis/core/set_operations.hpp""""
+
+    val zz = """#include <zz>"""
+
+    val f1 = """extern "C" long amplify_flt_eval_2099938059 ("""
+    val f2 = """extern "C" long amplify_flt_eval_2099938054 ("""
+
+    val sources = List[CodeLines](CodeLines.from(setOps, f1), CodeLines.from(zz, setOps, f2))
+
+    val result = CodeStructure.combine(sources.map(cl => CodeStructure.from(cl)))
+    assert(result == CodeLines.from(setOps, zz, f1, f2))
+  }
+}


### PR DESCRIPTION
Combine multiple sources together into a single source file, to simplify compilation steps required from many to just 1.

We parse each source file to figure out the headers followed by main code; then deduplicate headers and rejoin into a single file.

We can simplify/remove this code as part of a bigger step where we extract a lot of common/repeated functions into the general library.

Test evidence (no regression down from `main`):
![image](https://user-images.githubusercontent.com/52247468/151714661-0bcfc069-73fd-4ce1-b12d-20f3deb4c977.png)

https://www.sparkcyclone.io/tpc-html/20220131040527/