### PR TITLE
Serialize the JOIN

### DIFF
--- a/.github/workflows/benchmark-collector-all.yml
+++ b/.github/workflows/benchmark-collector-all.yml
@@ -3,7 +3,6 @@ name: "TPC-H Central All-Runner"
 env:
   INPUT_extra: "${{ github.event.inputs.extra }}"
   INPUT_fail-fast: "${{ github.event.inputs.fail-fast }}"
-  INPUT_filter-on-ve: "${{ github.event.inputs.filter-on-ve }}"
   INPUT_join-on-ve: "${{ github.event.inputs.join-on-ve }}"
   INPUT_pass-through-project: "${{ github.event.inputs.pass-through-project }}"
   INPUT_scale: "${{ github.event.inputs.scale }}"
@@ -19,10 +18,6 @@ env:
       fail-fast:
         type: "boolean"
         description: "Fail Fast"
-        default: "true"
-      filter-on-ve:
-        type: "boolean"
-        description: "Filter on VE"
         default: "true"
       join-on-ve:
         type: "boolean"

--- a/.github/workflows/benchmark-collector.yml
+++ b/.github/workflows/benchmark-collector.yml
@@ -3,7 +3,6 @@ name: "TPC-H Central runner"
 env:
   INPUT_extra: "${{ github.event.inputs.extra }}"
   INPUT_fail-fast: "${{ github.event.inputs.fail-fast }}"
-  INPUT_filter-on-ve: "${{ github.event.inputs.filter-on-ve }}"
   INPUT_join-on-ve: "${{ github.event.inputs.join-on-ve }}"
   INPUT_pass-through-project: "${{ github.event.inputs.pass-through-project }}"
   INPUT_query: "${{ github.event.inputs.query }}"
@@ -20,10 +19,6 @@ env:
       fail-fast:
         type: "boolean"
         description: "Fail Fast"
-        default: "true"
-      filter-on-ve:
-        type: "boolean"
-        description: "Filter on VE"
         default: "true"
       join-on-ve:
         type: "boolean"

--- a/.github/workflows/unittests-cmake.yml
+++ b/.github/workflows/unittests-cmake.yml
@@ -2,34 +2,31 @@ name: Unit tests (CMake)
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
   pull_request:
     types:
       - ready_for_review
+
 jobs:
   build:
-    runs-on: "ve"
-
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-
-      - name: Check User
-        run: whoami
-
-      - name: Check Path
-        run: pwd
-
-      - name: Check Access to VE
-        run: /opt/nec/ve/bin/vecmd info
-
-      - name: Branch Ref
-        run: echo ${GITHUB_REF#refs/heads/}
-
+      - name: Coursier cache
+        uses: coursier/cache-action@v6
+      - name: Install G++ 11
+        run: |
+          sudo apt-get -y install g++-11
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11
+          g++ -v
+          gcc -v
+      - uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: temurin
       - name: Generate TPC-H Data
         run: pushd src/test/resources/dbgen/ && make && ./dbgen && popd
-
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
-
-      - name: Run Vector Engine Tests
-        run: source /opt/rh/devtoolset-11/enable && SBT_OPTS="-Xmx16g" sbt "CMake / testQuick"
+      - name: Run CMake Tests
+        run: sbt "CMake / testQuick"

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val root = Project(id = "spark-cyclone-sql-plugin", base = file("."))
 lazy val tracing = project
   .enablePlugins(JavaServerAppPackaging)
   .enablePlugins(SystemdPlugin)
+  .disablePlugins(org.bytedeco.sbt.javacpp.Plugin)
   .enablePlugins(RpmPlugin)
   .dependsOn(root % "test->test")
   .settings(
@@ -49,6 +50,7 @@ lazy val tracing = project
  */
 lazy val `fun-bench` = project
   .enablePlugins(JmhPlugin)
+  .disablePlugins(org.bytedeco.sbt.javacpp.Plugin)
   .dependsOn(root % "compile->test")
   .settings(
     libraryDependencies ++= Seq(
@@ -123,7 +125,6 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.9" % "test,acc,cmake,ve",
   "com.eed3si9n.expecty" %% "expecty" % "0.15.4" % "test,acc,cmake,ve",
   "com.lihaoyi" %% "sourcecode" % "0.2.7",
-  "org.bytedeco" % "javacpp" % "1.5.7-SNAPSHOT",
   "org.bytedeco" % "veoffload" % "2.8.2-1.5.7-SNAPSHOT",
   "org.bytedeco" % "veoffload" % "2.8.2-1.5.7-SNAPSHOT" classifier "linux-x86_64",
   "net.java.dev.jna" % "jna-platform" % "5.8.0",
@@ -137,6 +138,8 @@ libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.3" % "test,acc,cmake,ve",
   "co.fs2" %% "fs2-io" % "3.0.6" % "test,acc,cmake,ve"
 ).map(_.excludeAll(ExclusionRule("*", "log4j"), ExclusionRule("*", "slf4j-log4j12")))
+
+javaCppVersion := "1.5.7"
 
 libraryDependencies ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {
@@ -387,6 +390,7 @@ Test / javaOptions ++= {
 
 lazy val tpchbench = project
   .in(file("tests/tpchbench"))
+  .disablePlugins(org.bytedeco.sbt.javacpp.Plugin)
   .settings(
     libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
     scalacOptions ++= Seq("-Xfatal-warnings", "-feature", "-deprecation"),
@@ -411,6 +415,7 @@ lazy val tpchbench = project
   )
 
 lazy val `tpcbench-run` = project
+  .disablePlugins(org.bytedeco.sbt.javacpp.Plugin)
   .settings(
     libraryDependencies ++= Seq(
       "org.xerial" % "sqlite-jdbc" % "3.36.0.3",

--- a/src/main/scala/com/nec/arrow/ArrowEncodingSettings.scala
+++ b/src/main/scala/com/nec/arrow/ArrowEncodingSettings.scala
@@ -28,7 +28,8 @@ object ArrowEncodingSettings {
   }
 
   private val Mb: Long = 1024 * 1024
-  // 64M
+
+  // 64M -- trying 128M does not change performance [2022-02-11]
   private val DefaultTargetBatchSize: Long = 64 * Mb
 
 }

--- a/src/main/scala/com/nec/arrow/VeArrowNativeInterface.scala
+++ b/src/main/scala/com/nec/arrow/VeArrowNativeInterface.scala
@@ -55,6 +55,10 @@ object VeArrowNativeInterface extends LazyLogging {
     require(result > 0, s"Result should be > 0, got $result")
   }
 
+  def requirePositive(result: Long, note: => String): Unit = {
+    require(result > 0, s"Result should be > 0, got $result; $note")
+  }
+
   final class VeArrowNativeInterfaceLazyLib(proc: veo_proc_handle, libPath: String)
     extends ArrowNativeInterface {
 

--- a/src/main/scala/com/nec/arrow/colvector/GenericColVector.scala
+++ b/src/main/scala/com/nec/arrow/colvector/GenericColVector.scala
@@ -13,6 +13,11 @@ final case class GenericColVector[Data](
   buffers: List[Data]
 ) {
 
+  require(
+    bufferSizes.size == buffers.size,
+    s"Expecting buffersizes to equal buffers in size (${bufferSizes.size} & ${buffers.size})"
+  )
+
   def toUnit: UnitColVector = UnitColVector(map(_ => ()))
 
   require(

--- a/src/main/scala/com/nec/arrow/colvector/UnitColVector.scala
+++ b/src/main/scala/com/nec/arrow/colvector/UnitColVector.scala
@@ -70,6 +70,9 @@ final case class UnitColVector(underlying: GenericColVector[Unit]) {
     dataOutputStream.writeInt(UnitColVector.veTypeToTag(underlying.veType))
   }
 
+  def streamedSize: Int =
+    List(4, underlying.source.identifier.length, 4, 4, underlying.name.size, 4, 4).sum
+
 }
 
 object UnitColVector {

--- a/src/main/scala/com/nec/spark/agile/join/JoinMatcher.scala
+++ b/src/main/scala/com/nec/spark/agile/join/JoinMatcher.scala
@@ -1,0 +1,100 @@
+package com.nec.spark.agile.join
+
+import com.nec.spark.agile.CFunctionGeneration
+import com.nec.spark.agile.SparkExpressionToCExpression.sparkTypeToVeType
+import com.nec.spark.agile.join.GenericJoiner.FilteredOutput
+import com.nec.spark.planning.VERewriteStrategy.InputPrefix
+import org.apache.spark.sql.catalyst.expressions.{
+  And,
+  AttributeReference,
+  EqualTo,
+  KnownFloatingPointNormalized
+}
+import org.apache.spark.sql.catalyst.optimizer.NormalizeNaNAndZero
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.{logical, Inner}
+
+final case class JoinMatcher(
+  leftChild: LogicalPlan,
+  rightChild: LogicalPlan,
+  inputsLeft: List[CFunctionGeneration.CVector],
+  inputsRight: List[CFunctionGeneration.CVector],
+  genericJoiner: GenericJoiner
+)
+object JoinMatcher {
+
+  /**
+   * This is a Join by function eg f(a.x) = f(b.y)
+   * This is currently not supported, and the underlying C++ code probably should be not refactored yet
+   * to accommodate for the possibility we may have to change the shape of the code.
+   */
+  val JoinWithFunctionSupported = false
+
+  def unapply(logicalPlan: LogicalPlan): Option[JoinMatcher] = {
+    PartialFunction.condOpt(logicalPlan) {
+      case j @ logical.Join(
+            leftChild,
+            rightChild,
+            Inner,
+            Some(
+              condition @ And(
+                EqualTo(
+                  KnownFloatingPointNormalized(
+                    NormalizeNaNAndZero(ar1 @ AttributeReference(_, _, _, _))
+                  ),
+                  KnownFloatingPointNormalized(
+                    NormalizeNaNAndZero(ar2 @ AttributeReference(_, _, _, _))
+                  )
+                ),
+                EqualTo(ar3 @ AttributeReference(_, _, _, _), ar4 @ AttributeReference(_, _, _, _))
+              )
+            ),
+            _
+          ) if JoinWithFunctionSupported =>
+        sys.error("Join with function is not yet implemented")
+      case j @ logical.Join(
+            leftChild,
+            rightChild,
+            Inner,
+            Some(
+              condition @ EqualTo(
+                ar1 @ AttributeReference(_, _, _, _),
+                ar2 @ AttributeReference(_, _, _, _)
+              )
+            ),
+            _
+          ) =>
+        val inputsLeft: List[CFunctionGeneration.CVector] =
+          leftChild.output.toList.zipWithIndex.map { case (att, idx) =>
+            sparkTypeToVeType(att.dataType).makeCVector(s"l_$InputPrefix$idx")
+          }
+        val inputsRight = rightChild.output.toList.zipWithIndex.map { case (att, idx) =>
+          sparkTypeToVeType(att.dataType).makeCVector(s"r_$InputPrefix$idx")
+        }
+
+        val joins =
+          List(
+            GenericJoiner.Join(
+              left = inputsLeft(
+                leftChild.output.indexWhere(attr => List(ar1, ar2).exists(_.exprId == attr.exprId))
+              ),
+              right = inputsRight(
+                rightChild.output.indexWhere(attr => List(ar1, ar2).exists(_.exprId == attr.exprId))
+              )
+            )
+          )
+        JoinMatcher(
+          leftChild,
+          rightChild,
+          inputsLeft,
+          inputsRight,
+          GenericJoiner(
+            inputsLeft = inputsLeft,
+            inputsRight = inputsRight,
+            joins = joins,
+            outputs = (inputsLeft ++ inputsRight).map(cv => FilteredOutput(s"o_${cv.name}", cv))
+          )
+        )
+    }
+  }
+}

--- a/src/main/scala/com/nec/spark/planning/plans/VectorEngineJoinPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VectorEngineJoinPlan.scala
@@ -31,7 +31,7 @@ case class VectorEngineJoinPlan(
 
   override def executeVeColumnar(): RDD[VeColBatch] =
     VeRDD
-      .joinExchangeLB(
+      .joinExchange(
         left = left.asInstanceOf[SupportsKeyedVeColBatch].executeVeColumnarKeyed(),
         right = right.asInstanceOf[SupportsKeyedVeColBatch].executeVeColumnarKeyed(),
         cleanUpInput = true

--- a/src/main/scala/com/nec/ve/VeProcess.scala
+++ b/src/main/scala/com/nec/ve/VeProcess.scala
@@ -23,7 +23,6 @@ import java.nio.channels.Channels
 import java.nio.file.Path
 
 trait VeProcess {
-
   def loadFromStream(inputStream: InputStream, bytes: Int)(implicit
     context: OriginalCallingContext
   ): Long
@@ -90,7 +89,6 @@ object VeProcess {
 
   final case class LibraryReference(value: Long)
   final case class DeferredVeProcess(f: () => VeProcess) extends VeProcess with LazyLogging {
-
     override def validateVectors(list: List[VeColVector]): Unit = f().validateVectors(list)
     override def loadLibrary(path: Path): LibraryReference = f().loadLibrary(path)
 
@@ -467,7 +465,8 @@ object VeProcess {
       if (bufLen > 1) {
         val buf = new BytePointer(bufLen)
         veo.veo_read_mem(veo_proc_handle, buf, bufPos, bufLen)
-        Channels.newChannel(outStream).write(buf.asBuffer())
+        val numWritten = Channels.newChannel(outStream).write(buf.asBuffer())
+        require(numWritten == bufLen, s"Written ${numWritten}, expected ${bufLen}")
       }
     }
 

--- a/src/main/scala/com/nec/ve/VeProcessMetrics.scala
+++ b/src/main/scala/com/nec/ve/VeProcessMetrics.scala
@@ -10,7 +10,6 @@ trait VeProcessMetrics {
   def registerSerializationTime(timeTaken: Long): Unit
   def registerDeserializationTime(timeTaken: Long): Unit
   def registerFunctionCallTime(timeTaken: Long, functionName: String): Unit
-
 }
 
 object VeProcessMetrics {

--- a/src/main/scala/com/nec/ve/colvector/VeColVector.scala
+++ b/src/main/scala/com/nec/ve/colvector/VeColVector.scala
@@ -34,6 +34,8 @@ import sun.misc.Unsafe
 import java.io.{DataOutputStream, OutputStream}
 
 final case class VeColVector(underlying: GenericColVector[Long]) {
+  def serializedSize: Int = underlying.bufferSizes.sum
+
   def serializeToStream(outStream: OutputStream)(implicit veProcess: VeProcess): Unit = {
     underlying.buffers.zip(underlying.bufferSizes).foreach { case (bufPos, bufLen) =>
       veProcess.writeToStream(outStream, bufPos, bufLen)

--- a/src/main/scala/com/nec/ve/serializer/package.scala
+++ b/src/main/scala/com/nec/ve/serializer/package.scala
@@ -1,6 +1,21 @@
 package com.nec.ve
 
+import com.nec.ve.serializer.DualBatchOrBytes.{BytesOnly, ColBatchWrapper}
+
 package object serializer {
   val CbTag: Int = 91
   val IntTag: Int = 92
+  val MixedCbTagColBatch: Int = 93
+
+  sealed trait DualBatchOrBytes {
+    def fold[T](a: BytesOnly => T, b: VeColBatch => T): T = this match {
+      case ColBatchWrapper(veColBatch) => b(veColBatch)
+      case bytesOnly: BytesOnly        => a(bytesOnly)
+    }
+  }
+  object DualBatchOrBytes {
+    final case class ColBatchWrapper(veColBatch: VeColBatch) extends DualBatchOrBytes
+    /** Underlying byte buffer may be re-used for performance */
+    final class BytesOnly(val bytes: Array[Byte], val size: Int) extends DualBatchOrBytes
+  }
 }

--- a/src/test/scala/com/nec/arrow/colvector/UnitColVectorSpec.scala
+++ b/src/test/scala/com/nec/arrow/colvector/UnitColVectorSpec.scala
@@ -1,5 +1,6 @@
 package com.nec.arrow.colvector
 
+import com.eed3si9n.expecty.Expecty.expect
 import com.nec.spark.agile.CFunctionGeneration.VeScalarType.VeNullableInt
 import com.nec.ve.colvector.VeColBatch.VeColVectorSource
 import org.scalatest.freespec.AnyFreeSpec
@@ -30,6 +31,6 @@ final class UnitColVectorSpec extends AnyFreeSpec {
     val bais = new ByteArrayInputStream(bytes)
     val dais = new DataInputStream(bais)
     val ucvOut = UnitColVector.fromStreamFast(dais)
-    assert(ucvOut == ucv)
+    expect(ucvOut == ucv, ucv.streamedSize == bytes.length)
   }
 }

--- a/src/test/scala/com/nec/ve/VERDDSpec.scala
+++ b/src/test/scala/com/nec/ve/VERDDSpec.scala
@@ -103,6 +103,7 @@ object VERDDSpec {
             }),
         preservesPartitioning = true
       )
+      .filter(_._2.nonEmpty)
       .exchangeBetweenVEs(cleanUpInput = true)
       .mapPartitions(vectorIter =>
         Iterator

--- a/src/test/scala/com/nec/ve/serializer/VeSerializerSpec.scala
+++ b/src/test/scala/com/nec/ve/serializer/VeSerializerSpec.scala
@@ -4,6 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import com.nec.arrow.ArrowVectorBuilders.withArrowFloat8VectorI
 import com.nec.arrow.WithTestAllocator
 import com.nec.ve.colvector.VeColBatch.VeColVector
+import com.nec.ve.serializer.DualBatchOrBytes.ColBatchWrapper
 import com.nec.ve.{VeColBatch, VeKernelInfra, WithVeProcess}
 import org.scalatest.freespec.AnyFreeSpec
 
@@ -35,12 +36,12 @@ final class VeSerializerSpec extends AnyFreeSpec with WithVeProcess with VeKerne
     WithTestAllocator { implicit alloc =>
       withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
         withArrowFloat8VectorI(List(-1, -2, -3)) { f8v2 =>
-          val colVec: VeColBatch = VeColBatch.fromList(
+          val veColBatch: VeColBatch = VeColBatch.fromList(
             List(VeColVector.fromArrowVector(f8v), VeColVector.fromArrowVector(f8v2))
           )
           val byteArrayOutputStream = new ByteArrayOutputStream()
           val dataOutputStream = new DataOutputStream(byteArrayOutputStream)
-          try colVec.serializeToStream(dataOutputStream)
+          try veColBatch.serializeToStream(dataOutputStream)
           finally {
             byteArrayOutputStream.flush()
             byteArrayOutputStream.close()
@@ -51,6 +52,38 @@ final class VeSerializerSpec extends AnyFreeSpec with WithVeProcess with VeKerne
           val theBatch = VeColBatch.fromStream(dataInputStream)
           val gotVecStr = theBatch.cols.head.toArrowVector().toString
           val gotVecStr2 = theBatch.cols.drop(1).head.toArrowVector().toString
+          val expectedVecStr = f8v.toString
+          val expectedVecStr2 = f8v2.toString
+
+          expect(gotVecStr == expectedVecStr, gotVecStr2 == expectedVecStr2)
+        }
+      }
+    }
+  }
+
+  "Check serializer fully" in {
+    WithTestAllocator { implicit alloc =>
+      withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
+        withArrowFloat8VectorI(List(-1, -2, -3)) { f8v2 =>
+          val veColBatch: VeColBatch = VeColBatch.fromList(
+            List(VeColVector.fromArrowVector(f8v), VeColVector.fromArrowVector(f8v2))
+          )
+
+          val byteArrayOutputStream = new ByteArrayOutputStream()
+          val serStr = new VeSerializationStream(byteArrayOutputStream)
+          serStr.writeObject(ColBatchWrapper(veColBatch))
+          serStr.flush()
+          serStr.close()
+
+          val byteArrayInputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray)
+          val deserStr = new VeDeserializationStream(byteArrayInputStream)
+          val bytesOnly = deserStr
+            .readObject[DualBatchOrBytes]()
+            .fold(bytesOnly => bytesOnly, _ => sys.error(s"Got col batch, expected bytes"))
+          val gotBatch =
+            VeColBatch.fromStream(new DataInputStream(new ByteArrayInputStream(bytesOnly.bytes)))
+          val gotVecStr = gotBatch.cols.head.toArrowVector().toString
+          val gotVecStr2 = gotBatch.cols.drop(1).head.toArrowVector().toString
           val expectedVecStr = f8v.toString
           val expectedVecStr2 = f8v2.toString
 

--- a/tpcbench-run/src/main/scala/sc/GitHubInput.scala
+++ b/tpcbench-run/src/main/scala/sc/GitHubInput.scala
@@ -31,7 +31,6 @@ object GitHubInput {
     "pass-through-project" -> OnOrOff("Pass-through in projection", default = false),
     "fail-fast" -> OnOrOff("Fail Fast", default = true),
     "join-on-ve" -> OnOrOff("Join on VE", default = false),
-    "filter-on-ve" -> OnOrOff("Filter on VE", default = true)
   )
 
   final case class Choice(description: String, default: Option[String], options: List[String])


### PR DESCRIPTION
Performance so far (Spark join = ~1m 30s):

![image](https://user-images.githubusercontent.com/52247468/153662498-8abea927-3d85-4294-a276-2e1ae6dbfa01.png)

Changes:
- Introduce dual-mode deserialization (seems deserializing straight from stream does not work when we do JOIN. Not clear why). Performance impact is minimal, however.
- Remove filter-on-ve configuration from GitHub action, so that it is less cluttered.
- Make CMake tests run on GH ubuntu, rather than on VH, so that the testing happens more quickly.
- Specify explicit `javaCppVersion`, to avoid dual library imports (which could yield some funny behaviors), and disable the JavaCPP SBT plugin for modules that don't need it.
- Add a header to specify how much space a serialization will take
- Extract `JoinMatcher` out of `VeRewriteStrategy`
- Use a nicer clean-up method in `VeHashExchange`
- `VeAmplifyBatches` to be more optimized (in case of 1 batch, just pass it through)
- Ensure that num of written bytes when serializing matches the expected.
- Add time measurements for serialization.
- Add extra log capture for `tpcbench-run` for better verbosity.

## Current plan

```
*(7) Sort [s_acctbal#243 DESC NULLS LAST, n_name#106 ASC NULLS FIRST, s_name#239 ASC NULLS FIRST, p_partkey#180L ASC NULLS FIRST], true, 0
+- Exchange rangepartitioning(s_acctbal#243 DESC NULLS LAST, n_name#106 ASC NULLS FIRST, s_name#239 ASC NULLS FIRST, p_partkey#180L ASC NULLS FIRST, 200), ENSURE_REQUIREMENTS, [id=#1137]
   +- *(6) ColumnarToRow
      +- VectorEngineToSparkPlan
         +- OneStageEvaluationPlan [s_acctbal#243, s_name#239, n_name#106, p_partkey#180L, p_mfgr#182, s_address#240, s_phone#242, s_comment#244], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_1220696630,List(CScalarVector(output_0,VeNullableDouble), CVarChar(output_1), CVarChar(output_2), CScalarVector(output_3,VeNullableLong), CVarChar(output_4), CVarChar(output_5), CVarChar(output_6), CVarChar(output_7)))
            +- VeAmplifyBatchesPlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),amplify_join_eval_771415145,List(CScalarVector(o_l_input_0,VeNullableLong), CVarChar(o_l_input_1), CVarChar(o_l_input_2), CVarChar(o_l_input_3), CVarChar(o_l_input_4), CScalarVector(o_l_input_5,VeNullableDouble), CVarChar(o_l_input_6), CVarChar(o_l_input_7), CScalarVector(o_l_input_8,VeNullableLong), CScalarVector(o_r_input_0,VeNullableLong)))
               +- VectorEngineJoinPlan [p_partkey#180L, p_mfgr#182, s_name#239, s_address#240, s_phone#242, s_acctbal#243, s_comment#244, n_name#106, n_regionkey#107L, r_regionkey#122L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),join_eval_771415145,List(CScalarVector(o_l_input_0,VeNullableLong), CVarChar(o_l_input_1), CVarChar(o_l_input_2), CVarChar(o_l_input_3), CVarChar(o_l_input_4), CScalarVector(o_l_input_5,VeNullableDouble), CVarChar(o_l_input_6), CVarChar(o_l_input_7), CScalarVector(o_l_input_8,VeNullableLong), CScalarVector(o_r_input_0,VeNullableLong)))
                  :- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_l_eval_771415145,List(CScalarVector(l_input_0,VeNullableLong), CVarChar(l_input_1), CVarChar(l_input_2), CVarChar(l_input_3), CVarChar(l_input_4), CScalarVector(l_input_5,VeNullableDouble), CVarChar(l_input_6), CVarChar(l_input_7), CScalarVector(l_input_8,VeNullableLong)))
                  :  +- OneStageEvaluationPlan [p_partkey#180L, p_mfgr#182, s_name#239, s_address#240, s_phone#242, s_acctbal#243, s_comment#244, n_name#106, n_regionkey#107L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_19767027,List(CScalarVector(output_0,VeNullableLong), CVarChar(output_1), CVarChar(output_2), CVarChar(output_3), CVarChar(output_4), CScalarVector(output_5,VeNullableDouble), CVarChar(output_6), CVarChar(output_7), CScalarVector(output_8,VeNullableLong)))
                  :     +- VeAmplifyBatchesPlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),amplify_join_eval_894590237,List(CScalarVector(o_l_input_0,VeNullableLong), CVarChar(o_l_input_1), CVarChar(o_l_input_2), CVarChar(o_l_input_3), CScalarVector(o_l_input_4,VeNullableLong), CVarChar(o_l_input_5), CScalarVector(o_l_input_6,VeNullableDouble), CVarChar(o_l_input_7), CScalarVector(o_r_input_0,VeNullableLong), CVarChar(o_r_input_1), CScalarVector(o_r_input_2,VeNullableLong)))
                  :        +- VectorEngineJoinPlan [p_partkey#180L, p_mfgr#182, s_name#239, s_address#240, s_nationkey#241L, s_phone#242, s_acctbal#243, s_comment#244, n_nationkey#105L, n_name#106, n_regionkey#107L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),join_eval_894590237,List(CScalarVector(o_l_input_0,VeNullableLong), CVarChar(o_l_input_1), CVarChar(o_l_input_2), CVarChar(o_l_input_3), CScalarVector(o_l_input_4,VeNullableLong), CVarChar(o_l_input_5), CScalarVector(o_l_input_6,VeNullableDouble), CVarChar(o_l_input_7), CScalarVector(o_r_input_0,VeNullableLong), CVarChar(o_r_input_1), CScalarVector(o_r_input_2,VeNullableLong)))
                  :           :- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_l_eval_894590237,List(CScalarVector(l_input_0,VeNullableLong), CVarChar(l_input_1), CVarChar(l_input_2), CVarChar(l_input_3), CScalarVector(l_input_4,VeNullableLong), CVarChar(l_input_5), CScalarVector(l_input_6,VeNullableDouble), CVarChar(l_input_7)))
                  :           :  +- OneStageEvaluationPlan [p_partkey#180L, p_mfgr#182, s_name#239, s_address#240, s_nationkey#241L, s_phone#242, s_acctbal#243, s_comment#244], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_171957993,List(CScalarVector(output_0,VeNullableLong), CVarChar(output_1), CVarChar(output_2), CVarChar(output_3), CScalarVector(output_4,VeNullableLong), CVarChar(output_5), CScalarVector(output_6,VeNullableDouble), CVarChar(output_7)))
                  :           :     +- VeAmplifyBatchesPlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),amplify_join_eval_1845889250,List(CScalarVector(o_l_input_0,VeNullableLong), CVarChar(o_l_input_1), CScalarVector(o_l_input_2,VeNullableLong), CScalarVector(o_r_input_0,VeNullableLong), CVarChar(o_r_input_1), CVarChar(o_r_input_2), CScalarVector(o_r_input_3,VeNullableLong), CVarChar(o_r_input_4), CScalarVector(o_r_input_5,VeNullableDouble), CVarChar(o_r_input_6)))
                  :           :        +- VectorEngineJoinPlan [p_partkey#180L, p_mfgr#182, ps_suppkey#215L, s_suppkey#238L, s_name#239, s_address#240, s_nationkey#241L, s_phone#242, s_acctbal#243, s_comment#244], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),join_eval_1845889250,List(CScalarVector(o_l_input_0,VeNullableLong), CVarChar(o_l_input_1), CScalarVector(o_l_input_2,VeNullableLong), CScalarVector(o_r_input_0,VeNullableLong), CVarChar(o_r_input_1), CVarChar(o_r_input_2), CScalarVector(o_r_input_3,VeNullableLong), CVarChar(o_r_input_4), CScalarVector(o_r_input_5,VeNullableDouble), CVarChar(o_r_input_6)))
                  :           :           :- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_l_eval_1845889250,List(CScalarVector(l_input_0,VeNullableLong), CVarChar(l_input_1), CScalarVector(l_input_2,VeNullableLong)))
                  :           :           :  +- OneStageEvaluationPlan [p_partkey#180L, p_mfgr#182, ps_suppkey#215L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_943421495,List(CScalarVector(output_0,VeNullableLong), CVarChar(output_1), CScalarVector(output_2,VeNullableLong)))
                  :           :           :     +- SparkToVectorEnginePlan
                  :           :           :        +- RowToColumnar
                  :           :           :           +- *(5) SortMergeJoin [knownfloatingpointnormalized(normalizenanandzero(ps_supplycost#217)), p_partkey#180L], [knownfloatingpointnormalized(normalizenanandzero(min(ps_supplycost)#1685)), ps_partkey#214L#2069L], Inner
                  :           :           :              :- *(2) Sort [knownfloatingpointnormalized(normalizenanandzero(ps_supplycost#217)) ASC NULLS FIRST, p_partkey#180L ASC NULLS FIRST], false, 0
                  :           :           :              :  +- Exchange hashpartitioning(knownfloatingpointnormalized(normalizenanandzero(ps_supplycost#217)), p_partkey#180L, 200), ENSURE_REQUIREMENTS, [id=#1103]
                  :           :           :              :     +- *(1) ColumnarToRow
                  :           :           :              :        +- VectorEngineToSparkPlan
                  :           :           :              :           +- OneStageEvaluationPlan [p_partkey#180L, p_mfgr#182, ps_suppkey#215L, ps_supplycost#217], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_1190029611,List(CScalarVector(output_0,VeNullableLong), CVarChar(output_1), CScalarVector(output_2,VeNullableLong), CScalarVector(output_3,VeNullableDouble)))
                  :           :           :              :              +- VeAmplifyBatchesPlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),amplify_join_eval_219563819,List(CScalarVector(o_l_input_0,VeNullableLong), CVarChar(o_l_input_1), CScalarVector(o_r_input_0,VeNullableLong), CScalarVector(o_r_input_1,VeNullableLong), CScalarVector(o_r_input_2,VeNullableDouble)))
                  :           :           :              :                 +- VectorEngineJoinPlan [p_partkey#180L, p_mfgr#182, ps_partkey#214L, ps_suppkey#215L, ps_supplycost#217], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),join_eval_219563819,List(CScalarVector(o_l_input_0,VeNullableLong), CVarChar(o_l_input_1), CScalarVector(o_r_input_0,VeNullableLong), CScalarVector(o_r_input_1,VeNullableLong), CScalarVector(o_r_input_2,VeNullableDouble)))
                  :           :           :              :                    :- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_l_eval_219563819,List(CScalarVector(l_input_0,VeNullableLong), CVarChar(l_input_1)))
                  :           :           :              :                    :  +- OneStageEvaluationPlan [p_partkey#180L, p_mfgr#182], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_1624711585,List(CScalarVector(output_0,VeNullableLong), CVarChar(output_1)))
                  :           :           :              :                    :     +- VeAmplifyBatchesPlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),amplify_flt_eval_342664504,List(CScalarVector(input_0,VeNullableLong), CVarChar(input_1), CVarChar(input_2), CVarChar(input_3), CVarChar(input_4), CScalarVector(input_5,VeNullableLong), CVarChar(input_6), CScalarVector(input_7,VeNullableDouble), CVarChar(input_8)))
                  :           :           :              :                    :        +- OneStageEvaluationPlan [p_partkey#180L, p_name#181, p_mfgr#182, p_brand#183, p_type#184, p_size#185L, p_container#186, p_retailprice#187, p_comment#188], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),flt_eval_342664504,List(CScalarVector(output_0,VeNullableLong), CVarChar(output_1), CVarChar(output_2), CVarChar(output_3), CVarChar(output_4), CScalarVector(output_5,VeNullableLong), CVarChar(output_6), CScalarVector(output_7,VeNullableDouble), CVarChar(output_8)))
                  :           :           :              :                    :           +- VeFetchFromCachePlan true
                  :           :           :              :                    :              +- Scan In-memory table part [p_partkey#180L, p_name#181, p_mfgr#182, p_brand#183, p_type#184, p_size#185L, p_container#186, p_retailprice#187, p_comment#188]
                  :           :           :              :                    :                    +- InMemoryRelation [p_partkey#180L, p_name#181, p_mfgr#182, p_brand#183, p_type#184, p_size#185L, p_container#186, p_retailprice#187, p_comment#188], StorageLevel(disk, memory, deserialized, 1 replicas)
                  :           :           :              :                    :                          +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, com.nec.tpc.Part, true])).p_partkey AS p_partkey#180L, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Part, true])).p_name, true, false) AS p_name#181, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Part, true])).p_mfgr, true, false) AS p_mfgr#182, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Part, true])).p_brand, true, false) AS p_brand#183, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Part, true])).p_type, true, false) AS p_type#184, knownnotnull(assertnotnull(input[0, com.nec.tpc.Part, true])).p_size AS p_size#185L, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Part, true])).p_container, true, false) AS p_container#186, knownnotnull(assertnotnull(input[0, com.nec.tpc.Part, true])).p_retailprice AS p_retailprice#187, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Part, true])).p_comment, true, false) AS p_comment#188]
                  :           :           :              :                    :                             +- Scan[obj#179]
                  :           :           :              :                    +- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_r_eval_219563819,List(CScalarVector(r_input_0,VeNullableLong), CScalarVector(r_input_1,VeNullableLong), CScalarVector(r_input_2,VeNullableDouble)))
                  :           :           :              :                       +- OneStageEvaluationPlan [ps_partkey#214L, ps_suppkey#215L, ps_supplycost#217], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_1157881184,List(CScalarVector(output_0,VeNullableLong), CScalarVector(output_1,VeNullableLong), CScalarVector(output_2,VeNullableDouble)))
                  :           :           :              :                          +- VeFetchFromCachePlan true
                  :           :           :              :                             +- Scan In-memory table partsupp [ps_partkey#214L, ps_suppkey#215L, ps_availqty#216L, ps_supplycost#217, ps_comment#218]
                  :           :           :              :                                   +- InMemoryRelation [ps_partkey#214L, ps_suppkey#215L, ps_availqty#216L, ps_supplycost#217, ps_comment#218], StorageLevel(disk, memory, deserialized, 1 replicas)
                  :           :           :              :                                         +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, com.nec.tpc.Partsupp, true])).ps_partkey AS ps_partkey#214L, knownnotnull(assertnotnull(input[0, com.nec.tpc.Partsupp, true])).ps_suppkey AS ps_suppkey#215L, knownnotnull(assertnotnull(input[0, com.nec.tpc.Partsupp, true])).ps_availqty AS ps_availqty#216L, knownnotnull(assertnotnull(input[0, com.nec.tpc.Partsupp, true])).ps_supplycost AS ps_supplycost#217, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Partsupp, true])).ps_comment, true, false) AS ps_comment#218]
                  :           :           :              :                                            +- Scan[obj#213]
                  :           :           :              +- *(4) Sort [knownfloatingpointnormalized(normalizenanandzero(min(ps_supplycost)#1685)) ASC NULLS FIRST, ps_partkey#214L#2069L ASC NULLS FIRST], false, 0
                  :           :           :                 +- Exchange hashpartitioning(knownfloatingpointnormalized(normalizenanandzero(min(ps_supplycost)#1685)), ps_partkey#214L#2069L, 200), ENSURE_REQUIREMENTS, [id=#1111]
                  :           :           :                    +- *(3) ColumnarToRow
                  :           :           :                       +- VectorEngineToSparkPlan
                  :           :           :                          +- VeAmplifyBatchesPlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),amplify_flt_eval_961050100,List(CScalarVector(input_0,VeNullableDouble), CScalarVector(input_1,VeNullableLong)))
                  :           :           :                             +- OneStageEvaluationPlan [min(ps_supplycost)#1685, ps_partkey#214L#2069L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),flt_eval_961050100,List(CScalarVector(output_0,VeNullableDouble), CScalarVector(output_1,VeNullableLong)))
                  :           :           :                                +- VeAmplifyBatchesPlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),amplify_eval_1166317581,List(CScalarVector(agg_0,VeNullableDouble), CScalarVector(sp_1,VeNullableLong)))
                  :           :           :                                   +- !VeFinalAggregate [min(ps_supplycost#217) AS min(ps_supplycost)#1685, ps_partkey#214L AS ps_partkey#214L#2069L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),final_eval_1166317581,List(CScalarVector(agg_0,VeNullableDouble), CScalarVector(sp_1,VeNullableLong)))
                  :           :           :                                      +- VeFlattenPartition VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),merge_eval_1166317581,List(CScalarVector(partial_group_0,VeNullableLong), CScalarVector(partial_sp_1,VeNullableLong), CScalarVector(partial_agg_0_attr_min,VeNullableDouble)))
                  :           :           :                                         +- !VePartialAggregate [VeNullableLong_0#2402L, VeNullableLong_1#2403L, VeNullableDouble_2#2404], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),partial_eval_1166317581,List(CScalarVector(partial_group_0,VeNullableLong), CScalarVector(partial_sp_1,VeNullableLong), CScalarVector(partial_agg_0_attr_min,VeNullableDouble)))
                  :           :           :                                            +- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_eval_1166317581,List(CScalarVector(input_0,VeNullableLong), CScalarVector(input_1,VeNullableDouble)))
                  :           :           :                                               +- OneStageEvaluationPlan [ps_partkey#214L, ps_supplycost#217], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_1097667950,List(CScalarVector(output_0,VeNullableLong), CScalarVector(output_1,VeNullableDouble)))
                  :           :           :                                                  +- VeAmplifyBatchesPlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),amplify_join_eval_893284028,List(CScalarVector(o_l_input_0,VeNullableLong), CScalarVector(o_l_input_1,VeNullableDouble), CScalarVector(o_l_input_2,VeNullableLong), CScalarVector(o_r_input_0,VeNullableLong)))
                  :           :           :                                                     +- VectorEngineJoinPlan [ps_partkey#214L, ps_supplycost#217, n_regionkey#107L, r_regionkey#122L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),join_eval_893284028,List(CScalarVector(o_l_input_0,VeNullableLong), CScalarVector(o_l_input_1,VeNullableDouble), CScalarVector(o_l_input_2,VeNullableLong), CScalarVector(o_r_input_0,VeNullableLong)))
                  :           :           :                                                        :- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_l_eval_893284028,List(CScalarVector(l_input_0,VeNullableLong), CScalarVector(l_input_1,VeNullableDouble), CScalarVector(l_input_2,VeNullableLong)))
                  :           :           :                                                        :  +- OneStageEvaluationPlan [ps_partkey#214L, ps_supplycost#217, n_regionkey#107L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_117934466,List(CScalarVector(output_0,VeNullableLong), CScalarVector(output_1,VeNullableDouble), CScalarVector(output_2,VeNullableLong)))
                  :           :           :                                                        :     +- VeAmplifyBatchesPlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),amplify_join_eval_597975719,List(CScalarVector(o_l_input_0,VeNullableLong), CScalarVector(o_l_input_1,VeNullableDouble), CScalarVector(o_l_input_2,VeNullableLong), CScalarVector(o_r_input_0,VeNullableLong), CScalarVector(o_r_input_1,VeNullableLong)))
                  :           :           :                                                        :        +- VectorEngineJoinPlan [ps_partkey#214L, ps_supplycost#217, s_nationkey#241L, n_nationkey#105L, n_regionkey#107L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),join_eval_597975719,List(CScalarVector(o_l_input_0,VeNullableLong), CScalarVector(o_l_input_1,VeNullableDouble), CScalarVector(o_l_input_2,VeNullableLong), CScalarVector(o_r_input_0,VeNullableLong), CScalarVector(o_r_input_1,VeNullableLong)))
                  :           :           :                                                        :           :- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_l_eval_597975719,List(CScalarVector(l_input_0,VeNullableLong), CScalarVector(l_input_1,VeNullableDouble), CScalarVector(l_input_2,VeNullableLong)))
                  :           :           :                                                        :           :  +- OneStageEvaluationPlan [ps_partkey#214L, ps_supplycost#217, s_nationkey#241L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_1299112585,List(CScalarVector(output_0,VeNullableLong), CScalarVector(output_1,VeNullableDouble), CScalarVector(output_2,VeNullableLong)))
                  :           :           :                                                        :           :     +- VeAmplifyBatchesPlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),amplify_join_eval_1766342753,List(CScalarVector(o_l_input_0,VeNullableLong), CScalarVector(o_l_input_1,VeNullableLong), CScalarVector(o_l_input_2,VeNullableDouble), CScalarVector(o_r_input_0,VeNullableLong), CScalarVector(o_r_input_1,VeNullableLong)))
                  :           :           :                                                        :           :        +- VectorEngineJoinPlan [ps_partkey#214L, ps_suppkey#215L, ps_supplycost#217, s_suppkey#238L, s_nationkey#241L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),join_eval_1766342753,List(CScalarVector(o_l_input_0,VeNullableLong), CScalarVector(o_l_input_1,VeNullableLong), CScalarVector(o_l_input_2,VeNullableDouble), CScalarVector(o_r_input_0,VeNullableLong), CScalarVector(o_r_input_1,VeNullableLong)))
                  :           :           :                                                        :           :           :- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_l_eval_1766342753,List(CScalarVector(l_input_0,VeNullableLong), CScalarVector(l_input_1,VeNullableLong), CScalarVector(l_input_2,VeNullableDouble)))
                  :           :           :                                                        :           :           :  +- OneStageEvaluationPlan [ps_partkey#214L, ps_suppkey#215L, ps_supplycost#217], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_1157881184,List(CScalarVector(output_0,VeNullableLong), CScalarVector(output_1,VeNullableLong), CScalarVector(output_2,VeNullableDouble)))
                  :           :           :                                                        :           :           :     +- VeFetchFromCachePlan true
                  :           :           :                                                        :           :           :        +- Scan In-memory table partsupp [ps_partkey#214L, ps_suppkey#215L, ps_availqty#216L, ps_supplycost#217, ps_comment#218]
                  :           :           :                                                        :           :           :              +- InMemoryRelation [ps_partkey#214L, ps_suppkey#215L, ps_availqty#216L, ps_supplycost#217, ps_comment#218], StorageLevel(disk, memory, deserialized, 1 replicas)
                  :           :           :                                                        :           :           :                    +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, com.nec.tpc.Partsupp, true])).ps_partkey AS ps_partkey#214L, knownnotnull(assertnotnull(input[0, com.nec.tpc.Partsupp, true])).ps_suppkey AS ps_suppkey#215L, knownnotnull(assertnotnull(input[0, com.nec.tpc.Partsupp, true])).ps_availqty AS ps_availqty#216L, knownnotnull(assertnotnull(input[0, com.nec.tpc.Partsupp, true])).ps_supplycost AS ps_supplycost#217, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Partsupp, true])).ps_comment, true, false) AS ps_comment#218]
                  :           :           :                                                        :           :           :                       +- Scan[obj#213]
                  :           :           :                                                        :           :           +- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_r_eval_1766342753,List(CScalarVector(r_input_0,VeNullableLong), CScalarVector(r_input_1,VeNullableLong)))
                  :           :           :                                                        :           :              +- OneStageEvaluationPlan [s_suppkey#238L, s_nationkey#241L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_12710557,List(CScalarVector(output_0,VeNullableLong), CScalarVector(output_1,VeNullableLong)))
                  :           :           :                                                        :           :                 +- VeFetchFromCachePlan true
                  :           :           :                                                        :           :                    +- Scan In-memory table supplier [s_suppkey#238L, s_name#239, s_address#240, s_nationkey#241L, s_phone#242, s_acctbal#243, s_comment#244]
                  :           :           :                                                        :           :                          +- InMemoryRelation [s_suppkey#238L, s_name#239, s_address#240, s_nationkey#241L, s_phone#242, s_acctbal#243, s_comment#244], StorageLevel(disk, memory, deserialized, 1 replicas)
                  :           :           :                                                        :           :                                +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_suppkey AS s_suppkey#238L, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_name, true, false) AS s_name#239, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_address, true, false) AS s_address#240, knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_nationkey AS s_nationkey#241L, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_phone, true, false) AS s_phone#242, knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_acctbal AS s_acctbal#243, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_comment, true, false) AS s_comment#244]
                  :           :           :                                                        :           :                                   +- Scan[obj#237]
                  :           :           :                                                        :           +- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_r_eval_597975719,List(CScalarVector(r_input_0,VeNullableLong), CScalarVector(r_input_1,VeNullableLong)))
                  :           :           :                                                        :              +- OneStageEvaluationPlan [n_nationkey#105L, n_regionkey#107L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_81415053,List(CScalarVector(output_0,VeNullableLong), CScalarVector(output_1,VeNullableLong)))
                  :           :           :                                                        :                 +- VeFetchFromCachePlan true
                  :           :           :                                                        :                    +- Scan In-memory table nation [n_nationkey#105L, n_name#106, n_regionkey#107L, n_comment#108]
                  :           :           :                                                        :                          +- InMemoryRelation [n_nationkey#105L, n_name#106, n_regionkey#107L, n_comment#108], StorageLevel(disk, memory, deserialized, 1 replicas)
                  :           :           :                                                        :                                +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, com.nec.tpc.Nation, true])).n_nationkey AS n_nationkey#105L, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Nation, true])).n_name, true, false) AS n_name#106, knownnotnull(assertnotnull(input[0, com.nec.tpc.Nation, true])).n_regionkey AS n_regionkey#107L, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Nation, true])).n_comment, true, false) AS n_comment#108]
                  :           :           :                                                        :                                   +- Scan[obj#104]
                  :           :           :                                                        +- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_r_eval_893284028,List(CScalarVector(r_input_0,VeNullableLong)))
                  :           :           :                                                           +- OneStageEvaluationPlan [r_regionkey#122L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_590368566,List(CScalarVector(output_0,VeNullableLong)))
                  :           :           :                                                              +- VeAmplifyBatchesPlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),amplify_flt_eval_961424201,List(CScalarVector(input_0,VeNullableLong), CVarChar(input_1), CVarChar(input_2)))
                  :           :           :                                                                 +- OneStageEvaluationPlan [r_regionkey#122L, r_name#123, r_comment#124], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),flt_eval_961424201,List(CScalarVector(output_0,VeNullableLong), CVarChar(output_1), CVarChar(output_2)))
                  :           :           :                                                                    +- VeFetchFromCachePlan true
                  :           :           :                                                                       +- Scan In-memory table region [r_regionkey#122L, r_name#123, r_comment#124]
                  :           :           :                                                                             +- InMemoryRelation [r_regionkey#122L, r_name#123, r_comment#124], StorageLevel(disk, memory, deserialized, 1 replicas)
                  :           :           :                                                                                   +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, com.nec.tpc.Region, true])).r_regionkey AS r_regionkey#122L, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Region, true])).r_name, true, false) AS r_name#123, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Region, true])).r_comment, true, false) AS r_comment#124]
                  :           :           :                                                                                      +- Scan[obj#121]
                  :           :           +- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_r_eval_1845889250,List(CScalarVector(r_input_0,VeNullableLong), CVarChar(r_input_1), CVarChar(r_input_2), CScalarVector(r_input_3,VeNullableLong), CVarChar(r_input_4), CScalarVector(r_input_5,VeNullableDouble), CVarChar(r_input_6)))
                  :           :              +- VeFetchFromCachePlan true
                  :           :                 +- Scan In-memory table supplier [s_suppkey#238L, s_name#239, s_address#240, s_nationkey#241L, s_phone#242, s_acctbal#243, s_comment#244]
                  :           :                       +- InMemoryRelation [s_suppkey#238L, s_name#239, s_address#240, s_nationkey#241L, s_phone#242, s_acctbal#243, s_comment#244], StorageLevel(disk, memory, deserialized, 1 replicas)
                  :           :                             +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_suppkey AS s_suppkey#238L, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_name, true, false) AS s_name#239, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_address, true, false) AS s_address#240, knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_nationkey AS s_nationkey#241L, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_phone, true, false) AS s_phone#242, knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_acctbal AS s_acctbal#243, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Supplier, true])).s_comment, true, false) AS s_comment#244]
                  :           :                                +- Scan[obj#237]
                  :           +- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_r_eval_894590237,List(CScalarVector(r_input_0,VeNullableLong), CVarChar(r_input_1), CScalarVector(r_input_2,VeNullableLong)))
                  :              +- OneStageEvaluationPlan [n_nationkey#105L, n_name#106, n_regionkey#107L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_1548998961,List(CScalarVector(output_0,VeNullableLong), CVarChar(output_1), CScalarVector(output_2,VeNullableLong)))
                  :                 +- VeFetchFromCachePlan true
                  :                    +- Scan In-memory table nation [n_nationkey#105L, n_name#106, n_regionkey#107L, n_comment#108]
                  :                          +- InMemoryRelation [n_nationkey#105L, n_name#106, n_regionkey#107L, n_comment#108], StorageLevel(disk, memory, deserialized, 1 replicas)
                  :                                +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, com.nec.tpc.Nation, true])).n_nationkey AS n_nationkey#105L, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Nation, true])).n_name, true, false) AS n_name#106, knownnotnull(assertnotnull(input[0, com.nec.tpc.Nation, true])).n_regionkey AS n_regionkey#107L, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Nation, true])).n_comment, true, false) AS n_comment#108]
                  :                                   +- Scan[obj#104]
                  +- VeHashExchangePlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),exchange_r_eval_771415145,List(CScalarVector(r_input_0,VeNullableLong)))
                     +- OneStageEvaluationPlan [r_regionkey#122L], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),project_eval_590368566,List(CScalarVector(output_0,VeNullableLong)))
                        +- VeAmplifyBatchesPlan VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),amplify_flt_eval_961424201,List(CScalarVector(input_0,VeNullableLong), CVarChar(input_1), CVarChar(input_2)))
                           +- OneStageEvaluationPlan [r_regionkey#122L, r_name#123, r_comment#124], VeFunction(Compiled(/tmp/ve-spark-tmp8028415682995227607/_spark_-1778630442.so),flt_eval_961424201,List(CScalarVector(output_0,VeNullableLong), CVarChar(output_1), CVarChar(output_2)))
                              +- VeFetchFromCachePlan true
                                 +- Scan In-memory table region [r_regionkey#122L, r_name#123, r_comment#124]
                                       +- InMemoryRelation [r_regionkey#122L, r_name#123, r_comment#124], StorageLevel(disk, memory, deserialized, 1 replicas)
                                             +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, com.nec.tpc.Region, true])).r_regionkey AS r_regionkey#122L, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Region, true])).r_name, true, false) AS r_name#123, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, com.nec.tpc.Region, true])).r_comment, true, false) AS r_comment#124]
                                                +- Scan[obj#121]


```

## Overall performance metrics

They show the slowness is really coming through the Arrow conversion.

```
2022-02-13T21:12:54.027Z: type=HISTOGRAM, name=application_1643194586439_0036.6.VEProcessExecutor.ve.arrowConversionTimeHist, count=9, min=0, max=119, mean=33.77777777777778, stddev=49.54235000930461, p50=2.0, p75=78.5, p95=119.0, p98=119.0, p99=119.0, p999=119.0
2022-02-13T21:12:54.027Z: type=HISTOGRAM, name=application_1643194586439_0036.6.VEProcessExecutor.ve.deserializationTime, count=22, min=0, max=21, mean=4.0, stddev=5.468524655221178, p50=1.0, p75=9.25, p95=19.49999999999998, p98=21.0, p99=21.0, p999=21.0
2022-02-13T21:12:54.027Z: type=HISTOGRAM, name=application_1643194586439_0036.6.VEProcessExecutor.ve.serializationTime, count=52, min=0, max=14, mean=1.9615384615384615, stddev=2.6932125176373236, p50=1.0, p75=2.0, p95=9.749999999999972, p98=13.939999999999998, p99=14.0, p999=14.0
2022-02-13T21:12:54.027Z: type=HISTOGRAM, name=application_1643194586439_0036.6.VEProcessExecutor.ve.veCallTimeHist_final_eval_1640966307, count=1, min=5, max=5, mean=5.0, stddev=0.0, p50=5.0, p75=5.0, p95=5.0, p98=5.0, p99=5.0, p999=5.0
2022-02-13T21:12:54.031Z: type=HISTOGRAM, name=application_1643194586439_0036.4.VEProcessExecutor.ve.arrowConversionTimeHist, count=5, min=2, max=1467, mean=295.8, stddev=654.7229948611856, p50=2.0, p75=736.5, p95=1467.0, p98=1467.0, p99=1467.0, p999=1467.0
2022-02-13T21:12:54.027Z: type=HISTOGRAM, name=application_1643194586439_0036.6.VEProcessExecutor.ve.veCallTimeHist_flt_eval_1010187482, count=1, min=1, max=1, mean=1.0, stddev=0.0, p50=1.0, p75=1.0, p95=1.0, p98=1.0, p99=1.0, p999=1.0
2022-02-13T21:12:54.028Z: type=HISTOGRAM, name=application_1643194586439_0036.6.VEProcessExecutor.ve.veCallTimeHist_flt_eval_1377896630, count=2, min=1, max=10, mean=5.5, stddev=6.363961030678928, p50=5.5, p75=10.0, p95=10.0, p98=10.0, p99=10.0, p999=10.0
2022-02-13T21:12:54.031Z: type=HISTOGRAM, name=application_1643194586439_0036.4.VEProcessExecutor.ve.deserializationTime, count=18, min=0, max=17, mean=3.0555555555555554, stddev=4.543543864614185, p50=1.5, p75=3.0, p95=17.0, p98=17.0, p99=17.0, p999=17.0
2022-02-13T21:12:54.028Z: type=HISTOGRAM, name=application_1643194586439_0036.6.VEProcessExecutor.ve.veCallTimeHist_join_eval_151190985, count=8, min=4, max=6, mean=5.0, stddev=0.5345224838248488, p50=5.0, p75=5.0, p95=6.0, p98=6.0, p99=6.0, p999=6.0
2022-02-13T21:12:54.031Z: type=HISTOGRAM, name=application_1643194586439_0036.4.VEProcessExecutor.ve.serializationTime, count=26, min=0, max=11, mean=2.3076923076923075, stddev=2.4620191838282786, p50=1.0, p75=4.0, p95=9.249999999999993, p98=11.0, p99=11.0, p999=11.0
2022-02-13T21:12:54.028Z: type=HISTOGRAM, name=application_1643194586439_0036.6.VEProcessExecutor.ve.veCallTimeHist_join_eval_80126989, count=16, min=2, max=4, mean=2.875, stddev=0.5, p50=3.0, p75=3.0, p95=4.0, p98=4.0, p99=4.0, p999=4.0
2022-02-13T21:12:54.031Z: type=HISTOGRAM, name=application_1643194586439_0036.4.VEProcessExecutor.ve.veCallTimeHist_final_eval_1640966307, count=1, min=5, max=5, mean=5.0, stddev=0.0, p50=5.0, p75=5.0, p95=5.0, p98=5.0, p99=5.0, p999=5.0
2022-02-13T21:12:54.031Z: type=HISTOGRAM, name=application_1643194586439_0036.4.VEProcessExecutor.ve.veCallTimeHist_flt_eval_1010187482, count=1, min=0, max=0, mean=0.0, stddev=0.0, p50=0.0, p75=0.0, p95=0.0, p98=0.0, p99=0.0, p999=0.0
2022-02-13T21:12:54.031Z: type=HISTOGRAM, name=application_1643194586439_0036.4.VEProcessExecutor.ve.veCallTimeHist_join_eval_151190985, count=4, min=5, max=6, mean=5.25, stddev=0.5, p50=5.0, p75=5.75, p95=6.0, p98=6.0, p99=6.0, p999=6.0
2022-02-13T21:12:54.028Z: type=HISTOGRAM, name=application_1643194586439_0036.6.VEProcessExecutor.ve.veCallTimeHist_join_eval_992837114, count=4, min=1, max=2, mean=1.25, stddev=0.5, p50=1.0, p75=1.75, p95=2.0, p98=2.0, p99=2.0, p999=2.0
2022-02-13T21:12:54.031Z: type=HISTOGRAM, name=application_1643194586439_0036.4.VEProcessExecutor.ve.veCallTimeHist_join_eval_80126989, count=16, min=2, max=5, mean=3.0625, stddev=0.6800735254367721, p50=3.0, p75=3.0, p95=5.0, p98=5.0, p99=5.0, p999=5.0
2022-02-13T21:12:54.031Z: type=HISTOGRAM, name=application_1643194586439_0036.4.VEProcessExecutor.ve.veCallTimeHist_join_eval_992837114, count=4, min=1, max=5, mean=2.75, stddev=2.0615528128088303, p50=2.5, p75=4.75, p95=5.0, p98=5.0, p99=5.0, p999=5.0
```