### PR TITLE
[checks] Remove exact checks

### DIFF
--- a/src/test/scala/com/nec/testing/ProductListEquivalenceCheck.scala
+++ b/src/test/scala/com/nec/testing/ProductListEquivalenceCheck.scala
@@ -1,41 +1,36 @@
 package com.nec.testing
-import ProductListEquivalenceCheck._
-import com.eed3si9n.expecty.Expecty.expect
-import com.nec.cmake.DynamicCSqlExpressionEvaluationSpec
-import com.nec.spark.SparkAdditions
-import com.nec.spark.agile.CFunctionGeneration.CFunction
-import com.typesafe.scalalogging.LazyLogging
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.{Dataset, SparkSession}
-import org.scalactic.source.Position
-import org.scalactic.{Equality, Equivalence, TolerantNumerics}
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.{MatchResult, Matcher}
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAllConfigMap, ConfigMap}
-import scalatags.Text.tags2.{details, summary}
 
-final class ProductListEquivalenceCheck extends AnyFreeSpec {
-  "A list of classes with some Doubles is equivalent" in {
-    assert(
-      listEq.areEqual(List[(String, Double)](("a", 0.0005)), List[(String, Double)](("a", 0.0003)))
-    )
-  }
-  "When values are too far apart, it is no longer equivalent" in {
-    assert(
-      !listEq.areEqual(List[(String, Double)](("a", 1.0005)), List[(String, Double)](("a", 0.0003)))
-    )
+import org.scalactic.{Equality, TolerantNumerics}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.{MatchResult, Matcher}
+import org.scalatest.matchers.should.Matchers._
+
+final class ProductListEquivalenceCheckUnitSpec extends AnyWordSpec {
+  import ProductListEquivalenceCheck._
+
+  "SeqProductMatcherWithDoubleTolerance" should {
+    "match when Doubles are close enough" in {
+      listEq.areEqual(Seq(("a", 0.0005d)), Seq(("a", 0.0003d))) should be (true)
+      Seq(("a", 0.0005d)) should containTheSameProducts(Seq(("a", 0.0003d)))
+    }
+
+    "not match when Doubles are too far apart" in {
+      listEq.areEqual(Seq(("a", 1.0005d)), Seq(("a", 0.0003d))) should be (false)
+      Seq(("a", 1.0005d)) shouldNot containTheSameProducts(Seq(("a", 0.0003d)))
+    }
   }
 }
 
 object ProductListEquivalenceCheck {
-  class ContainsTheSameElementsAsWithDoubleTolerance[A  <: Product](expected: Seq[A]) extends Matcher[Seq[A]] {
+  class SeqProductMatcherWithDoubleTolerance[A <: Product](expected: Seq[A]) extends Matcher[Seq[A]] {
     def apply(left: Seq[A]): MatchResult = {
       val notEqual = left.zipAll(expected, null, null).filter {
-        case (elem, expect) if(elem == null || expect == null) => true
-        case (elem: Product, expect: Product) => !twoProductsEq.areEqual(elem, expect)
+        case (elem, expect) if (elem == null || expect == null) => true
+        case (elem: Product, expect: Product) => !productEq.areEqual(elem, expect)
       }
-      val message = notEqual.map{
+
+      val message = notEqual.map {
         case (null, expect) => s"Expected ${expect} but value was missing."
         case (value, null) => s"Value was ${value}, but didn't expect anything."
         case (value, expect) => s"Value was ${value}, expected was ${expect}."
@@ -49,10 +44,11 @@ object ProductListEquivalenceCheck {
     }
   }
 
-  def shouldContainTheSameProducts[A <: Product](expected: Seq[A]) = new ContainsTheSameElementsAsWithDoubleTolerance[A](expected)
+  def containTheSameProducts[A <: Product](expected: Seq[A]) = new SeqProductMatcherWithDoubleTolerance[A](expected)
 
   implicit val doubleEq: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(1e-2)
-  implicit val twoProductsEq: Equality[Product] = (aProduct: Product, _b: Any) => {
+
+  implicit val productEq: Equality[Product] = (aProduct: Product, _b: Any) => {
     val bProduct = _b.asInstanceOf[Product]
     aProduct.productArity == bProduct.productArity &&
     aProduct.productIterator.zip(bProduct.productIterator).forall {
@@ -62,11 +58,12 @@ object ProductListEquivalenceCheck {
         a == b
     }
   }
-  implicit val listEq: Equality[List[Product]] = (a: List[Product], _b: Any) => {
-    val b = _b.asInstanceOf[List[Product]]
+
+  implicit val listEq: Equality[Seq[Product]] = (a: Seq[Product], _b: Any) => {
+    val b = _b.asInstanceOf[Seq[Product]]
     (a.isEmpty && b.isEmpty) || ((a.size == b.size) && a.zip(b).forall {
       case (aProduct, bProduct) =>
-        twoProductsEq.areEqual(aProduct, bProduct)
+        productEq.areEqual(aProduct, bProduct)
     })
   }
 }

--- a/src/test/scala/com/nec/tpc/TPCHSqlCSpec.scala
+++ b/src/test/scala/com/nec/tpc/TPCHSqlCSpec.scala
@@ -32,7 +32,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAllConfigMap, ConfigMap}
 import scalatags.Text.tags2.{details, summary}
-import com.nec.testing.ProductListEquivalenceCheck.shouldContainTheSameProducts
+import com.nec.testing.ProductListEquivalenceCheck.containTheSameProducts
 import java.time.LocalDate
 
 abstract class TPCHSqlCSpec
@@ -349,7 +349,7 @@ abstract class TPCHSqlCSpec
         )
       ).sortBy(v => (v._1, v._2))
 
-      result should shouldContainTheSameProducts(expected)
+      result should containTheSameProducts(expected)
 
     }
   }
@@ -432,7 +432,7 @@ abstract class TPCHSqlCSpec
           .sorted
 
       val expected = result.sorted
-      resultQuery should shouldContainTheSameProducts(expected)
+      resultQuery should containTheSameProducts(expected)
     }
   }
 
@@ -486,7 +486,7 @@ abstract class TPCHSqlCSpec
     sparkSession.sql(sql).debugSqlHere { ds =>
       val resultCompute = ds.as[(Long, Double, String, Long)].collect().toList.sorted
       val expected = result.sorted
-      resultCompute should shouldContainTheSameProducts(expected)
+      resultCompute should containTheSameProducts(expected)
     }
   }
 
@@ -561,7 +561,7 @@ abstract class TPCHSqlCSpec
         revenue desc
     """
     sparkSession.sql(sql).debugSqlHere { ds =>
-          ds.as[(String, Double)].collect().toList.sorted should  shouldContainTheSameProducts(
+          ds.as[(String, Double)].collect().toList.sorted should  containTheSameProducts(
           List(
             ("INDONESIA", 5.5502041169699915e7),
             ("VIETNAM", 5.529508699669991e7),
@@ -833,7 +833,7 @@ abstract class TPCHSqlCSpec
       ds.as[(Long, String, Double, Double, String, String, String, String)]
             .collect()
             .toList
-            .sorted should shouldContainTheSameProducts(result.sorted)
+            .sorted should containTheSameProducts(result.sorted)
     }
   }
   withTpchViews("Query 11", configuration) { sparkSession =>
@@ -880,7 +880,7 @@ abstract class TPCHSqlCSpec
       .toList
 
     sparkSession.sql(sql).debugSqlHere { ds =>
-      ds.as[(Long, Double)].collect().toList.sorted should shouldContainTheSameProducts(result.sorted)
+      ds.as[(Long, Double)].collect().toList.sorted should containTheSameProducts(result.sorted)
     }
   }
   //This doesn't work.
@@ -1083,11 +1083,8 @@ abstract class TPCHSqlCSpec
 
     sparkSession.sql(sql1).show()
     sparkSession.sql(sql2).debugSqlHere { ds =>
-      assert(
-        ds.as[(Long, String, String, String, Double)].collect.toList.sorted === List(
-          (8449, "Supplier#000008449", "Wp34zim9qYFbVctdW", "20-469-856-8873", 1772627.2087000003)
-        ).sorted
-      )
+      val expected = Seq((8449L, "Supplier#000008449", "Wp34zim9qYFbVctdW", "20-469-856-8873", 1772627.2087000003))
+      ds.as[(Long, String, String, String, Double)].collect.toList.sorted should containTheSameProducts(expected)
     }
     sparkSession.sql(sql3).show()
   }
@@ -1177,9 +1174,7 @@ abstract class TPCHSqlCSpec
         )
     """
     sparkSession.sql(sql).debugSqlHere { ds =>
-      assert(
-        ds.as[Double].collect().toList.sorted === List(348406.05428571434)
-      ) //  348406.0.sorted5
+      ds.as[Double].collect().toList.sorted.map(Tuple1(_)) should containTheSameProducts(Seq(Tuple1(348406.05428571434))) //  348406.0.sorted5
     }
   }
 
@@ -1484,16 +1479,16 @@ abstract class TPCHSqlCSpec
         cntrycode
     """
     sparkSession.sql(sql).debugSqlHere { ds =>
-      assert(
-        ds.as[(String, Long, Double)].collect.toList.sorted === List(
-          ("13", 888, 6737713.989999999),
-          ("17", 861, 6460573.719999993),
-          ("18", 964, 7236687.399999998),
-          ("23", 892, 6701457.950000002),
-          ("29", 948, 7158866.629999999),
-          ("30", 909, 6808436.129999996),
-          ("31", 922, 6806670.179999999)
-        )
+      ds.as[(String, Long, Double)].collect.toList.sorted should containTheSameProducts(
+        List(
+          ("13", 888L, 6737713.989999999),
+          ("17", 861L, 6460573.719999993),
+          ("18", 964L, 7236687.399999998),
+          ("23", 892L, 6701457.950000002),
+          ("29", 948L, 7158866.629999999),
+          ("30", 909L, 6808436.129999996),
+          ("31", 922L, 6806670.179999999)
+        ).sorted
       ) // 13 888 6737713.9.sorted9
     }
   }


### PR DESCRIPTION
- Remove exact checks from TPC-H Q15, Q17, and Q22 so that they can pass

Addresses https://github.com/XpressAI/SparkCyclone/issues/471

![image](https://user-images.githubusercontent.com/255046/152266501-67ce1cb4-219a-4b4d-9bf6-83fdaeecb423.png)
![image](https://user-images.githubusercontent.com/255046/152266573-eb69ac78-7cee-426f-a50b-2003c8fef6ba.png)
![image](https://user-images.githubusercontent.com/255046/152266722-963498ba-68b2-48f9-a480-9913ddc2857d.png)
