### PR TITLE
Changed the old style C casts into new style C++ casts.

### DIFF
--- a/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
+++ b/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
@@ -590,7 +590,7 @@ object CFunctionGeneration {
             },
             outputs.map { cVector =>
               CodeLines.from(
-                s"${cVector.veType.cVectorType}* ${cVector.name} = (${cVector.veType.cVectorType} *)malloc(sizeof(${cVector.veType.cVectorType}));",
+                s"${cVector.veType.cVectorType}* ${cVector.name} = static_cast<${cVector.veType.cVectorType}*>(malloc(sizeof(${cVector.veType.cVectorType})));",
                 s"*${cVector.name}_mo = ${cVector.name};"
               )
             },
@@ -625,8 +625,8 @@ object CFunctionGeneration {
         sortOutput.map { case CScalarVector(outputName, outputVeType) =>
           CodeLines.from(
             s"$outputName->count = input_0->count;",
-            s"$outputName->validityBuffer = (uint64_t *) calloc(($outputName->count + 63) / 64, sizeof(uint64_t));",
-            s"$outputName->data = (${outputVeType.cScalarType}*) malloc($outputName->count * sizeof(${outputVeType.cScalarType}));"
+            s"$outputName->validityBuffer = static_cast<uint64_t*>(calloc(($outputName->count + 63) / 64, sizeof(uint64_t)));",
+            s"$outputName->data = static_cast<${outputVeType.cScalarType}*>(malloc($outputName->count * sizeof(${outputVeType.cScalarType})));"
           )
         },
         "// create an array of indices, which by default are in order, but afterwards are out of order.",
@@ -809,8 +809,8 @@ object CFunctionGeneration {
         case (Right(NamedTypedCExpression(outputName, veType, _)), idx) =>
           CodeLines.from(
             s"$outputName->count = input_0->count;",
-            s"$outputName->data = (${veType.cScalarType}*) malloc($outputName->count * sizeof(${veType.cScalarType}));",
-            s"$outputName->validityBuffer = (uint64_t *) calloc(($outputName->count + 63) / 64, sizeof(uint64_t));"
+            s"$outputName->data = static_cast<${veType.cScalarType}*>(malloc($outputName->count * sizeof(${veType.cScalarType})));",
+            s"$outputName->validityBuffer = static_cast<uint64_t*>(calloc(($outputName->count + 63) / 64, sizeof(uint64_t)));"
           )
         case (Left(NamedStringExpression(name, stringProducer: FrovedisStringProducer)), idx) =>
           StringProducer
@@ -894,8 +894,8 @@ object CFunctionGeneration {
           joinExpression.fold(whenProj =
             _ =>
               CodeLines.from(
-                s"${outputName}->data = (${veType.cScalarType}*) malloc(left_out.size() * sizeof(${veType.cScalarType}));",
-                s"${outputName}->validityBuffer = (uint64_t *) calloc(validityBuffSize, sizeof(uint64_t));"
+                s"${outputName}->data = static_cast<${veType.cScalarType}*>(malloc(left_out.size() * sizeof(${veType.cScalarType})));",
+                s"${outputName}->validityBuffer = static_cast<uint64_t*>(calloc(validityBuffSize, sizeof(uint64_t)));"
               )
           )
         },
@@ -1053,8 +1053,8 @@ object CFunctionGeneration {
             joinExpression.fold(whenProj =
               _ =>
                 CodeLines.from(
-                  s"${outputName}->data = (${veType.cScalarType}*) malloc((left_out.size() + outer_idx.size()) * sizeof(${veType.cScalarType}));",
-                  s"${outputName}->validityBuffer = (uint64_t *) calloc(validityBuffSize, sizeof(uint64_t));"
+                  s"${outputName}->data = static_cast<${veType.cScalarType}*>(malloc((left_out.size() + outer_idx.size()) * sizeof(${veType.cScalarType})));",
+                  s"${outputName}->validityBuffer = static_cast<uint64_t*>(calloc(validityBuffSize, sizeof(uint64_t)));"
                 )
             )
         },

--- a/src/main/scala/com/nec/spark/agile/groupby/GroupByOutline.scala
+++ b/src/main/scala/com/nec/spark/agile/groupby/GroupByOutline.scala
@@ -156,7 +156,7 @@ object GroupByOutline {
   def dealloc(cv: CVector): CodeLines = CodeLines.empty
 
   def declare(cv: CVector): CodeLines = CodeLines.from(
-    s"${cv.veType.cVectorType} *${cv.name} = (${cv.veType.cVectorType}*)malloc(sizeof(${cv.veType.cVectorType}));"
+    s"${cv.veType.cVectorType} *${cv.name} = static_cast<${cv.veType.cVectorType}*>(malloc(sizeof(${cv.veType.cVectorType})));"
   )
 
   final case class StringReference(name: String)
@@ -199,8 +199,8 @@ object GroupByOutline {
   ): CodeLines =
     CodeLines.from(
       s"$variableName->count = ${countExpression};",
-      s"$variableName->data = (${veScalarType.cScalarType}*) malloc($variableName->count * sizeof(${veScalarType.cScalarType}));",
-      s"$variableName->validityBuffer = (uint64_t *) calloc((${countExpression} + 63) / 64, sizeof(uint64_t));"
+      s"$variableName->data = static_cast<${veScalarType.cScalarType}*>(malloc($variableName->count * sizeof(${veScalarType.cScalarType})));",
+      s"$variableName->validityBuffer = static_cast<uint64_t*>(calloc((${countExpression} + 63) / 64, sizeof(uint64_t)));"
     )
 
   def scalarVectorFromStdVector(
@@ -209,7 +209,7 @@ object GroupByOutline {
     sourceName: String
   ): CodeLines =
     CodeLines.from(
-      s"$targetName = (${veScalarType.cVectorType}*)malloc(sizeof(${veScalarType.cVectorType}));",
+      s"$targetName = static_cast<${veScalarType.cVectorType}*>(malloc(sizeof(${veScalarType.cVectorType})));",
       initializeScalarVector(veScalarType, targetName, s"$sourceName.size()"),
       s"for ( int x = 0; x < $sourceName.size(); x++ ) {",
       CodeLines

--- a/src/main/scala/com/nec/ve/GroupingFunction.scala
+++ b/src/main/scala/com/nec/ve/GroupingFunction.scala
@@ -99,25 +99,25 @@ object GroupingFunction {
             s"auto dsize = ${input.name}[0]->dataSize;",
             "",
             // Allocate the nullable_varchar_vector[] with size 1
-            s"*${output.name} = (${output.veType.cVectorType} *) malloc(sizeof(nullptr));",
+            s"*${output.name} = static_cast<${output.veType.cVectorType}*>(malloc(sizeof(nullptr)));",
             // Allocate the nullable_varchar_vector at [0]
-            s"${output.name}[0] = (${output.veType.cVectorType} *) malloc(sizeof(${output.veType.cVectorType}));",
+            s"${output.name}[0] = static_cast<${output.veType.cVectorType}*>(malloc(sizeof(${output.veType.cVectorType})));",
             // Set count and dataSize
             s"${output.name}[0]->count = count;",
             s"${output.name}[0]->dataSize = dsize;",
             "",
             // Set data - allocate and then copy over
-            s"${output.name}[0]->data = (char *) malloc(dsize);",
+            s"${output.name}[0]->data = static_cast<char*>(malloc(dsize));",
             s"memcpy(${output.name}[0]->data, ${input.name}[0]->data, dsize);",
             "",
             // Set offsets - allocate and then copy over
             s"auto obytes_count = (count + 1) * sizeof(int32_t);",
-            s"${output.name}[0]->offsets = (int32_t *) malloc(obytes_count);",
+            s"${output.name}[0]->offsets = static_cast<int32_t*>(malloc(obytes_count));",
             s"memcpy(${output.name}[0]->offsets, ${input.name}[0]->offsets, obytes_count);",
             "",
             // Set validityBuffer - preserve the validity bits
             s"auto vbytes_count = ((count + 63) / 64) * sizeof(uint64_t);",
-            s"${output.name}[0]->validityBuffer = (uint64_t *) calloc(vbytes_count, 1);",
+            s"${output.name}[0]->validityBuffer = static_cast<uint64_t*>(calloc(vbytes_count, 1));",
             s"memcpy(${output.name}[0]->validityBuffer, ${input.name}[0]->validityBuffer, vbytes_count);"
           )
         }
@@ -129,20 +129,20 @@ object GroupingFunction {
             s"auto count = ${input.name}[0]->count;",
             "",
             // Allocate the nullable_T_vector[] with size 1
-            s"*${output.name} = (${output.veType.cVectorType} *) malloc(sizeof(nullptr));",
+            s"*${output.name} = static_cast<${output.veType.cVectorType}*>(malloc(sizeof(nullptr)));",
             // Allocate the nullable_T_vector at [0]
-            s"${output.name}[0] = (${output.veType.cVectorType} *) malloc(sizeof(${output.veType.cVectorType}));",
+            s"${output.name}[0] = static_cast<${output.veType.cVectorType}*>(malloc(sizeof(${output.veType.cVectorType})));",
             // Set count
             s"${output.name}[0]->count = count;",
             "",
             // Set data - allocate and then copy over
             s"auto dbytes_count = count * sizeof(${scalar.cScalarType});",
-            s"${output.name}[0]->data = (${scalar.cScalarType} *) malloc(dbytes_count);",
+            s"${output.name}[0]->data = static_cast<${scalar.cScalarType}*>(malloc(dbytes_count));",
             s"memcpy(${output.name}[0]->data, ${input.name}[0]->data, dbytes_count);",
             "",
             // Set validityBuffer - preserve the validity bits
             s"auto vbytes_count = ((count + 63) / 64) * sizeof(uint64_t);",
-            s"${output.name}[0]->validityBuffer = (uint64_t *) calloc(vbytes_count, 1);",
+            s"${output.name}[0]->validityBuffer = static_cast<uint64_t*>(calloc(vbytes_count, 1));",
             s"memcpy(${output.name}[0]->validityBuffer, ${input.name}[0]->validityBuffer, vbytes_count);"
           )
         }
@@ -263,13 +263,13 @@ object GroupingFunction {
     ) {
       CodeLines.from(
         // Allocate the nullable_T_vector[] with size buckets
-        s"*${output.name} = (${output.veType.cVectorType} *) malloc(sizeof(nullptr) * ${buckets});",
+        s"*${output.name} = static_cast<${output.veType.cVectorType}*>(malloc(sizeof(nullptr) * ${buckets}));",
         "",
         // Loop over each bucket
         CodeLines.forLoop("b", s"${buckets}") {
           CodeLines.from(
             // Allocate the nullable_T_vector at [0]
-            s"${output.name}[b] = (${output.veType.cVectorType} *) malloc(sizeof(${output.veType.cVectorType}));",
+            s"${output.name}[b] = static_cast<${output.veType.cVectorType}*>(malloc(sizeof(${output.veType.cVectorType})));",
             // Perform the copy based on type T (scalar or varchar)
             copyStmt
           )

--- a/src/main/scala/com/nec/ve/MergerFunction.scala
+++ b/src/main/scala/com/nec/ve/MergerFunction.scala
@@ -62,9 +62,9 @@ object MergerFunction {
     CodeLines.scoped(s"Merge ${in}[...] into ${out}[0]") {
       CodeLines.from(
         // Allocate the nullable_T_vector[]
-        s"*${out} = (${vetype.cVectorType} *) malloc(sizeof(nullptr));",
+        s"*${out} = static_cast<${vetype.cVectorType}*>(malloc(sizeof(nullptr)));",
         // Allocate new mullable_T_vector
-        s"${out}[0] = (${vetype.cVectorType} *) malloc(sizeof(${vetype.cVectorType}));",
+        s"${out}[0] = static_cast<${vetype.cVectorType}*>(malloc(sizeof(${vetype.cVectorType})));",
         // Set a temporary pointer
         s"auto *${tmp} = ${out}[0];",
         "",

--- a/src/test/scala/com/nec/cmake/eval/LongBigIntRetrieveSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/LongBigIntRetrieveSpec.scala
@@ -42,8 +42,8 @@ final class LongBigIntRetrieveSpec extends AnyFreeSpec {
             .from(
               """ extern "C" long x(nullable_bigint_vector *v) { """,
               "v->count = 1;",
-              "v->data = (int64_t *)malloc(v->count * sizeof(int64_t));",
-              "v->validityBuffer = (uint64_t *) calloc((v->count + 63) / 64, sizeof(uint64_t)); ",
+              "v->data = static_cast<int64_t*>(malloc(v->count * sizeof(int64_t)));",
+              "v->validityBuffer = static_cast<uint64_t*>(calloc((v->count + 63) / 64, sizeof(uint64_t)));",
               "v->data[0] = 123;",
               "set_validity(v->validityBuffer, 0, 1); ",
               "return 0;",

--- a/src/test/scala/com/nec/ve/PureVeFunctions.scala
+++ b/src/test/scala/com/nec/ve/PureVeFunctions.scala
@@ -12,7 +12,7 @@ object PureVeFunctions {
       .from(
         CodeLines
           .from(
-            "nullable_double_vector* o = (nullable_double_vector *)malloc(sizeof(nullable_double_vector));",
+            "nullable_double_vector* o = static_cast<nullable_double_vector*>(malloc(sizeof(nullable_double_vector)));",
             "*o_p = o;",
             GroupByOutline.initializeScalarVector(VeScalarType.VeNullableDouble, "o", "input[0]->count"),
             "for ( int i = 0; i < input[0]->count; i++ ) {",
@@ -33,7 +33,7 @@ object PureVeFunctions {
       .from(
         "int SETS_TO_DO = 5;",
         "int MAX_SET_ID = SETS_TO_DO - 1;",
-        "*o_p = (nullable_double_vector*) malloc(sizeof(nullptr) * SETS_TO_DO);",
+        "*o_p = static_cast<nullable_double_vector*>(malloc(sizeof(nullptr) * SETS_TO_DO));",
         "for ( int s = 0; s < SETS_TO_DO; s++ ) {",
         CodeLines
           .from(


### PR DESCRIPTION
(int*)(xxx) became static_cast<int*>(xxx).

Note that these casts are strictly not required. Casting from nullptr to another type of pointer can be done via an implicit conversion. But there is significant value in documenting what type the value is being converted into. Also, static_cast has no runtime overhead.