### PR TITLE
Failfast off by default

### DIFF
--- a/SBT.md
+++ b/SBT.md
@@ -33,24 +33,13 @@ ln -f -s /opt/nec/ve/bin/nc++ ~/.local/bin/nc++
 ln -f -s /opt/nec/ve/bin/ps ~/.local/bin/veps
 source /opt/rh/devtoolset-9/enable
 export SPARK_SCALA_VERSION=2.12
+export SPARK_HOME=/path/to/spark # you might want to download your own too
 ```
 
 ## Cluster tests
 
 For Cluster-mode/detection tests that run on the `VectorEngine` scope, ensure that `$SPARK_HOME/work` is
 writable (`mkdir -p /opt/spark/work && chmod -R 777 /opt/spark/work`).
-
-## Development for Spark 2.3 / Scala 2.11
-
-Done using SBT's cross-build: https://www.scala-sbt.org/1.x/docs/Cross-Build.html
-
-You can eg create a directory `src/main/scala-2.12` and `src/main/scala-2.11` for compiling those version-specific
-sources.
-
-As such, any Spark 2.3-specific tests should be done through `src/test/scala-2.11`.
-
-In the shell, switch using `+ 2.11.12`. We tried to use https://github.com/sbt/sbt-projectmatrix - while it worked it
-did not gel so well with IntelliJ.
 
 ## SBT commands
 
@@ -61,104 +50,6 @@ did not gel so well with IntelliJ.
 - Functional tests on JVM: `testQuick`
 - Acceptance tests, which also generate `../FEATURES.md`: `AcceptanceTest / test` (or `Acc`)
 - Check before committing: `check` (checks scalafmt and runs any outstanding unit tests)
-
-### Benchmarks
-
-```
-~ VectorEngine / runMain com.nec.ve.VeBenchmarkApp
-```
-
-Run a specific benchmark:
-
-```
-VectorEngine / runMain com.nec.ve.VeBenchmarkApp sum
-```
-
-#### JMH
-
-Get a gist about JMH here in this good tutorial: http://tutorials.jenkov.com/java-performance/jmh.html
-In this project, we generate the JMH benchmarks programmatically based on Scala definitions, in order to try out many
-different variations.
-
-In order to automatically generate and invoke all currently supported benchmarks You should invoke the follwing
-commands:
-
-```
-export CUDF_PATH=/opt/cyclone/cudf-0.19.2-cuda10-1.jar
-```
-
-```
-# get help -- you'll really need to understand these in depth before running benchmarks, else they might be quite meaningless
-; skipBenchTests; bench -h; unskipBenchTests
-
-# list benchmarks
-; skipBenchTests; bench -h; unskipBenchTests
-
-# run all benchmarks
-bench -t1 -f 1 -wi 0 -i 1 .*
-
-# run a specific benchmark with extra options, and also request a flight recording.
-# in this case we want to look at the benchmarks to see what is going on at the moment.
-bench -f 1 -wi 0 -prof jfr -i 1 .*Parquet.*Rapid.* -to 20m -jvmArgsAppend -Dspark.ui.enabled=true
-
-# to force small data set for whatever reason (eg running on local machine, and don't have the huge data-set), use:  
--jvmArgsAppend -Dnec.testing.force-small=true
-
-bench -f 1 -wi 0 -prof jfr -i 1 -jvmArgsAppend -Dspark.ui.enabled=true .*
-
-# to enable compiler debugging, use:
--jvmArgsAppend -Dncc.debug=1
-
-# or if running under Spark:
--jvmArgsAppend -Dspark.com.nec.spark.ncc.debug=1
-
-```
-
-The first one will set the path to cudf JAR required by rapids benchmarks, while the other one will generate all
-benchmarks defined in `BenchTestingPossibilities` class and then start them.
-
-Adding new benchmarks requires implementing `Testing` abstract class and making sure it is included
-in `BenchTestingPossibilities.possibilities` list.
-
-##### Custom profiler
-
-Add the following option to periodically collect stack traces during a benchmark run:
-
-```
-# Run profiler with default 1s sampling interval
--prof org.openjdk.jmh.profile.nec.StackSamplingProfiler
-# Run profiler with 5s sampling interval
--prof org.openjdk.jmh.profile.nec.StackSamplingProfiler:5s
-```
-
-The output will be in `fun-bench/<benchmark id>/thread-samples.json`.
-
-The intention of this is offline analysis to see where we are actually spending time, as it seems that we cannot get
-that information fully from JFR, and the basic stack sampler does not provide enough detail for us to make any
-conclusions.
-
-An example analyzer has been included. To use it, run `fun-bench/run`. This is an example output from a small collection:
-```
-[info] running com.nec.jmh.AnalyzeDataApp
-Choose from the following files:
-[1] fun-bench\nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-SingleShotTime\thread-samples.json
-1
-Choosing 'fun-bench\nec.DynamicBenchmark.TestingOUR_TestingOUR_InJVM_JVM-SingleShotTime\thread-samples.json':'
-8 WindowsSelectorImpl.java:-2 sun.nio.ch.WindowsSelectorImpl$SubSelector#poll0
-4 Inet6AddressImpl.java:-2 java.net.Inet6AddressImpl#getHostByAddr
-2 NetworkInterface.java:-2 java.net.NetworkInterface#getAll
-1 Frame.java:779 jdk.internal.org.objectweb.asm.Frame#init
-1 Inflater.java:-2 java.util.zip.Inflater#inflateBytes
-1 SqlBaseParser.java:18952 org.apache.spark.sql.catalyst.parser.SqlBaseParser#strictIdentifier
-1 UTF8Reader.java:153 com.ctc.wstx.io.UTF8Reader#read
-1 ZipFile.java:-2 java.util.zip.ZipFile#getEntry
-```
-
-
-
-## Currently supported queries
-
-List of currently supported and tested queries can be found [in this file](../FEATURES.md).
 
 ## Produce the deployable JAR
 
@@ -193,6 +84,14 @@ To deploy to `a5`, do:
 
 https://docs.rackspace.com/blog/speeding-up-ssh-session-creation/
 
+# SBT options
+
+## `failFast`
+
+`set failFast := true` if you'd like it to fail fast in `TPC/test`
+
+`set debugToHtml := true` if you'd like `TPC/test` to output more detail for verbosity (like plans).
+
 # Other things
 
 ## Frovedis
@@ -207,38 +106,6 @@ For exploration and possible integration purposes, we include the JAR file from 
 reference.
 
 What is also interesting is that Frovedis has an x86 mode which could be tremendously useful for our development.
+
 However, we need to investigate more to see how they have done things and what we can adopt.
 
-### Docker container
-
-To do some exploration we have a Docker container
-
-In order to repeat this, we use Docker:
-
-```
-$ cd docker
-$ docker build -t frov:1 -f Dockerfile .
-$ docker run -it frov:1
-```
-
-### JAR repository
-
-We've built some JAR files from the Frovedis sources, so they can be easily consumed from the plug-in and browsed
-through IntelliJ's powerful navigation capabilities. This is to aid exploration of what is available. The repository is
-located in at https://github.com/bytedeco/javacpp-presets/tree/aurora/frovedis
-and is available through a default import of SBT. It includes both source and test JARs.
-
-# Tracing
-
-```
-sbt> show tracing / Rpm / packageBin
-# rpm --force -i /path/to/spark-cyclone/tracing/target/rpm/RPMS/noarch/tracing-0.1.0-SNAPSHOT.noarch.rpm
-sbt> VectorEngine / testOnly *TPC* -- -z " 4"
-# journalctl -u tracing -f
-# echo 'LOG_DIR=/opt/cyclone/tracing' >> /etc/default/tracing
-# mkdir -p /opt/cyclone/tracing
-# chown -R tracing:tracing /opt/cyclone/tracing
-# chmod -R 777 /opt/cyclone/tracing
-# systemctl daemon-reload
-# systemctl restart tracing
-```

--- a/src/main/scala/com/nec/spark/LocalVeoExtension.scala
+++ b/src/main/scala/com/nec/spark/LocalVeoExtension.scala
@@ -20,7 +20,13 @@
 package com.nec.spark
 
 import com.nec.spark.LocalVeoExtension.compilerRule
-import com.nec.spark.planning.{CombinedCompilationColumnarRule, ParallelCompilationColumnarRule, VERewriteStrategy, VeColumnarRule, VeRewriteStrategyOptions}
+import com.nec.spark.planning.{
+  CombinedCompilationColumnarRule,
+  ParallelCompilationColumnarRule,
+  VERewriteStrategy,
+  VeColumnarRule,
+  VeRewriteStrategyOptions
+}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.ColumnarRule
@@ -35,11 +41,12 @@ object LocalVeoExtension extends LazyLogging {
 
 final class LocalVeoExtension extends (SparkSessionExtensions => Unit) with Logging {
   override def apply(sparkSessionExtensions: SparkSessionExtensions): Unit = {
-    sparkSessionExtensions.injectPlannerStrategy(sparkSession =>
+
+    sparkSessionExtensions.injectPlannerStrategy(sparkSession => {
       new VERewriteStrategy(
         options = VeRewriteStrategyOptions.fromConfig(sparkSession.sparkContext.getConf)
       )
-    )
+    })
     sparkSessionExtensions.injectColumnar(compilerRule)
     sparkSessionExtensions.injectColumnar(_ => new VeColumnarRule)
   }

--- a/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
+++ b/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
@@ -91,9 +91,8 @@ object VERewriteStrategy {
   val HashExchangeBuckets: Int = 8
 }
 
-final case class VERewriteStrategy(
-  options: VeRewriteStrategyOptions = VeRewriteStrategyOptions.default
-) extends Strategy
+final case class VERewriteStrategy(options: VeRewriteStrategyOptions)
+  extends Strategy
   with LazyLogging {
 
   import com.github.ghik.silencer.silent

--- a/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
+++ b/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
@@ -12,7 +12,7 @@ final case class VeRewriteStrategyOptions(
   failFast: Boolean,
   joinOnVe: Boolean,
   amplifyBatches: Boolean
-) {}
+)
 
 object VeRewriteStrategyOptions {
   //noinspection MapGetOrElseBoolean
@@ -42,10 +42,12 @@ object VeRewriteStrategyOptions {
         .getOption(key = "spark.com.nec.spark.pass-through-project")
         .map(_.toBoolean)
         .getOrElse(default.passThroughProject),
-      failFast = sparkConf
-        .getOption(key = "spark.com.nec.spark.fail-fast")
-        .map(_.toBoolean)
-        .getOrElse(default.failFast),
+      failFast = {
+        sparkConf
+          .getOption(key = "spark.com.nec.spark.fail-fast")
+          .map(_.toBoolean)
+          .getOrElse(default.failFast)
+      },
       joinOnVe = sparkConf
         .getOption(key = "spark.com.nec.spark.join-on-ve")
         .map(_.toBoolean)

--- a/src/test/scala/com/nec/spark/BenchTestingPossibilities.scala
+++ b/src/test/scala/com/nec/spark/BenchTestingPossibilities.scala
@@ -179,7 +179,6 @@ object BenchTestingPossibilities extends LazyLogging {
             .builder()
             .master(MasterName)
             .appName(name.value)
-            .withExtensions(sse => sse.injectPlannerStrategy(_ => VERewriteStrategy()))
             .config(key = "spark.com.nec.spark.batch-batches", value = "3")
             .config(CODEGEN_FALLBACK.key, value = false)
             .config(CODEGEN_COMMENTS.key, value = true)

--- a/src/test/scala/com/nec/spark/SparkAdditions.scala
+++ b/src/test/scala/com/nec/spark/SparkAdditions.scala
@@ -58,7 +58,6 @@ trait SparkAdditions {
     val conf = new SparkConf()
     conf.setMaster("local")
     conf.setAppName("local-test")
-    conf.set("spark.com.nec.spark.fail-fast", "true")
     // conf.set("spark.ui.enabled", "false")
     val sparkSession = configure(SparkSession.builder().config(conf)).getOrCreate()
     try f(sparkSession)

--- a/src/test/scala/com/nec/tpc/TPCHSqlCSpec.scala
+++ b/src/test/scala/com/nec/tpc/TPCHSqlCSpec.scala
@@ -59,11 +59,12 @@ abstract class TPCHSqlCSpec
 
   private var printMarkup = false
 
+  protected var failFast = false
+
   protected override def beforeAll(configMap: ConfigMap): Unit = {
     printMarkup = configMap.getOptional[String]("markup").contains("true")
+    failFast = configMap.getOptional[String]("failFast").contains("true")
   }
-
-  private var initialized = false
 
   def configuration: SparkSession.Builder => SparkSession.Builder
   val resultsDir = "src/test/resources/com/nec/spark/results/"

--- a/src/test/scala/com/nec/ve/CachingSpec.scala
+++ b/src/test/scala/com/nec/ve/CachingSpec.scala
@@ -25,26 +25,27 @@ object CachingSpec {
   )
 }
 final class CachingSpec extends AnyFreeSpec with SparkAdditions with VeKernelInfra {
-  "We can retrieve cached items back out" in withSparkSession2(TPCHVESqlSpec.VeConfiguration) {
-    sparkSession =>
-      import sparkSession.implicits._
-      sparkSession
-        .createDataset(CachingSpec.SampleItems)
-        .repartition(2)
-        .createTempView("sample")
+  "We can retrieve cached items back out" in withSparkSession2(
+    TPCHVESqlSpec.VeConfiguration(failFast = true)
+  ) { sparkSession =>
+    import sparkSession.implicits._
+    sparkSession
+      .createDataset(CachingSpec.SampleItems)
+      .repartition(2)
+      .createTempView("sample")
 
-      sparkSession.sql("cache table sample")
+    sparkSession.sql("cache table sample")
 
-      val query = sparkSession.sql("select * from sample where num = 5").as[SampleStructure]
-      val plan = query.queryExecution.executedPlan.toString()
-      info(plan)
-      val rddInfo = query.queryExecution.executedPlan.execute()
-      info(s"$rddInfo")
-      val result = query.collect().toList.toSet
-      val expectedResult = CachingSpec.SampleItems.filter(_.num == 5).toSet
-      assert(result == expectedResult, "results should be the same")
+    val query = sparkSession.sql("select * from sample where num = 5").as[SampleStructure]
+    val plan = query.queryExecution.executedPlan.toString()
+    info(plan)
+    val rddInfo = query.queryExecution.executedPlan.execute()
+    info(s"$rddInfo")
+    val result = query.collect().toList.toSet
+    val expectedResult = CachingSpec.SampleItems.filter(_.num == 5).toSet
+    assert(result == expectedResult, "results should be the same")
 
-      assert(plan.contains("VeFetchFromCachePlan"), "info on ve fetch from cache should be there")
+    assert(plan.contains("VeFetchFromCachePlan"), "info on ve fetch from cache should be there")
   }
 
 }

--- a/src/test/scala/com/nec/ve/DynamicVeSqlExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/ve/DynamicVeSqlExpressionEvaluationSpec.scala
@@ -20,7 +20,7 @@
 package com.nec.ve
 
 import com.nec.cmake.DynamicCSqlExpressionEvaluationSpec
-import com.nec.spark.planning.VERewriteStrategy
+import com.nec.spark.planning.{VERewriteStrategy, VeRewriteStrategyOptions}
 import com.nec.spark.{AuroraSqlPlugin, SparkCycloneExecutorPlugin}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf.CODEGEN_FALLBACK
@@ -32,7 +32,13 @@ object DynamicVeSqlExpressionEvaluationSpec {
     _.config(CODEGEN_FALLBACK.key, value = false)
       .config("spark.sql.codegen.comments", value = true)
       .config("spark.plugins", classOf[AuroraSqlPlugin].getCanonicalName)
-      .withExtensions(sse => sse.injectPlannerStrategy(sparkSession => new VERewriteStrategy()))
+      .withExtensions(sse =>
+        sse.injectPlannerStrategy(sparkSession =>
+          new VERewriteStrategy(
+            VeRewriteStrategyOptions.fromConfig(sparkSession.sparkContext.getConf)
+          )
+        )
+      )
   }
 
 }


### PR DESCRIPTION
But with option to enable it.
Also, clean up `SBT.md`

E.g.:


```
 because of: java.lang.RuntimeException: Could not map scalar-subquery#1647 [] (class org.apache.spark.sql.catalyst.expressions.ScalarSubquery None); input is List(l_suppkey#53L, sum((l_extendedprice * (CAST(1 AS DOUBLE) - l_discount)))#1651), condition is (isnotnull(sum((l_extendedprice * (CAST(1 AS DOUBLE) - l_discount)))#1651) AND (sum((l_extendedprice * (CAST(1 AS DOUBLE) - l_discount)))#1651 = scalar-subquery#1647 []))
java.lang.RuntimeException: Could not map scalar-subquery#1647 [] (class org.apache.spark.sql.catalyst.expressions.ScalarSubquery None); input is List(l_suppkey#53L, sum((l_extendedprice * (CAST(1 AS DOUBLE) - l_discount)))#1651), condition is (isnotnull(sum((l_extendedprice * (CAST(1 AS DOUBLE) - l_discount)))#1651) AND (sum((l_extendedprice * (CAST(1 AS DOUBLE) - l_discount)))#1651 = scalar-subquery#1647 []))
        at scala.sys.package$.error(package.scala:30)
        at com.nec.spark.planning.VERewriteStrategy.$anonfun$apply$20(VERewriteStrategy.scala:327)
        at scala.util.Either.fold(Either.scala:192)
        at com.nec.spark.planning.VERewriteStrategy.res$1(VERewriteStrategy.scala:329)

...

        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
++
||
++
++
++
[info] - Query 15
[info] Run completed in 1 minute, 16 seconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```