### PR TITLE
Use a custom Serializer for exchanges (Part 1 of 2)

### DIFF
--- a/src/main/scala/com/nec/arrow/colvector/UnitColBatch.scala
+++ b/src/main/scala/com/nec/arrow/colvector/UnitColBatch.scala
@@ -1,0 +1,23 @@
+package com.nec.arrow.colvector
+
+import com.nec.ve.VeProcess
+import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.ve.colvector.VeColBatch
+import com.nec.ve.colvector.VeColBatch.VeColVectorSource
+
+final case class UnitColBatch(underlying: GenericColBatch[UnitColVector]) {
+  def deserialize(seqs: List[Array[Byte]])(implicit
+    veProcess: VeProcess,
+    originalCallingContext: OriginalCallingContext,
+    veColVectorSource: VeColVectorSource
+  ): VeColBatch = {
+    val theMap = underlying.cols
+      .zip(seqs)
+      .map { case (unitCv, bytes) =>
+        unitCv -> unitCv.deserialize(bytes)
+      }
+      .toMap
+
+    VeColBatch(underlying.map(ucv => theMap(ucv)))
+  }
+}

--- a/src/main/scala/com/nec/spark/planning/aggregation/VeHashExchangePlan.scala
+++ b/src/main/scala/com/nec/spark/planning/aggregation/VeHashExchangePlan.scala
@@ -19,8 +19,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 
-import java.time.{Duration, Instant}
-
 case class VeHashExchangePlan(exchangeFunction: VeFunction, child: SparkPlan)
   extends UnaryExecNode
   with SupportsVeColBatch
@@ -53,7 +51,7 @@ case class VeHashExchangePlan(exchangeFunction: VeFunction, child: SparkPlan)
 
             val (filled, unfilled) = multiBatches.partition(_._2.head.nonEmpty)
             unfilled.flatMap(_._2).foreach(vcv => vcv.free())
-            filled
+            filled.map { case (p, cl) => p -> VeColBatch.fromList(cl) }
           } finally {
             child.asInstanceOf[SupportsVeColBatch].dataCleanup.cleanup(veColBatch)
           }
@@ -61,7 +59,6 @@ case class VeHashExchangePlan(exchangeFunction: VeFunction, child: SparkPlan)
       }
     }
     .exchangeBetweenVEs(cleanUpInput = true)
-    .mapPartitions(f = _.map(lv => VeColBatch.fromList(lv)), preservesPartitioning = true)
 
   override def output: Seq[Attribute] = child.output
 

--- a/src/main/scala/com/nec/spark/planning/plans/VectorEngineJoinPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VectorEngineJoinPlan.scala
@@ -36,12 +36,10 @@ case class VectorEngineJoinPlan(
         right = right.asInstanceOf[SupportsKeyedVeColBatch].executeVeColumnarKeyed(),
         cleanUpInput = true
       )
-      .map { case (leftListVcv, rightListVcv) =>
+      .map { case (leftColBatch, rightColBatch) =>
         import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
         import com.nec.spark.SparkCycloneExecutorPlugin.source
         withVeLibrary { libRefJoin =>
-          val leftColBatch = VeColBatch.fromList(leftListVcv)
-          val rightColBatch = VeColBatch.fromList(rightListVcv)
           logger.debug(s"Mapping ${leftColBatch} / ${rightColBatch} for join")
           import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
           val batch =

--- a/src/main/scala/com/nec/ve/colvector/VeColVector.scala
+++ b/src/main/scala/com/nec/ve/colvector/VeColVector.scala
@@ -16,7 +16,7 @@ import com.nec.spark.SparkCycloneExecutorPlugin.metrics.{
   measureRunningTime,
   registerSerializationTime
 }
-import com.nec.arrow.colvector.{BytePointerColVector, GenericColVector}
+import com.nec.arrow.colvector.{BytePointerColVector, GenericColVector, UnitColVector}
 import com.nec.cache.VeColColumnarVector
 import com.nec.spark.agile.CFunctionGeneration.{VeScalarType, VeString, VeType}
 import com.nec.spark.agile.SparkExpressionToCExpression.likelySparkType
@@ -32,6 +32,7 @@ import org.bytedeco.javacpp.BytePointer
 import sun.misc.Unsafe
 
 final case class VeColVector(underlying: GenericColVector[Long]) {
+  def toUnit: UnitColVector = underlying.toUnit
   def allAllocations = containerLocation :: bufferLocations
   def bufferLocations = underlying.buffers
   def containerLocation = underlying.containerLocation
@@ -151,11 +152,7 @@ final case class VeColVector(underlying: GenericColVector[Long]) {
           float8Vector.getValidityBufferAddress,
           Math.ceil(numItems / 64.0).toInt * 8
         )
-        getUnsafe.copyMemory(
-          vhTarget.address(),
-          float8Vector.getDataBufferAddress,
-          dataSize
-        )
+        getUnsafe.copyMemory(vhTarget.address(), float8Vector.getDataBufferAddress, dataSize)
       }
       float8Vector
     case VeScalarType.VeNullableLong =>
@@ -172,11 +169,7 @@ final case class VeColVector(underlying: GenericColVector[Long]) {
           bigIntVector.getValidityBufferAddress,
           Math.ceil(numItems / 64.0).toInt * 8
         )
-        getUnsafe.copyMemory(
-          vhTarget.address(),
-          bigIntVector.getDataBufferAddress,
-          dataSize
-        )
+        getUnsafe.copyMemory(vhTarget.address(), bigIntVector.getDataBufferAddress, dataSize)
       }
       bigIntVector
     case VeScalarType.VeNullableInt =>
@@ -193,11 +186,7 @@ final case class VeColVector(underlying: GenericColVector[Long]) {
           intVector.getValidityBufferAddress,
           Math.ceil(numItems / 64.0).toInt * 8
         )
-        getUnsafe.copyMemory(
-          vhTarget.address(),
-          intVector.getDataBufferAddress,
-          dataSize
-        )
+        getUnsafe.copyMemory(vhTarget.address(), intVector.getDataBufferAddress, dataSize)
       }
       intVector
     case VeString =>
@@ -223,16 +212,8 @@ final case class VeColVector(underlying: GenericColVector[Long]) {
           vcvr.getValidityBufferAddress,
           Math.ceil(numItems / 64.0).toInt * 8
         )
-        getUnsafe.copyMemory(
-          offTarget.address(),
-          vcvr.getOffsetBufferAddress,
-          offsetsSize
-        )
-        getUnsafe.copyMemory(
-          vhTarget.address(),
-          vcvr.getDataBufferAddress,
-          dataSize
-        )
+        getUnsafe.copyMemory(offTarget.address(), vcvr.getOffsetBufferAddress, offsetsSize)
+        getUnsafe.copyMemory(vhTarget.address(), vcvr.getDataBufferAddress, dataSize)
       }
       vcvr
     case other => sys.error(s"Not supported for conversion to arrow vector: $other")

--- a/src/main/scala/com/nec/ve/serializer/VeDeserializationStream.scala
+++ b/src/main/scala/com/nec/ve/serializer/VeDeserializationStream.scala
@@ -1,0 +1,59 @@
+package com.nec.ve.serializer
+
+import com.nec.ve.{VeColBatch, VeProcess}
+import com.nec.ve.colvector.VeColBatch.VeColVectorSource
+import org.apache.spark.internal.Logging
+import org.apache.spark.serializer.DeserializationStream
+
+import java.io.{DataInputStream, EOFException, InputStream}
+import scala.reflect.ClassTag
+
+class VeDeserializationStream(in: InputStream)(implicit
+  veProcess: VeProcess,
+  veColVectorSource: VeColVectorSource
+) extends DeserializationStream
+  with Logging {
+  logDebug(s"Inputting from ==> ${in}; ${in.getClass}")
+  val dataInputStream = new DataInputStream(in)
+
+  /**
+   * Generally, the call chain looks like:
+   *        at com.nec.ve.VeSerializer$VeDeserializationStream.readObject(VeSerializer.scala:78)
+   *        at org.apache.spark.serializer.DeserializationStream.readKey(Serializer.scala:156) (or readValue)
+   *        at org.apache.spark.serializer.DeserializationStream$$anon$2.getNext(Serializer.scala:188)
+   *        at org.apache.spark.serializer.DeserializationStream$$anon$2.getNext(Serializer.scala:185)
+   *        at org.apache.spark.util.NextIterator.hasNext(NextIterator.scala:73)
+   *        at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:488)
+   *        at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:458)
+   *        at org.apache.spark.util.CompletionIterator.hasNext(CompletionIterator.scala:31)
+   *        at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
+   *        at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:458)
+   *        at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:489)
+   *        at scala.collection.Iterator.isEmpty(Iterator.scala:385)
+   *        at scala.collection.Iterator.isEmpty$(Iterator.scala:385)
+   *        at scala.collection.AbstractIterator.isEmpty(Iterator.scala:1429)
+   *        at scala.collection.TraversableOnce.max(TraversableOnce.scala:233)
+   *        at scala.collection.TraversableOnce.max$(TraversableOnce.scala:232)
+   *        at scala.collection.AbstractIterator.max(Iterator.scala:1429)
+   *        at com.nec.ve.VERDDSpec$.$anonfun$exchangeBatches$7(VERDDSpec.scala:120)
+   *
+   * For our use case, Spark only writes Ints and VeColBatch for serialization.
+   */
+  override def readObject[T: ClassTag](): T =
+    in.synchronized {
+      dataInputStream.readInt() match {
+        case IntTag =>
+          dataInputStream.readInt()
+        case CbTag =>
+          import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+          VeColBatch.fromStream(dataInputStream)
+        case -1 =>
+          throw new EOFException()
+        case other =>
+          sys.error(s"Unexpected tag: ${other}, expected only ${IntTag} or ${CbTag}")
+      }
+    }.asInstanceOf[T]
+
+  override def close(): Unit =
+    dataInputStream.close()
+}

--- a/src/main/scala/com/nec/ve/serializer/VeSerializationStream.scala
+++ b/src/main/scala/com/nec/ve/serializer/VeSerializationStream.scala
@@ -1,0 +1,52 @@
+package com.nec.ve.serializer
+
+import com.nec.ve.VeProcess
+import com.nec.ve.colvector.VeColBatch
+import com.nec.ve.colvector.VeColBatch.VeColVectorSource
+import org.apache.spark.internal.Logging
+import org.apache.spark.serializer.SerializationStream
+
+import java.io.{DataOutputStream, OutputStream}
+import scala.reflect.ClassTag
+
+class VeSerializationStream(out: OutputStream)(implicit
+  veProcess: VeProcess,
+  veColVectorSource: VeColVectorSource
+) extends SerializationStream
+  with Logging {
+  val dataOutputStream = new DataOutputStream(out)
+  logDebug(s"Outputting to ==> ${out}; ${out.getClass}")
+
+  /**
+   * Generally, the call chain looks like:
+   * at com.nec.ve.VeSerializer$VeSerializationStream.writeObject(VeSerializer.scala:64)
+   * at org.apache.spark.serializer.SerializationStream.writeValue(Serializer.scala:134)
+   * at org.apache.spark.storage.DiskBlockObjectWriter.write(DiskBlockObjectWriter.scala:249)
+   * at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:158)
+   * at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
+   *
+   * For our use case, Spark only writes Ints and VeColBatch for serialization.
+   */
+  override def writeObject[T: ClassTag](t: T): SerializationStream = {
+    t match {
+      case i: java.lang.Integer =>
+        dataOutputStream.writeInt(IntTag)
+        dataOutputStream.writeInt(i)
+        this
+      case v: VeColBatch =>
+        dataOutputStream.writeInt(CbTag)
+        v.serializeToStream(dataOutputStream)
+        this
+      case other =>
+        sys.error(s"Not supported here to write item of type ${other.getClass.getCanonicalName}")
+    }
+  }
+
+  override def flush(): Unit = {
+    dataOutputStream.flush()
+  }
+
+  override def close(): Unit = {
+    dataOutputStream.close()
+  }
+}

--- a/src/main/scala/com/nec/ve/serializer/VeSerializer.scala
+++ b/src/main/scala/com/nec/ve/serializer/VeSerializer.scala
@@ -1,0 +1,8 @@
+package com.nec.ve.serializer
+
+import org.apache.spark.SparkConf
+import org.apache.spark.serializer.{Serializer, SerializerInstance}
+
+class VeSerializer(conf: SparkConf, cleanUpInput: Boolean) extends Serializer with Serializable {
+  override def newInstance(): SerializerInstance = new VeSerializerInstance(cleanUpInput)
+}

--- a/src/main/scala/com/nec/ve/serializer/VeSerializerInstance.scala
+++ b/src/main/scala/com/nec/ve/serializer/VeSerializerInstance.scala
@@ -1,0 +1,33 @@
+package com.nec.ve.serializer
+
+import com.nec.spark.SparkCycloneExecutorPlugin
+import org.apache.spark.internal.Logging
+import org.apache.spark.serializer.{DeserializationStream, SerializationStream, SerializerInstance}
+
+import java.io.{InputStream, OutputStream}
+import java.nio.ByteBuffer
+import scala.reflect.ClassTag
+
+class VeSerializerInstance(cleanUpInput: Boolean) extends SerializerInstance with Logging {
+  override def serialize[T: ClassTag](t: T): ByteBuffer =
+    sys.error("This should not be reached")
+
+  override def deserialize[T: ClassTag](bytes: ByteBuffer): T =
+    sys.error("This should not be reached")
+
+  override def deserialize[T: ClassTag](bytes: ByteBuffer, loader: ClassLoader): T =
+    sys.error("This should not be reached")
+
+  override def serializeStream(s: OutputStream): SerializationStream =
+    new VeSerializationStream(s)(
+      SparkCycloneExecutorPlugin.veProcess,
+      SparkCycloneExecutorPlugin.source
+    )
+
+  override def deserializeStream(s: InputStream): DeserializationStream =
+    new VeDeserializationStream(s)(
+      SparkCycloneExecutorPlugin.veProcess,
+      SparkCycloneExecutorPlugin.source
+    )
+
+}

--- a/src/main/scala/com/nec/ve/serializer/package.scala
+++ b/src/main/scala/com/nec/ve/serializer/package.scala
@@ -1,0 +1,6 @@
+package com.nec.ve
+
+package object serializer {
+  val CbTag: Int = 91
+  val IntTag: Int = 92
+}

--- a/src/test/scala/com/nec/ve/JoinRDDSpec.scala
+++ b/src/test/scala/com/nec/ve/JoinRDDSpec.scala
@@ -56,7 +56,7 @@ object JoinRDDSpec {
         cleanUpInput = true
       )
       .map { case (la, lb) =>
-        (la.flatMap(_.toList), lb.flatMap(_.toList))
+        (la.cols.flatMap(_.toList), lb.cols.flatMap(_.toList))
       }
       .collect()
       .toList

--- a/src/test/scala/com/nec/ve/VERDDSpec.scala
+++ b/src/test/scala/com/nec/ve/VERDDSpec.scala
@@ -103,7 +103,7 @@ object VERDDSpec {
             }),
         preservesPartitioning = true
       )
-      .exchangeBetweenVEs()
+      .exchangeBetweenVEs(cleanUpInput = true)
       .mapPartitions(vectorIter =>
         Iterator
           .continually {


### PR DESCRIPTION
Doing this change in 2 parts, as was having unexpected failures on Query 1, so better to do it in stages as it's more or less code-complete.

The key concept is that we intercept/serialize only when it is needed to do (for exchange, rather than generally) so to avoid complications in dealing with unfamiliar types. That is where we therefore pass the serializer explicitly.

In part 2 (next PR), we will adapt a streaming-writing approach (in this change, it is using on-heap/inefficient approaches; we just want to have the right framework in place first).

Depends on #480 (so before that is merged, there is a bit more noise in the PR) and uses code extracted from #479.

Query 1 and Query 2 work.