### PR TITLE
Implement `clone()` and `equals()` methods for the `nullable_T_vector` structs 

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/Makefile
+++ b/src/main/resources/com/nec/cyclone/cpp/Makefile
@@ -4,7 +4,8 @@ CPP_OPTS = -std=gnu++17 \
 	-I. \
 	-O4 \
 	-finline-functions \
-	-pthread
+	-pthread \
+	-Werror=return-type
 
 # Add extra flags if we're using nc++
 ifeq (${shell ls /opt/nec/ve/bin/nc++ > /dev/null 2>&1 && echo 1 || echo 0}, 1)

--- a/src/main/resources/com/nec/cyclone/cpp/README.md
+++ b/src/main/resources/com/nec/cyclone/cpp/README.md
@@ -1,8 +1,8 @@
 # Cyclone C++ Library
 
-This Cyclone C++ library is and linked to by the Spark Cyclone plugin as it
-generates C++ code to perform Spark SQL queries on the Vector Engine.  The
-library contains the following:
+The Cyclone C++ library is linked to by the Spark Cyclone plugin as it generates
+C++ code to perform Spark SQL queries on the Vector Engine.  The library contains
+the following:
 
 * A subset of the [Frovedis](https://github.com/frovedis/frovedis) library that
   contains vectorizable data structures and algorithms that are used by Spark
@@ -12,12 +12,13 @@ library contains the following:
 * A collection of common functions that are to be called by Spark Cyclone-generated
   C++ code.
 
-This library has been written so that it can be built standalone.  This allows us
-the following:
+This library has been written so that it can be built standalone.  This allows
+for the following:
 
-* To experiment with Frovedis and algorithm optimizations as needed.
-* Enables for C++ code to be tested and benchmarked on its own
-* Reduces the complexity of C++ code generation from the Spark Cyclone plugin,
+* Experiment with the Frovedis API and algorithm optimizations as needed.
+* Test and benchmark the C++ code on its own before integrating it into the Spark
+  Cyclone plugin's code generation.
+* Reduce the complexity of C++ code generation from the Spark Cyclone plugin,
   which for all intents and purposes is not unit-testable.
 
 
@@ -27,7 +28,8 @@ the following:
 ### Building the Library
 
 The Cyclone C++ library is generally portable, and building the library only
-requires `make` and a `c++` compiler that is visible in the `PATH`:
+requires `make` and a `c++` compiler that is visible in the `PATH` and supports
+**C++17** (with GNU extensions):
 
 ```sh
 make
@@ -58,10 +60,19 @@ make examples
 
 ### Adding New Code
 
-New code should be added to the `cyclone/` subdirectory and `cyclone` namespace.
-Corresponding tests should be added to the `tests/` subdirectory as a header
-file and `cyclone::tests` namespace.  **The tests file will then need to be
-`#include`d in `tests/driver.cc` in order to run.**
+The steps for adding new code to the Cyclone library are generally as follows:
 
-See `cyclone/example.cc` and `tests/example.hpp` for examples of adding library
-code and tests, respectively.
+1.  Add the new source and header files to the `cyclone/` subdirectory (e.g.
+    `cyclone/example.hpp` and `cyclone/example.cc`).
+
+1.  Make sure the code is under the `cyclone` namespace, and the `#includes`
+    reference the full path from project root (e.g. `cyclone/cyclone.hpp` instead
+    of `cyclone.hpp`).
+
+1.  Add the corresponding spec as a header file to the `tests/` subdirectory
+    (e.g. `tests/example-spec.hpp`).
+
+1.  `#include` the spec header file inside `tests/driver.cpp`
+    (e.g. `#include "tests/example-spec.hpp"`).
+
+Re-running `make test`should include the newly added tests into the tests executable.

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.cc
@@ -87,10 +87,6 @@ frovedis::words data_offsets_to_words(
     return ret;
 }
 
-frovedis::words varchar_vector_to_words(const non_null_varchar_vector *v) {
-    return data_offsets_to_words(v->data, v->offsets, v->dataSize, v->count);
-}
-
 frovedis::words varchar_vector_to_words(const nullable_varchar_vector *v) {
     return data_offsets_to_words(v->data, v->offsets, v->dataSize, v->count);
 }

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.hpp
@@ -45,8 +45,6 @@ inline uint64_t check_valid(uint64_t *validityBuffer, int32_t idx) {
 
 frovedis::words data_offsets_to_words(const char *data, const int32_t *offsets, const int32_t size, const int32_t count);
 
-frovedis::words varchar_vector_to_words(const non_null_varchar_vector *v);
-
 frovedis::words varchar_vector_to_words(const nullable_varchar_vector *v);
 
 void words_to_varchar_vector(frovedis::words& in, nullable_varchar_vector *out);

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021 Xpress AI.
+ *
+ * This file is part of Spark Cyclone.
+ * See https://github.com/XpressAI/SparkCyclone for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#pragma once
+
+#include "cyclone/transfer-definitions.hpp"
+#include "cyclone/cyclone.hpp"
+#include "frovedis/core/utility.hpp"
+#include <stdlib.h>
+
+template <typename T>
+bool NullableScalarVec<T>::equals(const NullableScalarVec<T> * const other) {
+  // Compare count
+  auto output = (count == other->count);
+
+  // Compare data
+  for (auto i = 0; i < count; i++) {
+    output = output && (data[i] == other->data[i]);
+  }
+
+  // Compare validityBuffer
+  for (auto i = 0; i < count; i++) {
+    output = output && (check_valid(validityBuffer, i) == check_valid(other->validityBuffer, i));
+  }
+
+  return output;
+}
+
+template <typename T>
+NullableScalarVec<T> * NullableScalarVec<T>::clone() {
+  // Allocate
+  auto * output = static_cast<NullableScalarVec<T> *>(malloc(sizeof(NullableScalarVec<T>)));
+
+  // Copy the count
+  output->count = count;
+
+  // Copy the data
+  auto dbytes = output->count * sizeof(T);
+  output->data = static_cast<T *>(malloc(dbytes));
+  memcpy(output->data, data, dbytes);
+
+  // Copy the validity buffer
+  auto vbytes = frovedis::ceil_div(output->count, int32_t(64)) * sizeof(uint64_t);
+
+  output->validityBuffer = static_cast<uint64_t *>(malloc(vbytes));
+  memcpy(output->validityBuffer, validityBuffer, vbytes);
+
+  return output;
+}
+
+bool nullable_varchar_vector::equals(const nullable_varchar_vector * const other) {
+  // Compare count
+  auto output = (count == other->count);
+
+  // Compare dataSize
+  output = output && (dataSize == other->dataSize);
+
+  // Compare data
+  for (auto i = 0; i < count; i++) {
+    output = output && (data[i] == other->data[i]);
+  }
+
+  // Compare offsets
+  for (auto i = 0; i < count + 1; i++) {
+    output = output && (offsets[i] == other->offsets[i]);
+  }
+
+  // Compare validityBuffer
+  for (auto i = 0; i < count; i++) {
+    output = output && (check_valid(validityBuffer, i) == check_valid(other->validityBuffer, i));
+  }
+
+  return output;
+}
+
+nullable_varchar_vector * nullable_varchar_vector::clone() {
+  // Allocate
+  auto * output = static_cast<nullable_varchar_vector *>(malloc(sizeof(nullable_varchar_vector)));
+
+  // Copy the count and dataSizes
+  output->count = count;
+  output->dataSize = dataSize;
+
+  // Copy the data
+  output->data = static_cast<char *>(malloc(output->dataSize));
+  memcpy(output->data, data, output->dataSize);
+
+  // Copy the offsets
+  auto obytes_count = (output->count + 1) * sizeof(int32_t);
+  output->offsets = static_cast<int32_t *>(malloc(obytes_count));
+  memcpy(output->offsets, offsets, obytes_count);
+
+  // Copy the validity buffer
+  auto vbytes_count = frovedis::ceil_div(output->count, int32_t(64)) * sizeof(uint64_t);
+  output->validityBuffer = static_cast<uint64_t *>(malloc(vbytes_count));
+  memcpy(output->validityBuffer, validityBuffer, vbytes_count);
+
+  return output;
+}
+
+// Forward declare the class template instantiations to prevent linker errors:
+// https://stackoverflow.com/questions/3008541/template-class-symbols-not-found
+template class NullableScalarVec<int32_t>;
+template class NullableScalarVec<double>;
+template class NullableScalarVec<int64_t>;

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.cc
@@ -57,8 +57,7 @@ NullableScalarVec<T> * NullableScalarVec<T>::clone() {
 
   // Copy the validity buffer
   auto vbytes = frovedis::ceil_div(output->count, int32_t(64)) * sizeof(uint64_t);
-
-  output->validityBuffer = static_cast<uint64_t *>(malloc(vbytes));
+  output->validityBuffer = static_cast<uint64_t *>(calloc(vbytes, 1));
   memcpy(output->validityBuffer, validityBuffer, vbytes);
 
   return output;
@@ -102,14 +101,14 @@ nullable_varchar_vector * nullable_varchar_vector::clone() {
   memcpy(output->data, data, output->dataSize);
 
   // Copy the offsets
-  auto obytes_count = (output->count + 1) * sizeof(int32_t);
-  output->offsets = static_cast<int32_t *>(malloc(obytes_count));
-  memcpy(output->offsets, offsets, obytes_count);
+  auto obytes = (output->count + 1) * sizeof(int32_t);
+  output->offsets = static_cast<int32_t *>(malloc(obytes));
+  memcpy(output->offsets, offsets, obytes);
 
   // Copy the validity buffer
-  auto vbytes_count = frovedis::ceil_div(output->count, int32_t(64)) * sizeof(uint64_t);
-  output->validityBuffer = static_cast<uint64_t *>(malloc(vbytes_count));
-  memcpy(output->validityBuffer, validityBuffer, vbytes_count);
+  auto vbytes = frovedis::ceil_div(output->count, int32_t(64)) * sizeof(uint64_t);
+  output->validityBuffer = static_cast<uint64_t *>(calloc(vbytes, 1));
+  memcpy(output->validityBuffer, validityBuffer, vbytes);
 
   return output;
 }
@@ -117,5 +116,6 @@ nullable_varchar_vector * nullable_varchar_vector::clone() {
 // Forward declare the class template instantiations to prevent linker errors:
 // https://stackoverflow.com/questions/3008541/template-class-symbols-not-found
 template class NullableScalarVec<int32_t>;
-template class NullableScalarVec<double>;
 template class NullableScalarVec<int64_t>;
+template class NullableScalarVec<float>;
+template class NullableScalarVec<double>;

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
@@ -43,16 +43,16 @@ struct NullableScalarVec {
 };
 
 // Explicitly instantiate struct template for int32_t
-// struct nullable_int_vector : NullableScalarVec<int32_t> {};
-typedef NullableScalarVec<int32_t>  nullable_int_vector;
-
-// Explicitly instantiate struct template for double
-// struct nullable_double_vector : NullableScalarVec<double> {};
-typedef NullableScalarVec<double>  nullable_double_vector;
+typedef NullableScalarVec<int32_t> nullable_int_vector;
 
 // Explicitly instantiate struct template for int64_t
-// struct nullable_bigint_vector : NullableScalarVec<int64_t> {};
-typedef NullableScalarVec<int64_t>  nullable_bigint_vector;
+typedef NullableScalarVec<int64_t> nullable_bigint_vector;
+
+// Explicitly instantiate struct template for float
+typedef NullableScalarVec<float> nullable_float_vector;
+
+// Explicitly instantiate struct template for double
+typedef NullableScalarVec<double> nullable_double_vector;
 
 struct nullable_varchar_vector {
   // NOTE: Field declaration order must be maintained to match existing JNA bindings

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
@@ -21,57 +21,58 @@
 
 #ifndef VE_TD_DEFS
 
-#include <stddef.h>
 #include <stdint.h>
+#include <type_traits>
 
-struct data_out {
-    void **data;
-    size_t count;
-    size_t size;
+template<typename T>
+struct NullableScalarVec {
+  // Allow instantiations of this template only for primiitive types T
+  static_assert(std::is_fundamental_v<T>, "NullableScalarVec<T> can only be instantiated with T where T is a primitive type!");
+
+  // NOTE: Field declaration order must be maintained to match existing JNA bindings
+
+  T         *data;              // The raw data
+  uint64_t  *validityBuffer;    // Bit vector to denote null values
+  int32_t   count;              // Row count (synonymous with size of data array)
+
+  // Returns a deep copy of this NullableScalarVec<T>
+  NullableScalarVec<T> * clone();
+
+  // Value equality check against another NullableScalarVec<T>
+  bool equals(const NullableScalarVec<T> * const other);
 };
 
-struct varchar_vector {
-    char *data;
-    int32_t *offsets;
-    int32_t count;
-};
+// Explicitly instantiate struct template for int32_t
+// struct nullable_int_vector : NullableScalarVec<int32_t> {};
+typedef NullableScalarVec<int32_t>  nullable_int_vector;
 
-struct nullable_int_vector {
-    int32_t *data;
-    uint64_t *validityBuffer;
-    int32_t count;
-};
+// Explicitly instantiate struct template for double
+// struct nullable_double_vector : NullableScalarVec<double> {};
+typedef NullableScalarVec<double>  nullable_double_vector;
 
-struct nullable_double_vector {
-    double *data;
-    uint64_t *validityBuffer;
-    int32_t count;
-};
-
-struct nullable_bigint_vector {
-    int64_t *data;
-    uint64_t *validityBuffer;
-    int32_t count;
-};
-
-struct non_null_varchar_vector {
-    char *data;
-    int32_t *offsets;
-    int32_t dataSize;
-    int32_t count;
-};
+// Explicitly instantiate struct template for int64_t
+// struct nullable_bigint_vector : NullableScalarVec<int64_t> {};
+typedef NullableScalarVec<int64_t>  nullable_bigint_vector;
 
 struct nullable_varchar_vector {
-    char *data;
-    int32_t *offsets;
-    uint64_t *validityBuffer;
-    int32_t dataSize;
-    int32_t count;
+  // NOTE: Field declaration order must be maintained to match existing JNA bindings
+
+  char      *data;              // The raw data containing all the varchars concatenated together
+  int32_t   *offsets;           // Offsets to denote varchar start and end positions
+  uint64_t  *validityBuffer;    // Bit vector to denote null values
+  int32_t   dataSize;           // Size of data array
+  int32_t   count;              // The row count
+
+  // Returns a deep copy of this nullable_varchar_vector
+  nullable_varchar_vector * clone();
+
+  // Value equality check against another nullable_varchar_vector
+  bool equals(const nullable_varchar_vector * const other);
 };
 
 struct non_null_c_bounded_string {
-    char *data;
-    int32_t length;
+  char *data;
+  int32_t length;
 };
 
 #define VE_TD_DEFS 1

--- a/src/main/resources/com/nec/cyclone/cpp/tests/driver.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/driver.cc
@@ -21,7 +21,8 @@
 #include "tests/doctest.h"
 
 // Include all tests to be run
-#include "tests/example.hpp"
+#include "tests/example-spec.hpp"
+#include "tests/transfer-definitions-spec.hpp"
 
 int main(int argc, char** argv) {
   // Based on: https://github.com/doctest/doctest/blob/master/doc/markdown/main.md

--- a/src/main/resources/com/nec/cyclone/cpp/tests/example-spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/example-spec.hpp
@@ -21,12 +21,9 @@
 
 #include "cyclone/example.hpp"
 #include "tests/doctest.h"
-#include "tests/test-utils.hpp"
 
 namespace cyclone::tests {
   TEST_CASE("Testing the factorial function") {
-    test_util_fn();
-
     CHECK(factorial(0) == 1);
     CHECK(factorial(1) == 1);
     CHECK(factorial(2) == 2);

--- a/src/main/resources/com/nec/cyclone/cpp/tests/test-utils.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/test-utils.cc
@@ -19,11 +19,73 @@
  */
 #pragma once
 
-#include <iostream>
 #include "tests/test-utils.hpp"
+#include <math.h>
+#include <iostream>
 
 namespace cyclone::tests {
-  void test_util_fn() {
-    std::cout << "Hello from test!" << std::endl;
+  nullable_varchar_vector * to_nullable_varchar_vector(const std::vector<std::string> &data) {
+    auto *vec = new nullable_varchar_vector;
+
+    // Initialize count
+    vec->count = data.size();
+
+    // Initialize dataSize
+    vec->dataSize = 0;
+    for (auto i = 0; i < data.size(); i++) {
+      vec->dataSize += data[i].size();
+    }
+
+    // Copy strings to data
+    vec->data = new char[vec->dataSize];
+    auto p = 0;
+    for (auto i = 0; i < data.size(); i++) {
+      for (auto j = 0; j < data[i].size(); j++) {
+        vec->data[p++] = data[i][j];
+      }
+    }
+
+    // Set the offsets
+    vec->offsets = new int32_t[data.size() + 1];
+    vec->offsets[0] = 0;
+    for (auto i = 0; i < data.size(); i++) {
+      vec->offsets[i+1] = vec->offsets[i] + data[i].size();
+    }
+
+    // Set the validityBuffer
+    size_t vcount = ceil(data.size() / 64.0);
+    vec->validityBuffer = new uint64_t[vcount];
+    for (auto i = 0; i < vcount; i++) {
+      vec->validityBuffer[i] = 0xffffffffffffffff;
+    }
+
+    return vec;
   }
+
+  template <typename T>
+  NullableScalarVec<T> * to_nullable_scalar_vector(const std::vector<T> &data) {
+    auto *vec = new NullableScalarVec<T>;
+
+    // Initialize count
+    vec->count = data.size();
+
+    // Copy the data
+    vec->data = new T[data.size()];
+    for (auto i = 0; i < data.size(); i++) {
+      vec->data[i] = data[i];
+    }
+
+    // Set the validityBuffer
+    size_t vcount = ceil(data.size() / 64.0);
+    vec->validityBuffer = new uint64_t[vcount];
+    for (auto i = 0; i < vcount; i++) {
+      vec->validityBuffer[i] = 0xffffffffffffffff;
+    }
+
+    return vec;
+  }
+
+  template NullableScalarVec<int32_t> * to_nullable_scalar_vector(const std::vector<int32_t> &data);
+  template NullableScalarVec<double> * to_nullable_scalar_vector(const std::vector<double> &data);
+  template NullableScalarVec<int64_t> * to_nullable_scalar_vector(const std::vector<int64_t> &data);
 }

--- a/src/main/resources/com/nec/cyclone/cpp/tests/test-utils.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/test-utils.cc
@@ -85,7 +85,9 @@ namespace cyclone::tests {
     return vec;
   }
 
+  // Forward declare the function template instantiations to prevent linker errors
   template NullableScalarVec<int32_t> * to_nullable_scalar_vector(const std::vector<int32_t> &data);
-  template NullableScalarVec<double> * to_nullable_scalar_vector(const std::vector<double> &data);
   template NullableScalarVec<int64_t> * to_nullable_scalar_vector(const std::vector<int64_t> &data);
+  template NullableScalarVec<float> * to_nullable_scalar_vector(const std::vector<float> &data);
+  template NullableScalarVec<double> * to_nullable_scalar_vector(const std::vector<double> &data);
 }

--- a/src/main/resources/com/nec/cyclone/cpp/tests/test-utils.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/test-utils.hpp
@@ -19,6 +19,13 @@
  */
 #pragma once
 
+#include "cyclone/transfer-definitions.hpp"
+#include <string>
+#include <vector>
+
 namespace cyclone::tests {
-  void test_util_fn();
+  nullable_varchar_vector * to_nullable_varchar_vector(const std::vector<std::string> &data);
+
+  template <typename T>
+  NullableScalarVec<T> * to_nullable_scalar_vector(const std::vector<T> &data);
 }

--- a/src/main/resources/com/nec/cyclone/cpp/tests/transfer-definitions-spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/transfer-definitions-spec.hpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 Xpress AI.
+ *
+ * This file is part of Spark Cyclone.
+ * See https://github.com/XpressAI/SparkCyclone for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#pragma once
+
+#include "cyclone/cyclone.hpp"
+#include "cyclone/transfer-definitions.hpp"
+#include "tests/doctest.h"
+#include "tests/test-utils.hpp"
+
+namespace cyclone::tests {
+  TEST_SUITE("NullableScalarVec<T>") {
+    TEST_CASE("Equality checks work") {
+      // Instantiate with int32_t
+      std::vector<int32_t> raw1 { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 };
+      auto *input1 = to_nullable_scalar_vector(raw1);
+      set_validity(input1->validityBuffer, 1, 0);
+      set_validity(input1->validityBuffer, 4, 0);
+      set_validity(input1->validityBuffer, 8, 0);
+
+      // Instantiate with int64_t
+      std::vector<int64_t> raw2 { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 };
+      auto *input2 = to_nullable_scalar_vector(raw2);
+      set_validity(input2->validityBuffer, 2, 0);
+      set_validity(input2->validityBuffer, 5, 0);
+
+      // Instantiate with double
+      std::vector<double> raw3 { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 };
+      auto *input3 = to_nullable_scalar_vector(raw2);
+      set_validity(input3->validityBuffer, 3, 0);
+      set_validity(input3->validityBuffer, 7, 0);
+
+      CHECK(input1->equals(input1));
+      CHECK(input2->equals(input2));
+      CHECK(input3->equals(input3));
+    }
+
+    TEST_CASE("Clone works") {
+      std::vector<int32_t> raw { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 };
+      auto *input = to_nullable_scalar_vector(raw);
+      set_validity(input->validityBuffer, 1, 0);
+      set_validity(input->validityBuffer, 4, 0);
+      set_validity(input->validityBuffer, 8, 0);
+
+      auto *output = input->clone();
+      CHECK(output->equals(input));
+    }
+  }
+
+  TEST_SUITE("nullable_varchar_vector") {
+    TEST_CASE("Equality checks work") {
+      std::vector<std::string> raw { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
+      auto *input = to_nullable_varchar_vector(raw);
+      set_validity(input->validityBuffer, 1, 0);
+      set_validity(input->validityBuffer, 4, 0);
+      set_validity(input->validityBuffer, 10, 0);
+
+      CHECK(input->equals(input));
+    }
+
+    TEST_CASE("Clone works") {
+      std::vector<std::string> raw { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
+      auto *input = to_nullable_varchar_vector(raw);
+      set_validity(input->validityBuffer, 1, 0);
+      set_validity(input->validityBuffer, 4, 0);
+      set_validity(input->validityBuffer, 10, 0);
+
+      auto *output = input->clone();
+      CHECK(output->equals(input));
+    }
+  }
+}

--- a/src/main/resources/com/nec/cyclone/cpp/tests/transfer-definitions-spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/transfer-definitions-spec.hpp
@@ -27,28 +27,36 @@
 namespace cyclone::tests {
   TEST_SUITE("NullableScalarVec<T>") {
     TEST_CASE("Equality checks work") {
-      // Instantiate with int32_t
+      // Instantiate for int32_t
       std::vector<int32_t> raw1 { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 };
       auto *input1 = to_nullable_scalar_vector(raw1);
       set_validity(input1->validityBuffer, 1, 0);
       set_validity(input1->validityBuffer, 4, 0);
       set_validity(input1->validityBuffer, 8, 0);
 
-      // Instantiate with int64_t
+      // Instantiate for int64_t
       std::vector<int64_t> raw2 { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 };
       auto *input2 = to_nullable_scalar_vector(raw2);
       set_validity(input2->validityBuffer, 2, 0);
       set_validity(input2->validityBuffer, 5, 0);
 
-      // Instantiate with double
-      std::vector<double> raw3 { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 };
+      // Instantiate for float
+      std::vector<float> raw3 { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 };
       auto *input3 = to_nullable_scalar_vector(raw2);
       set_validity(input3->validityBuffer, 3, 0);
       set_validity(input3->validityBuffer, 7, 0);
 
+      // Instantiate for double
+      std::vector<double> raw4 { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 };
+      auto *input4 = to_nullable_scalar_vector(raw4);
+      set_validity(input4->validityBuffer, 2, 0);
+      set_validity(input4->validityBuffer, 6, 0);
+      set_validity(input4->validityBuffer, 8, 0);
+
       CHECK(input1->equals(input1));
       CHECK(input2->equals(input2));
       CHECK(input3->equals(input3));
+      CHECK(input4->equals(input4));
     }
 
     TEST_CASE("Clone works") {

--- a/src/main/scala/com/nec/spark/agile/CppResource.scala
+++ b/src/main/scala/com/nec/spark/agile/CppResource.scala
@@ -69,6 +69,7 @@ object CppResource {
     "frovedis/text/words.hpp",
     "cyclone/cyclone.cc",
     "cyclone/cyclone.hpp",
+    "cyclone/transfer-definitions.cc",
     "cyclone/transfer-definitions.hpp",
     "cyclone/tuple_hash.hpp",
     "Makefile",

--- a/src/main/scala/com/nec/ve/GroupingFunction.scala
+++ b/src/main/scala/com/nec/ve/GroupingFunction.scala
@@ -90,62 +90,13 @@ object GroupingFunction {
       "Cannot clone cVector - input and output VeTypes are not the same!"
     )
 
-    output.veType match {
-      case CFunctionGeneration.VeString =>
-        CodeLines.scoped(s"Clone ${input.name}[0] over to ${output.name}[0]") {
-          List(
-            // Declare count and dsize
-            s"auto count = ${input.name}[0]->count;",
-            s"auto dsize = ${input.name}[0]->dataSize;",
-            "",
-            // Allocate the nullable_varchar_vector[] with size 1
-            s"*${output.name} = static_cast<${output.veType.cVectorType}*>(malloc(sizeof(nullptr)));",
-            // Allocate the nullable_varchar_vector at [0]
-            s"${output.name}[0] = static_cast<${output.veType.cVectorType}*>(malloc(sizeof(${output.veType.cVectorType})));",
-            // Set count and dataSize
-            s"${output.name}[0]->count = count;",
-            s"${output.name}[0]->dataSize = dsize;",
-            "",
-            // Set data - allocate and then copy over
-            s"${output.name}[0]->data = static_cast<char*>(malloc(dsize));",
-            s"memcpy(${output.name}[0]->data, ${input.name}[0]->data, dsize);",
-            "",
-            // Set offsets - allocate and then copy over
-            s"auto obytes_count = (count + 1) * sizeof(int32_t);",
-            s"${output.name}[0]->offsets = static_cast<int32_t*>(malloc(obytes_count));",
-            s"memcpy(${output.name}[0]->offsets, ${input.name}[0]->offsets, obytes_count);",
-            "",
-            // Set validityBuffer - preserve the validity bits
-            s"auto vbytes_count = frovedis::ceil_div(size_t(count), size_t(64)) * sizeof(uint64_t);",
-            s"${output.name}[0]->validityBuffer = static_cast<uint64_t*>(calloc(vbytes_count, 1));",
-            s"memcpy(${output.name}[0]->validityBuffer, ${input.name}[0]->validityBuffer, vbytes_count);"
-          )
-        }
-
-      case scalar: VeScalarType =>
-        CodeLines.scoped(s"Clone ${input.name}[0] over to ${output.name}[0]") {
-          List(
-            // Declare count
-            s"auto count = ${input.name}[0]->count;",
-            "",
-            // Allocate the nullable_T_vector[] with size 1
-            s"*${output.name} = static_cast<${output.veType.cVectorType}*>(malloc(sizeof(nullptr)));",
-            // Allocate the nullable_T_vector at [0]
-            s"${output.name}[0] = static_cast<${output.veType.cVectorType}*>(malloc(sizeof(${output.veType.cVectorType})));",
-            // Set count
-            s"${output.name}[0]->count = count;",
-            "",
-            // Set data - allocate and then copy over
-            s"auto dbytes_count = count * sizeof(${scalar.cScalarType});",
-            s"${output.name}[0]->data = static_cast<${scalar.cScalarType}*>(malloc(dbytes_count));",
-            s"memcpy(${output.name}[0]->data, ${input.name}[0]->data, dbytes_count);",
-            "",
-            // Set validityBuffer - preserve the validity bits
-            s"auto vbytes_count = frovedis::ceil_div(size_t(count), size_t(64)) * sizeof(uint64_t);",
-            s"${output.name}[0]->validityBuffer = static_cast<uint64_t*>(calloc(vbytes_count, 1));",
-            s"memcpy(${output.name}[0]->validityBuffer, ${input.name}[0]->validityBuffer, vbytes_count);"
-          )
-        }
+    CodeLines.scoped(s"Clone ${input.name}[0] over to ${output.name}[0]") {
+      List(
+        // Allocate the nullable_T_vector[] with size 1
+        s"*${output.name} = static_cast<${output.veType.cVectorType} *>(malloc(sizeof(nullptr)));",
+        // Clone the input nullable_T_vector to output nullable_T_vector at [0]
+        s"${output.name}[0] = ${input.name}[0]->clone();",
+      )
     }
   }
 


### PR DESCRIPTION
Summary:

1. Redefine the nullable scalar vectors as instantiations of `NullableScalarVec<T>` for consistency of implementation
2. Implement the `clone()` and `equals()` methods for all the `nullable_T_vectors`
2. Add unit tests to check that these implementations are correct.
3. Simplify the implementation of `GroupingFunction.cloneVecStmt()` to call the C++ member functions for struct `copy()`.

See the [example](https://gist.github.com/q10/f300ee7e1f0a337f002c446c6c18a471) generated code for vastly simplfiied implementation of the exchange function for the zero key case.

The primary goal for this PR is to demonstrate that redefining the nullable scalar vectors as template instantiation of a common template class works.  Additional work will follow to fold the rest of the code generated `GroupingFunction.groupData` into common C++ library code.