### PR TITLE
Added code to call the ceil_div() function

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.cc
@@ -29,6 +29,7 @@
 #include <chrono>
 #include <ctime>
 #include <algorithm>
+#include "frovedis/core/utility.hpp"
 #include "frovedis/text/dict.hpp"
 #include "frovedis/text/words.hpp"
 #include "frovedis/text/char_int_conv.hpp"
@@ -157,7 +158,7 @@ void words_to_varchar_vector(frovedis::words& in, nullable_varchar_vector *out) 
         std::cout << std::endl;
     #endif
 
-    size_t validity_count = ceil(out->count / 64.0);
+    size_t validity_count = frovedis::ceil_div(out->count, int32_t(64));
     out->validityBuffer = (uint64_t *)malloc(validity_count * sizeof(uint64_t));
     if (!out->validityBuffer) {
         std::cout << "Failed to malloc " << validity_count << " * sizeof(uint64_t)" << std::endl;

--- a/src/main/resources/com/nec/cyclone/cpp/examples.cpp
+++ b/src/main/resources/com/nec/cyclone/cpp/examples.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <tuple>
 #include "frovedis/core/radix_sort.hpp"
+#include "frovedis/core/utility.hpp"
 #include "frovedis/dataframe/join.hpp"
 #include "frovedis/core/set_operations.hpp"
 #include "cyclone/cyclone.hpp"
@@ -41,7 +42,7 @@ nullable_varchar_vector * from_vec(const std::vector<std::string> &data) {
   }
 
   {
-    size_t vcount = ceil(data.size() / 64.0);
+    size_t vcount = frovedis::ceil_div(data.size(), size_t(64));
     vec->validityBuffer = new uint64_t[vcount];
     for (auto i = 0; i < vcount; i++) {
       vec->validityBuffer[i] = 0xffffffffffffffff;

--- a/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
+++ b/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
@@ -625,7 +625,7 @@ object CFunctionGeneration {
         sortOutput.map { case CScalarVector(outputName, outputVeType) =>
           CodeLines.from(
             s"$outputName->count = input_0->count;",
-            s"$outputName->validityBuffer = static_cast<uint64_t*>(calloc(($outputName->count + 63) / 64, sizeof(uint64_t)));",
+            s"$outputName->validityBuffer = static_cast<uint64_t*>(calloc(frovedis::ceil_div(size_t($outputName->count), size_t(64)), sizeof(uint64_t)));",
             s"$outputName->data = static_cast<${outputVeType.cScalarType}*>(malloc($outputName->count * sizeof(${outputVeType.cScalarType})));"
           )
         },
@@ -810,7 +810,7 @@ object CFunctionGeneration {
           CodeLines.from(
             s"$outputName->count = input_0->count;",
             s"$outputName->data = static_cast<${veType.cScalarType}*>(malloc($outputName->count * sizeof(${veType.cScalarType})));",
-            s"$outputName->validityBuffer = static_cast<uint64_t*>(calloc(($outputName->count + 63) / 64, sizeof(uint64_t)));"
+            s"$outputName->validityBuffer = static_cast<uint64_t*>(calloc(frovedis::ceil_div(size_t($outputName->count), size_t(64)), sizeof(uint64_t)));"
           )
         case (Left(NamedStringExpression(name, stringProducer: FrovedisStringProducer)), idx) =>
           StringProducer
@@ -889,7 +889,7 @@ object CFunctionGeneration {
         "std::vector<size_t> right_out;",
         "std::vector<size_t> left_out;",
         s"frovedis::equi_join<${veInnerJoin.leftKey.veType.cScalarType}>(left_vec, left_idx, right_vec, right_idx, left_out, right_out);",
-        "long validityBuffSize = ceil(left_out.size() / 64.0);",
+        "long validityBuffSize = frovedis::ceil_div(size_t(left_out.size()), size_t(64));",
         veInnerJoin.outputs.map { case NamedJoinExpression(outputName, veType, joinExpression) =>
           joinExpression.fold(whenProj =
             _ =>
@@ -1047,7 +1047,7 @@ object CFunctionGeneration {
               s"std::vector<size_t> outer_idx = frovedis::outer_equi_join<std::tuple<${veOuterJoin.leftKey.veType.cScalarType}, int>>(right_vec, right_idx, left_vec, left_idx, right_out, left_out);"
             )
         },
-        List("long validityBuffSize = ceil((left_out.size() + outer_idx.size()) / 64.0);"),
+        List("long validityBuffSize = frovedis::ceil_div(size_t(left_out.size() + outer_idx.size()), size_t(64));"),
         veOuterJoin.outputs.map {
           case OuterJoinOutput(NamedJoinExpression(outputName, veType, joinExpression), _) =>
             joinExpression.fold(whenProj =

--- a/src/main/scala/com/nec/spark/agile/groupby/GroupByOutline.scala
+++ b/src/main/scala/com/nec/spark/agile/groupby/GroupByOutline.scala
@@ -200,7 +200,7 @@ object GroupByOutline {
     CodeLines.from(
       s"$variableName->count = ${countExpression};",
       s"$variableName->data = static_cast<${veScalarType.cScalarType}*>(malloc($variableName->count * sizeof(${veScalarType.cScalarType})));",
-      s"$variableName->validityBuffer = static_cast<uint64_t*>(calloc((${countExpression} + 63) / 64, sizeof(uint64_t)));"
+      s"$variableName->validityBuffer = static_cast<uint64_t*>(calloc(frovedis::ceil_div(size_t(${countExpression}), size_t(64)), sizeof(uint64_t)));"
     )
 
   def scalarVectorFromStdVector(

--- a/src/main/scala/com/nec/ve/GroupingFunction.scala
+++ b/src/main/scala/com/nec/ve/GroupingFunction.scala
@@ -116,7 +116,7 @@ object GroupingFunction {
             s"memcpy(${output.name}[0]->offsets, ${input.name}[0]->offsets, obytes_count);",
             "",
             // Set validityBuffer - preserve the validity bits
-            s"auto vbytes_count = ((count + 63) / 64) * sizeof(uint64_t);",
+            s"auto vbytes_count = frovedis::ceil_div(size_t(count), size_t(64)) * sizeof(uint64_t);",
             s"${output.name}[0]->validityBuffer = static_cast<uint64_t*>(calloc(vbytes_count, 1));",
             s"memcpy(${output.name}[0]->validityBuffer, ${input.name}[0]->validityBuffer, vbytes_count);"
           )
@@ -141,7 +141,7 @@ object GroupingFunction {
             s"memcpy(${output.name}[0]->data, ${input.name}[0]->data, dbytes_count);",
             "",
             // Set validityBuffer - preserve the validity bits
-            s"auto vbytes_count = ((count + 63) / 64) * sizeof(uint64_t);",
+            s"auto vbytes_count = frovedis::ceil_div(size_t(count), size_t(64)) * sizeof(uint64_t);",
             s"${output.name}[0]->validityBuffer = static_cast<uint64_t*>(calloc(vbytes_count, 1));",
             s"memcpy(${output.name}[0]->validityBuffer, ${input.name}[0]->validityBuffer, vbytes_count);"
           )

--- a/src/test/scala/com/nec/cmake/eval/LongBigIntRetrieveSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/LongBigIntRetrieveSpec.scala
@@ -43,7 +43,7 @@ final class LongBigIntRetrieveSpec extends AnyFreeSpec {
               """ extern "C" long x(nullable_bigint_vector *v) { """,
               "v->count = 1;",
               "v->data = static_cast<int64_t*>(malloc(v->count * sizeof(int64_t)));",
-              "v->validityBuffer = static_cast<uint64_t*>(calloc((v->count + 63) / 64, sizeof(uint64_t)));",
+              "v->validityBuffer = static_cast<uint64_t*>(calloc(frovedis::ceil_div(size_t(v->count), size_t(64)), sizeof(uint64_t)));",
               "v->data[0] = 123;",
               "set_validity(v->validityBuffer, 0, 1); ",
               "return 0;",


### PR DESCRIPTION
function is found in src/main/resources/com/nec/cyclone/cpp/frovedis/core/utility.hpp

We used to do an inefficient ceiling conversion that involved conversion to and from a floating point value. This function is very efficient. This is a template function, so both arguments have to be exactly the same data type. This required adding casts to the arguments.