### PR TITLE
Use a custom Serializer for exchanges

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ val TPC = config("tpc") extend Test
 val VectorEngine = config("ve") extend Test
 
 /**
-Do not modify this, Spark uses 2.12.10, upgrading to eg 2.12.15 causes issues because Spark uses some Scala library internals.
-**/
+ * Do not modify this, Spark uses 2.12.10, upgrading to eg 2.12.15 causes issues because Spark uses some Scala library internals.
+ */
 lazy val defaultScalaVersion = "2.12.10"
 ThisBuild / scalaVersion := defaultScalaVersion
 val orcVversion = "1.5.8"
@@ -21,9 +21,7 @@ lazy val root = Project(id = "spark-cyclone-sql-plugin", base = file("."))
   .configs(VectorEngine)
   .configs(TPC)
   .configs(CMake)
-  .settings(
-    version := "0.9.1"
-  )
+  .settings(version := "0.9.1")
 
 lazy val tracing = project
   .enablePlugins(JavaServerAppPackaging)
@@ -471,8 +469,10 @@ cycloneVeLibrarySources :=
   sbt.nio.file.FileTreeView.default
     .list(
       Seq(
-        Glob((Compile / resourceDirectory).value.toString + "/com/nec/cyclone/cpp/*.hpp"),
-        Glob((Compile / resourceDirectory).value.toString + "/com/nec/cyclone/cpp/*.cc"),
+        Glob((Compile / resourceDirectory).value.toString + "/com/nec/cyclone/cpp/cyclone/*.hpp"),
+        Glob((Compile / resourceDirectory).value.toString + "/com/nec/cyclone/cpp/cyclone/*.cc"),
+        Glob((Compile / resourceDirectory).value.toString + "/com/nec/cyclone/cpp/tests/*.hpp"),
+        Glob((Compile / resourceDirectory).value.toString + "/com/nec/cyclone/cpp/tests/*.cc"),
         Glob((Compile / resourceDirectory).value.toString + "/com/nec/cyclone/cpp/frovedis/core/*"),
         Glob(
           (Compile / resourceDirectory).value.toString + "/com/nec/cyclone/cpp/frovedis/dataframe/*"
@@ -491,7 +491,10 @@ cycloneVeLibrary := {
     in.find(_.toString.contains("Makefile")) match {
       case Some(makefile) =>
         logger.info("Building and testing libcyclone.so...")
-        val exitcode = Process(command = Seq("make", "clean", "all", "test"), cwd = makefile.getParentFile) ! logger
+        val exitcode = Process(
+          command = Seq("make", "clean", "all", "test"),
+          cwd = makefile.getParentFile
+        ) ! logger
 
         if (exitcode != 0) {
           sys.error("Failed to build libcyclone.so; please check the compiler logs.")
@@ -500,8 +503,9 @@ cycloneVeLibrary := {
         val cycloneVeDir = (Compile / resourceManaged).value / "cycloneve"
         IO.createDirectory(cycloneVeDir)
 
-        val filesToCopy = in.filter(fp => fp.toString.endsWith(".hpp") || fp.toString.endsWith(".incl")) +
-          (new File(makefile.getParentFile, "libcyclone.so"))
+        val filesToCopy =
+          in.filter(fp => fp.toString.endsWith(".hpp") || fp.toString.endsWith(".incl")) +
+            (new File(makefile.getParentFile, "libcyclone.so"))
 
         filesToCopy.flatMap { sourceFile =>
           Path

--- a/src/main/scala/com/nec/arrow/VeArrowNativeInterface.scala
+++ b/src/main/scala/com/nec/arrow/VeArrowNativeInterface.scala
@@ -47,6 +47,9 @@ object VeArrowNativeInterface extends LazyLogging {
   def requireOk(result: Int): Unit = {
     require(result >= 0, s"Result should be >=0, got $result")
   }
+  def requireOk(result: Int, extra: => String): Unit = {
+    require(result >= 0, s"Result should be >=0, got $result; ${extra}")
+  }
 
   def requirePositive(result: Long): Unit = {
     require(result > 0, s"Result should be > 0, got $result")
@@ -103,7 +106,7 @@ object VeArrowNativeInterface extends LazyLogging {
     val veInputPointer = new LongPointer(1)
 
     /** No idea why Arrow in some cases returns a ByteBuffer with 0-capacity, so we have to pass a length explicitly! */
-    val size = len.getOrElse(bytePointer.capacity().toLong)
+    val size = len.getOrElse(bytePointer.limit())
     requireOk(veo.veo_alloc_mem(proc, veInputPointer, size))
     requireOk(
       veo.veo_write_mem(

--- a/src/main/scala/com/nec/arrow/colvector/BytePointerColVector.scala
+++ b/src/main/scala/com/nec/arrow/colvector/BytePointerColVector.scala
@@ -18,7 +18,7 @@ import com.nec.spark.SparkCycloneExecutorPlugin.metrics.{measureRunningTime, reg
  */
 
 final case class BytePointerColVector(underlying: GenericColVector[Option[BytePointer]]) {
-  
+
   def toVeColVector()(implicit
     veProcess: VeProcess,
     _source: VeColVectorSource,
@@ -50,7 +50,7 @@ final case class BytePointerColVector(underlying: GenericColVector[Option[BytePo
             try bp.asBuffer.array()
             catch {
               case _: UnsupportedOperationException =>
-                val size = bp.capacity()
+                val size = bp.limit()
                 val target: Array[Byte] = Array.fill(size.toInt)(-1)
                 bp.get(target)
                 target
@@ -85,7 +85,11 @@ final case class BytePointerColVector(underlying: GenericColVector[Option[BytePo
             float8Vector.getValidityBufferAddress,
             Math.ceil(numItems / 64.0).toInt * 8
           )
-          getUnsafe.copyMemory(bytePointersAddresses(0), float8Vector.getDataBufferAddress, dataSize)
+          getUnsafe.copyMemory(
+            bytePointersAddresses(0),
+            float8Vector.getDataBufferAddress,
+            dataSize
+          )
         }
         float8Vector
       case VeScalarType.VeNullableLong =>
@@ -98,7 +102,11 @@ final case class BytePointerColVector(underlying: GenericColVector[Option[BytePo
             bigIntVector.getValidityBufferAddress,
             Math.ceil(numItems / 64.0).toInt * 8
           )
-          getUnsafe.copyMemory(bytePointersAddresses(0), bigIntVector.getDataBufferAddress, dataSize)
+          getUnsafe.copyMemory(
+            bytePointersAddresses(0),
+            bigIntVector.getDataBufferAddress,
+            dataSize
+          )
         }
         bigIntVector
       case VeScalarType.VeNullableInt =>
@@ -259,7 +267,7 @@ object BytePointerColVector {
           Option(new BytePointer(varcharVector.getOffsetBuffer.nioBuffer())),
           Option(new BytePointer(varcharVector.getValidityBuffer.nioBuffer()))
         ),
-        variableSize = Some(varcharVector.getDataBuffer.nioBuffer().capacity())
+        variableSize = Some(varcharVector.getDataBuffer.nioBuffer().limit())
       )
     )
 

--- a/src/main/scala/com/nec/arrow/colvector/GenericColVector.scala
+++ b/src/main/scala/com/nec/arrow/colvector/GenericColVector.scala
@@ -15,7 +15,10 @@ final case class GenericColVector[Data](
 
   def toUnit: UnitColVector = UnitColVector(map(_ => ()))
 
-  if (veType == VeString) require(variableSize.nonEmpty, "String should come with variable size")
+  require(
+    bufferSizes.size == buffers.size,
+    s"Expecting buffersizes to equal buffers in size (${bufferSizes.size} & ${buffers.size})"
+  )
 
   def containerLocation: Data = container
 
@@ -41,4 +44,11 @@ final case class GenericColVector[Data](
   def map[Other](f: Data => Other): GenericColVector[Other] =
     copy(container = f(containerLocation), buffers = buffers.map(f))
 
+}
+
+object GenericColVector {
+  def bufCount(veType: VeType): Int = veType match {
+    case VeString => 3
+    case _        => 2
+  }
 }

--- a/src/main/scala/com/nec/arrow/colvector/UnitColBatch.scala
+++ b/src/main/scala/com/nec/arrow/colvector/UnitColBatch.scala
@@ -1,0 +1,23 @@
+package com.nec.arrow.colvector
+
+import com.nec.ve.VeProcess
+import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.ve.colvector.VeColBatch
+import com.nec.ve.colvector.VeColBatch.VeColVectorSource
+
+final case class UnitColBatch(underlying: GenericColBatch[UnitColVector]) {
+  def deserialize(seqs: List[Array[Byte]])(implicit
+    veProcess: VeProcess,
+    originalCallingContext: OriginalCallingContext,
+    veColVectorSource: VeColVectorSource
+  ): VeColBatch = {
+    val theMap = underlying.cols
+      .zip(seqs)
+      .map { case (unitCv, bytes) =>
+        unitCv -> unitCv.deserialize(bytes)
+      }
+      .toMap
+
+    VeColBatch(underlying.map(ucv => theMap(ucv)))
+  }
+}

--- a/src/main/scala/com/nec/spark/planning/aggregation/VeHashExchangePlan.scala
+++ b/src/main/scala/com/nec/spark/planning/aggregation/VeHashExchangePlan.scala
@@ -19,8 +19,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 
-import java.time.{Duration, Instant}
-
 case class VeHashExchangePlan(exchangeFunction: VeFunction, child: SparkPlan)
   extends UnaryExecNode
   with SupportsVeColBatch
@@ -53,7 +51,7 @@ case class VeHashExchangePlan(exchangeFunction: VeFunction, child: SparkPlan)
 
             val (filled, unfilled) = multiBatches.partition(_._2.head.nonEmpty)
             unfilled.flatMap(_._2).foreach(vcv => vcv.free())
-            filled
+            filled.map { case (p, cl) => p -> VeColBatch.fromList(cl) }
           } finally {
             child.asInstanceOf[SupportsVeColBatch].dataCleanup.cleanup(veColBatch)
           }
@@ -61,7 +59,6 @@ case class VeHashExchangePlan(exchangeFunction: VeFunction, child: SparkPlan)
       }
     }
     .exchangeBetweenVEs(cleanUpInput = true)
-    .mapPartitions(f = _.map(lv => VeColBatch.fromList(lv)), preservesPartitioning = true)
 
   override def output: Seq[Attribute] = child.output
 

--- a/src/main/scala/com/nec/spark/planning/plans/VectorEngineJoinPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VectorEngineJoinPlan.scala
@@ -36,12 +36,10 @@ case class VectorEngineJoinPlan(
         right = right.asInstanceOf[SupportsKeyedVeColBatch].executeVeColumnarKeyed(),
         cleanUpInput = true
       )
-      .map { case (leftListVcv, rightListVcv) =>
+      .map { case (leftColBatch, rightColBatch) =>
         import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
         import com.nec.spark.SparkCycloneExecutorPlugin.source
         withVeLibrary { libRefJoin =>
-          val leftColBatch = VeColBatch.fromList(leftListVcv)
-          val rightColBatch = VeColBatch.fromList(rightListVcv)
           logger.debug(s"Mapping ${leftColBatch} / ${rightColBatch} for join")
           import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
           val batch =

--- a/src/main/scala/com/nec/ve/VeProcess.scala
+++ b/src/main/scala/com/nec/ve/VeProcess.scala
@@ -18,9 +18,16 @@ import org.bytedeco.veoffload.global.veo
 import org.bytedeco.veoffload.veo_proc_handle
 import SparkCycloneExecutorPlugin.metrics.{measureRunningTime, registerVeCall}
 
+import java.io.{InputStream, OutputStream}
+import java.nio.channels.Channels
 import java.nio.file.Path
 
 trait VeProcess {
+
+  def loadFromStream(inputStream: InputStream, bytes: Int)(implicit
+    context: OriginalCallingContext
+  ): Long
+  def writeToStream(outStream: OutputStream, bufPos: Long, bufLen: Int): Unit
 
   final def readAsPointer(containerLocation: Long, containerSize: Int): BytePointer = {
     val bp = new BytePointer(containerSize)
@@ -90,7 +97,9 @@ object VeProcess {
     override def allocate(size: Long)(implicit context: OriginalCallingContext): Long =
       f().allocate(size)
 
-    override def putPointer(bytePointer: BytePointer)(implicit context: OriginalCallingContext): Long =
+    override def putPointer(bytePointer: BytePointer)(implicit
+      context: OriginalCallingContext
+    ): Long =
       f().putPointer(bytePointer)
 
     override def get(from: Long, to: BytePointer, size: Long): Unit = f().get(from, to, size)
@@ -123,6 +132,12 @@ object VeProcess {
     )(implicit context: OriginalCallingContext): List[VeColVector] =
       f().executeMultiIn(libraryReference, functionName, batches, results)
 
+    override def writeToStream(outStream: OutputStream, bufPos: Long, bufLen: Int): Unit =
+      f().writeToStream(outStream, bufPos, bufLen)
+
+    override def loadFromStream(inputStream: InputStream, bytes: Int)(implicit
+      context: OriginalCallingContext
+    ): Long = f().loadFromStream(inputStream, bytes)
   }
 
   final case class WrappingVeo(
@@ -158,14 +173,9 @@ object VeProcess {
     override def putPointer(
       bytePointer: BytePointer
     )(implicit context: OriginalCallingContext): Long = {
-      val memoryLocation = allocate(bytePointer.capacity().toLong)
+      val memoryLocation = allocate(bytePointer.limit())
       requireOk(
-        veo.veo_write_mem(
-          veo_proc_handle,
-          memoryLocation,
-          bytePointer,
-          bytePointer.capacity().toLong
-        )
+        veo.veo_write_mem(veo_proc_handle, memoryLocation, bytePointer, bytePointer.limit())
       )
       memoryLocation
     }
@@ -451,6 +461,33 @@ object VeProcess {
               List(bytePointer.getLong(0), bytePointer.getLong(8), bytePointer.getLong(16))
           ).register()
       }
+    }
+
+    override def writeToStream(outStream: OutputStream, bufPos: Long, bufLen: Int): Unit = {
+      if (bufLen > 1) {
+        val buf = new BytePointer(bufLen)
+        veo.veo_read_mem(veo_proc_handle, buf, bufPos, bufLen)
+        Channels.newChannel(outStream).write(buf.asBuffer())
+      }
+    }
+
+    override def loadFromStream(inputStream: InputStream, bytes: Int)(implicit
+      context: OriginalCallingContext
+    ): Long = {
+      val memoryLocation = allocate(bytes.toLong)
+      val bp = new BytePointer(bytes.toLong)
+      val buf = bp.asBuffer()
+
+      val channel = Channels.newChannel(inputStream)
+      var bytesRead = 0
+      while (bytesRead < bytes) {
+        bytesRead += channel.read(buf)
+      }
+      requireOk(
+        veo.veo_write_mem(veo_proc_handle, memoryLocation, bp, bytes.toLong),
+        s"Trying to write to memory location ${memoryLocation}; ${veProcessMetrics.checkTotalUsage()}"
+      )
+      memoryLocation
     }
 
   }

--- a/src/main/scala/com/nec/ve/VeProcessMetrics.scala
+++ b/src/main/scala/com/nec/ve/VeProcessMetrics.scala
@@ -1,6 +1,7 @@
 package com.nec.ve
 
 trait VeProcessMetrics {
+  def checkTotalUsage(): Long
   def registerAllocation(amount: Long, position: Long): Unit
   def deregisterAllocation(position: Long): Unit
   def registerVeCall(timeTaken: Long): Unit
@@ -22,5 +23,6 @@ object VeProcessMetrics {
     override def registerFunctionCallTime(timeTaken: Long, functionName: String): Unit = ()
     override def registerSerializationTime(timeTaken: Long): Unit = ()
     override def registerDeserializationTime(timeTaken: Long): Unit = ()
+    override def checkTotalUsage(): Long = Long.MinValue
   }
 }

--- a/src/main/scala/com/nec/ve/serializer/VeDeserializationStream.scala
+++ b/src/main/scala/com/nec/ve/serializer/VeDeserializationStream.scala
@@ -1,0 +1,59 @@
+package com.nec.ve.serializer
+
+import com.nec.ve.{VeColBatch, VeProcess}
+import com.nec.ve.colvector.VeColBatch.VeColVectorSource
+import org.apache.spark.internal.Logging
+import org.apache.spark.serializer.DeserializationStream
+
+import java.io.{DataInputStream, EOFException, InputStream}
+import scala.reflect.ClassTag
+
+class VeDeserializationStream(in: InputStream)(implicit
+  veProcess: VeProcess,
+  veColVectorSource: VeColVectorSource
+) extends DeserializationStream
+  with Logging {
+  logDebug(s"Inputting from ==> ${in}; ${in.getClass}")
+  val dataInputStream = new DataInputStream(in)
+
+  /**
+   * Generally, the call chain looks like:
+   *        at com.nec.ve.VeSerializer$VeDeserializationStream.readObject(VeSerializer.scala:78)
+   *        at org.apache.spark.serializer.DeserializationStream.readKey(Serializer.scala:156) (or readValue)
+   *        at org.apache.spark.serializer.DeserializationStream$$anon$2.getNext(Serializer.scala:188)
+   *        at org.apache.spark.serializer.DeserializationStream$$anon$2.getNext(Serializer.scala:185)
+   *        at org.apache.spark.util.NextIterator.hasNext(NextIterator.scala:73)
+   *        at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:488)
+   *        at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:458)
+   *        at org.apache.spark.util.CompletionIterator.hasNext(CompletionIterator.scala:31)
+   *        at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
+   *        at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:458)
+   *        at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:489)
+   *        at scala.collection.Iterator.isEmpty(Iterator.scala:385)
+   *        at scala.collection.Iterator.isEmpty$(Iterator.scala:385)
+   *        at scala.collection.AbstractIterator.isEmpty(Iterator.scala:1429)
+   *        at scala.collection.TraversableOnce.max(TraversableOnce.scala:233)
+   *        at scala.collection.TraversableOnce.max$(TraversableOnce.scala:232)
+   *        at scala.collection.AbstractIterator.max(Iterator.scala:1429)
+   *        at com.nec.ve.VERDDSpec$.$anonfun$exchangeBatches$7(VERDDSpec.scala:120)
+   *
+   * For our use case, Spark only writes Ints and VeColBatch for serialization.
+   */
+  override def readObject[T: ClassTag](): T =
+    in.synchronized {
+      dataInputStream.readInt() match {
+        case IntTag =>
+          dataInputStream.readInt()
+        case CbTag =>
+          import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+          VeColBatch.fromStream(dataInputStream)
+        case -1 =>
+          throw new EOFException()
+        case other =>
+          sys.error(s"Unexpected tag: ${other}, expected only ${IntTag} or ${CbTag}")
+      }
+    }.asInstanceOf[T]
+
+  override def close(): Unit =
+    dataInputStream.close()
+}

--- a/src/main/scala/com/nec/ve/serializer/VeSerializationStream.scala
+++ b/src/main/scala/com/nec/ve/serializer/VeSerializationStream.scala
@@ -1,0 +1,52 @@
+package com.nec.ve.serializer
+
+import com.nec.ve.VeProcess
+import com.nec.ve.colvector.VeColBatch
+import com.nec.ve.colvector.VeColBatch.VeColVectorSource
+import org.apache.spark.internal.Logging
+import org.apache.spark.serializer.SerializationStream
+
+import java.io.{DataOutputStream, OutputStream}
+import scala.reflect.ClassTag
+
+class VeSerializationStream(out: OutputStream)(implicit
+  veProcess: VeProcess,
+  veColVectorSource: VeColVectorSource
+) extends SerializationStream
+  with Logging {
+  val dataOutputStream = new DataOutputStream(out)
+  logDebug(s"Outputting to ==> ${out}; ${out.getClass}")
+
+  /**
+   * Generally, the call chain looks like:
+   * at com.nec.ve.VeSerializer$VeSerializationStream.writeObject(VeSerializer.scala:64)
+   * at org.apache.spark.serializer.SerializationStream.writeValue(Serializer.scala:134)
+   * at org.apache.spark.storage.DiskBlockObjectWriter.write(DiskBlockObjectWriter.scala:249)
+   * at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:158)
+   * at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
+   *
+   * For our use case, Spark only writes Ints and VeColBatch for serialization.
+   */
+  override def writeObject[T: ClassTag](t: T): SerializationStream = {
+    t match {
+      case i: java.lang.Integer =>
+        dataOutputStream.writeInt(IntTag)
+        dataOutputStream.writeInt(i)
+        this
+      case v: VeColBatch =>
+        dataOutputStream.writeInt(CbTag)
+        v.serializeToStream(dataOutputStream)
+        this
+      case other =>
+        sys.error(s"Not supported here to write item of type ${other.getClass.getCanonicalName}")
+    }
+  }
+
+  override def flush(): Unit = {
+    dataOutputStream.flush()
+  }
+
+  override def close(): Unit = {
+    dataOutputStream.close()
+  }
+}

--- a/src/main/scala/com/nec/ve/serializer/VeSerializer.scala
+++ b/src/main/scala/com/nec/ve/serializer/VeSerializer.scala
@@ -1,0 +1,8 @@
+package com.nec.ve.serializer
+
+import org.apache.spark.SparkConf
+import org.apache.spark.serializer.{Serializer, SerializerInstance}
+
+class VeSerializer(conf: SparkConf, cleanUpInput: Boolean) extends Serializer with Serializable {
+  override def newInstance(): SerializerInstance = new VeSerializerInstance(cleanUpInput)
+}

--- a/src/main/scala/com/nec/ve/serializer/VeSerializerInstance.scala
+++ b/src/main/scala/com/nec/ve/serializer/VeSerializerInstance.scala
@@ -1,0 +1,33 @@
+package com.nec.ve.serializer
+
+import com.nec.spark.SparkCycloneExecutorPlugin
+import org.apache.spark.internal.Logging
+import org.apache.spark.serializer.{DeserializationStream, SerializationStream, SerializerInstance}
+
+import java.io.{InputStream, OutputStream}
+import java.nio.ByteBuffer
+import scala.reflect.ClassTag
+
+class VeSerializerInstance(cleanUpInput: Boolean) extends SerializerInstance with Logging {
+  override def serialize[T: ClassTag](t: T): ByteBuffer =
+    sys.error("This should not be reached")
+
+  override def deserialize[T: ClassTag](bytes: ByteBuffer): T =
+    sys.error("This should not be reached")
+
+  override def deserialize[T: ClassTag](bytes: ByteBuffer, loader: ClassLoader): T =
+    sys.error("This should not be reached")
+
+  override def serializeStream(s: OutputStream): SerializationStream =
+    new VeSerializationStream(s)(
+      SparkCycloneExecutorPlugin.veProcess,
+      SparkCycloneExecutorPlugin.source
+    )
+
+  override def deserializeStream(s: InputStream): DeserializationStream =
+    new VeDeserializationStream(s)(
+      SparkCycloneExecutorPlugin.veProcess,
+      SparkCycloneExecutorPlugin.source
+    )
+
+}

--- a/src/main/scala/com/nec/ve/serializer/package.scala
+++ b/src/main/scala/com/nec/ve/serializer/package.scala
@@ -1,0 +1,6 @@
+package com.nec.ve
+
+package object serializer {
+  val CbTag: Int = 91
+  val IntTag: Int = 92
+}

--- a/src/main/scala/org/apache/spark/metrics/source/ProcessExecutorMetrics.scala
+++ b/src/main/scala/org/apache/spark/metrics/source/ProcessExecutorMetrics.scala
@@ -152,4 +152,6 @@ final class ProcessExecutorMetrics(val allocationTracker: AllocationTracker)
 
   def getAllocations: Map[Long, Long] = allocations.toMap
 
+  override def checkTotalUsage(): Long = allocations.valuesIterator.sum
+
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -35,6 +35,6 @@
 
     <logger name="org.apache" level="INFO"/>
 
-    <logger name="com.nec" level="TRACE"/>
+    <logger name="com.nec" level="DEBUG"/>
 </configuration>
 

--- a/src/test/scala/com/nec/arrow/colvector/UnitColVectorSpec.scala
+++ b/src/test/scala/com/nec/arrow/colvector/UnitColVectorSpec.scala
@@ -1,0 +1,35 @@
+package com.nec.arrow.colvector
+
+import com.nec.spark.agile.CFunctionGeneration.VeScalarType.VeNullableInt
+import com.nec.ve.colvector.VeColBatch.VeColVectorSource
+import org.scalatest.freespec.AnyFreeSpec
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, DataOutputStream}
+
+final class UnitColVectorSpec extends AnyFreeSpec {
+  val ucv = UnitColVector(
+    GenericColVector(
+      VeColVectorSource("tested"),
+      9,
+      "test",
+      Some(123),
+      VeNullableInt,
+      (),
+      buffers = List((), ())
+    )
+  )
+
+  "It works" in {
+    val baos = new ByteArrayOutputStream()
+    val daos = new DataOutputStream(baos)
+    try ucv.toStreamFast(daos)
+    finally daos.close()
+
+    val bytes: Array[Byte] = baos.toByteArray
+
+    val bais = new ByteArrayInputStream(bytes)
+    val dais = new DataInputStream(bais)
+    val ucvOut = UnitColVector.fromStreamFast(dais)
+    assert(ucvOut == ucv)
+  }
+}

--- a/src/test/scala/com/nec/ve/JoinRDDSpec.scala
+++ b/src/test/scala/com/nec/ve/JoinRDDSpec.scala
@@ -56,7 +56,7 @@ object JoinRDDSpec {
         cleanUpInput = true
       )
       .map { case (la, lb) =>
-        (la.flatMap(_.toList), lb.flatMap(_.toList))
+        (la.cols.flatMap(_.toList), lb.cols.flatMap(_.toList))
       }
       .collect()
       .toList

--- a/src/test/scala/com/nec/ve/VERDDSpec.scala
+++ b/src/test/scala/com/nec/ve/VERDDSpec.scala
@@ -103,7 +103,7 @@ object VERDDSpec {
             }),
         preservesPartitioning = true
       )
-      .exchangeBetweenVEs()
+      .exchangeBetweenVEs(cleanUpInput = true)
       .mapPartitions(vectorIter =>
         Iterator
           .continually {

--- a/src/test/scala/com/nec/ve/serializer/VeSerializerSpec.scala
+++ b/src/test/scala/com/nec/ve/serializer/VeSerializerSpec.scala
@@ -1,0 +1,63 @@
+package com.nec.ve.serializer
+
+import com.eed3si9n.expecty.Expecty.expect
+import com.nec.arrow.ArrowVectorBuilders.withArrowFloat8VectorI
+import com.nec.arrow.WithTestAllocator
+import com.nec.ve.colvector.VeColBatch.VeColVector
+import com.nec.ve.{VeColBatch, VeKernelInfra, WithVeProcess}
+import org.scalatest.freespec.AnyFreeSpec
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, DataOutputStream}
+
+final class VeSerializerSpec extends AnyFreeSpec with WithVeProcess with VeKernelInfra {
+  import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+
+  "Simple serialization of a batch of 2 columns works" in {
+    WithTestAllocator { implicit alloc =>
+      withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
+        withArrowFloat8VectorI(List(-1, -2, -3)) { f8v2 =>
+          val colVec: VeColBatch = VeColBatch.fromList(
+            List(VeColVector.fromArrowVector(f8v), VeColVector.fromArrowVector(f8v2))
+          )
+          val theBatch = VeColBatch.deserialize(colVec.serialize())
+          val gotVecStr = theBatch.cols.head.toArrowVector().toString
+          val gotVecStr2 = theBatch.cols.drop(1).head.toArrowVector().toString
+          val expectedVecStr = f8v.toString
+          val expectedVecStr2 = f8v2.toString
+
+          expect(gotVecStr == expectedVecStr, gotVecStr2 == expectedVecStr2)
+        }
+      }
+    }
+  }
+
+  "Stream serialization of a batch of 2 columns works" in {
+    WithTestAllocator { implicit alloc =>
+      withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
+        withArrowFloat8VectorI(List(-1, -2, -3)) { f8v2 =>
+          val colVec: VeColBatch = VeColBatch.fromList(
+            List(VeColVector.fromArrowVector(f8v), VeColVector.fromArrowVector(f8v2))
+          )
+          val byteArrayOutputStream = new ByteArrayOutputStream()
+          val dataOutputStream = new DataOutputStream(byteArrayOutputStream)
+          try colVec.serializeToStream(dataOutputStream)
+          finally {
+            byteArrayOutputStream.flush()
+            byteArrayOutputStream.close()
+          }
+          val bytes = byteArrayOutputStream.toByteArray
+          val byteArrayInputStream = new ByteArrayInputStream(bytes)
+          val dataInputStream = new DataInputStream(byteArrayInputStream)
+          val theBatch = VeColBatch.fromStream(dataInputStream)
+          val gotVecStr = theBatch.cols.head.toArrowVector().toString
+          val gotVecStr2 = theBatch.cols.drop(1).head.toArrowVector().toString
+          val expectedVecStr = f8v.toString
+          val expectedVecStr2 = f8v2.toString
+
+          expect(gotVecStr == expectedVecStr, gotVecStr2 == expectedVecStr2)
+        }
+      }
+    }
+  }
+
+}

--- a/src/test/scala/org/apache/spark/sql/vectorized/DualModeTest.scala
+++ b/src/test/scala/org/apache/spark/sql/vectorized/DualModeTest.scala
@@ -41,7 +41,7 @@ final class DualModeTest extends AnyFreeSpec {
       None,
       VeScalarType.veNullableInt,
       -1,
-      Nil
+      List(1, 2)
     )
     val expectedCb = VeColBatch(numRows = vcv.numItems, cols = List(vcv))
     val cv = new VeColColumnarVector(Left(vcv), IntegerType)


### PR DESCRIPTION
The key concept is that we intercept/serialize only when it is needed to do (for exchange, rather than generally) so to avoid complications in dealing with unfamiliar types. That is where we therefore pass the serializer explicitly.

Query 1 and Query 2 work.

- (De-)Serialize data from VE into the Serialization Stream as closely as possible. Using `Channels`.
- Disabled by default, will need @Wosin to complete the exchange fixing task.
- Disable `TRACE`-level log in TPC tests, affects performance a lot.

Next we could look at using a custom SerializationManager for even higher performance (separate task), possibly even get VE to speak to VE across network.

---

`VectorEngine` tests give this in terms of performance:


## Query 1 (speed up)

### When VE exchange is off

![image](https://user-images.githubusercontent.com/52247468/153301593-a2fc8278-d3c4-4287-962d-6e0009707576.png)

### When VE exchange is on:

![image](https://user-images.githubusercontent.com/52247468/153301802-df4a25e0-1f86-4c00-b027-b000c459fa57.png)

## Query 2 (slowdown)

> Could be due to slowness on joins mostly

### VE exchange off:

![image](https://user-images.githubusercontent.com/52247468/153301274-1edb1a66-2c37-45a1-97c3-8c4d95e42942.png)

### VE exchange on:

![image](https://user-images.githubusercontent.com/52247468/153301034-46a937c0-8d5d-403d-92ab-2f3bf265b7a7.png)
