### PR TITLE
[stringhole] Limit the range of delimiters for InStringHoleEvaluation

### DIFF
--- a/src/test/scala/com/nec/cmake/eval/InStringHoleEvaluationSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/InStringHoleEvaluationSpec.scala
@@ -96,7 +96,7 @@ final class InStringHoleEvaluationSpec extends AnyWordSpec {
     }
 
     "correctly filter out input set when match words contain spaces or other non-alphanumeric characters" in {
-      val delim = Random.shuffle(1.to(255).filter(!_.toChar.isLetterOrDigit)).head.toChar
+      val delim = Random.shuffle(1.to(127).filter(!_.toChar.isLetterOrDigit)).head.toChar
       val list = List(s"Cat${delim}Dog", "Cow", "Hotel", "Cyclone", "Spark", "Brown", "Fox")
       val toMatchList = List(s"Cat${delim}Dog", "Fox")
       val expected = list.collect {


### PR DESCRIPTION
- Limit the range of avilable delimiters for InStringHoleEvaluation from
[1, 255] to [1, 127].  While the delimiters with char value above 127
are fine in the generated C++ code, the string is being encoded as UTF-8,
and since the sign bit is set, it becomes 2 bytes, which map to 2 chars
sent to the C side.