### PR TITLE
Simplification of `GroupingFunction` and `MergerFunction`

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Xpress AI.
+ * Copyright (c) 2022 Xpress AI.
  *
  * This file is part of Spark Cyclone.
  * See https://github.com/XpressAI/SparkCyclone for further info.

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Xpress AI.
+ * Copyright (c) 2022 Xpress AI.
  *
  * This file is part of Spark Cyclone.
  * See https://github.com/XpressAI/SparkCyclone for further info.

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.hpp
@@ -26,23 +26,6 @@
 
 std::string utcnanotime();
 
-// inline void set_validity(uint64_t *validityBuffer, int32_t idx, int32_t validity) {
-//     int32_t byte = idx / 64;
-//     int32_t bitIndex = idx % 64;
-//     if (validity) {
-//         validityBuffer[byte] |= (1UL << bitIndex);
-//     } else {
-//         validityBuffer[byte] &= ~(1UL << bitIndex);
-//     }
-// }
-
-// inline uint64_t check_valid(uint64_t *validityBuffer, int32_t idx) {
-//     uint64_t byte = idx / 64;
-//     uint64_t bitIndex = idx % 64;
-//     uint64_t res = (validityBuffer[byte] >> bitIndex) & 1;
-//     return res;
-// }
-
 void debug_words(frovedis::words &in);
 
 std::vector<size_t> idx_to_std(nullable_int_vector *idx);

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.hpp
@@ -26,22 +26,22 @@
 
 std::string utcnanotime();
 
-inline void set_validity(uint64_t *validityBuffer, int32_t idx, int32_t validity) {
-    int32_t byte = idx / 64;
-    int32_t bitIndex = idx % 64;
-    if (validity) {
-        validityBuffer[byte] |= (1UL << bitIndex);
-    } else {
-        validityBuffer[byte] &= ~(1UL << bitIndex);
-    }
-}
+// inline void set_validity(uint64_t *validityBuffer, int32_t idx, int32_t validity) {
+//     int32_t byte = idx / 64;
+//     int32_t bitIndex = idx % 64;
+//     if (validity) {
+//         validityBuffer[byte] |= (1UL << bitIndex);
+//     } else {
+//         validityBuffer[byte] &= ~(1UL << bitIndex);
+//     }
+// }
 
-inline uint64_t check_valid(uint64_t *validityBuffer, int32_t idx) {
-    uint64_t byte = idx / 64;
-    uint64_t bitIndex = idx % 64;
-    uint64_t res = (validityBuffer[byte] >> bitIndex) & 1;
-    return res;
-}
+// inline uint64_t check_valid(uint64_t *validityBuffer, int32_t idx) {
+//     uint64_t byte = idx / 64;
+//     uint64_t bitIndex = idx % 64;
+//     uint64_t res = (validityBuffer[byte] >> bitIndex) & 1;
+//     return res;
+// }
 
 void debug_words(frovedis::words &in);
 

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/example.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/example.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Xpress AI.
+ * Copyright (c) 2022 Xpress AI.
  *
  * This file is part of Spark Cyclone.
  * See https://github.com/XpressAI/SparkCyclone for further info.

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/example.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/example.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Xpress AI.
+ * Copyright (c) 2022 Xpress AI.
  *
  * This file is part of Spark Cyclone.
  * See https://github.com/XpressAI/SparkCyclone for further info.

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
@@ -77,7 +77,7 @@ void NullableScalarVec<T>::print() const {
     // Print data
     stream << "  DATA: [ ";
     for (auto i = 0; i < count; i++) {
-      if (check_valid(validityBuffer, i)) {
+      if (get_validity(i)) {
         stream << data[i] << ", ";
       } else {
         stream << "#, ";
@@ -87,7 +87,7 @@ void NullableScalarVec<T>::print() const {
     // Print validityBuffer
     stream << "]\n  VALIDITY: [";
     for (auto i = 0; i < count; i++) {
-        stream << check_valid(validityBuffer, i) << ", ";
+        stream << get_validity(i) << ", ";
     }
     stream << "]\n";
   }
@@ -114,7 +114,7 @@ bool NullableScalarVec<T>::equals(const NullableScalarVec<T> * const other) cons
   // Compare validityBuffer
   #pragma _NEC ivdep
   for (auto i = 0; i < count; i++) {
-    output = output && (check_valid(validityBuffer, i) == check_valid(other->validityBuffer, i));
+    output = output && (get_validity(i) == other->get_validity(i));
   }
 
   return output;

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Xpress AI.
+ * Copyright (c) 2022 Xpress AI.
  *
  * This file is part of Spark Cyclone.
  * See https://github.com/XpressAI/SparkCyclone for further info.
@@ -36,7 +36,7 @@ NullableScalarVec<T>::NullableScalarVec(const std::vector<T> &src) {
 
   // Set the validityBuffer
   size_t vcount = ceil(src.size() / 64.0);
-  validityBuffer = static_cast<uint64_t *>(calloc(sizeof(uint64_t) * vcount, 1));
+  validityBuffer = static_cast<uint64_t *>(malloc(sizeof(uint64_t) * vcount));
   for (auto i = 0; i < vcount; i++) {
     validityBuffer[i] = 0xffffffffffffffff;
   }

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
@@ -65,8 +65,8 @@ bool NullableScalarVec<T>::is_default() const {
 template <typename T>
 void NullableScalarVec<T>::print() const {
   std::stringstream stream;
-
   stream << "NullableScalarVec<T> @ " << this << " {\n";
+
   // Print count
   stream << "  COUNT: " << count << "\n";
 

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Xpress AI.
+ * Copyright (c) 2022 Xpress AI.
  *
  * This file is part of Spark Cyclone.
  * See https://github.com/XpressAI/SparkCyclone for further info.
@@ -61,7 +61,7 @@ nullable_varchar_vector::nullable_varchar_vector(const std::vector<std::string> 
 
   // Set the validityBuffer
   size_t vcount = frovedis::ceil_div(count, int32_t(64));
-  validityBuffer = static_cast<uint64_t *>(calloc(sizeof(uint64_t) * vcount, 1));
+  validityBuffer = static_cast<uint64_t *>(malloc(sizeof(uint64_t) * vcount));
   for (auto i = 0; i < vcount; i++) {
     validityBuffer[i] = 0xffffffffffffffff;
   }
@@ -106,7 +106,7 @@ nullable_varchar_vector::nullable_varchar_vector(const frovedis::words &src) {
 
   // Set the validityBuffer
   size_t vcount = frovedis::ceil_div(count, int32_t(64));
-  validityBuffer = static_cast<uint64_t *>(calloc(sizeof(uint64_t) * vcount, 1));
+  validityBuffer = static_cast<uint64_t *>(malloc(sizeof(uint64_t) * vcount));
   for (auto i = 0; i < vcount; i++) {
     validityBuffer[i] = 0xffffffffffffffff;
   }

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -178,7 +178,7 @@ void nullable_varchar_vector::print() const {
     // Print string values
     stream << "  VALUES: [ ";
     for (auto i = 0; i < count; i++) {
-      if (check_valid(validityBuffer, i)) {
+      if (get_validity(i)) {
         stream << std::string(data,  offsets[i], offsets[i+1] - offsets[i]) << ", ";
       } else {
         stream << "#, ";
@@ -194,7 +194,7 @@ void nullable_varchar_vector::print() const {
     // Print validityBuffer
     stream << "]\n  VALIDITY: [";
     for (auto i = 0; i < count; i++) {
-        stream << check_valid(validityBuffer, i) << ", ";
+        stream << get_validity(i) << ", ";
     }
 
     // Print data
@@ -231,7 +231,7 @@ bool nullable_varchar_vector::equals(const nullable_varchar_vector * const other
   // Compare validityBuffer
   #pragma _NEC ivdep
   for (auto i = 0; i < count; i++) {
-    output = output && (check_valid(validityBuffer, i) == check_valid(other->validityBuffer, i));
+    output = output && (get_validity(i) == other->get_validity(i));
   }
 
   return output;

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -161,8 +161,8 @@ frovedis::words nullable_varchar_vector::to_words() const {
 
 void nullable_varchar_vector::print() const {
   std::stringstream stream;
-
   stream << "nullable_varchar_vector @ " << this << " {\n";
+
   // Print count
   stream << "  COUNT: " << count << "\n";
 

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Xpress AI.
+ * Copyright (c) 2022 Xpress AI.
  *
  * This file is part of Spark Cyclone.
  * See https://github.com/XpressAI/SparkCyclone for further info.

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
@@ -83,6 +83,12 @@ struct NullableScalarVec {
   // Print the data structure out for debugging
   void print() const;
 
+  // Compute the hash of the value at a given index, starting with a given seed
+  inline int32_t hash_at(const size_t idx,
+                         const int32_t seed) const {
+    return 31 * seed + data[idx];
+  }
+
   // Set the validity value of the vector at the given index
   inline void set_validity(const size_t idx,
                            const int32_t validity) {
@@ -164,6 +170,15 @@ struct nullable_varchar_vector {
 
   // Print the data structure out for debugging
   void print() const;
+
+  // Compute the hash of the value at a given index, starting with a given seed
+  inline int32_t hash_at(const size_t idx,
+                         int32_t seed) const {
+    for (int x = offsets[idx]; x < offsets[idx + 1]; x++) {
+      seed = 31 * seed + data[x];
+    }
+    return seed;
+  }
 
   // Set the validity value of the vector at the given index
   inline void set_validity(const size_t idx,

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
@@ -59,6 +59,10 @@ struct NullableScalarVec {
   uint64_t  *validityBuffer   = nullptr;  // Bit vector to denote null values
   int32_t   count             = 0;        // Row count (synonymous with size of data array)
 
+  // Merge N NullableScalarVec<T>s into 1 NullableScalarVec<T> (order is preserved)
+  static NullableScalarVec<T> * merge(const NullableScalarVec<T> * const * const inputs,
+                                      const size_t batches);
+
   // Explicitly force the generation of a default constructor
   NullableScalarVec() = default;
 
@@ -128,7 +132,12 @@ struct nullable_varchar_vector {
   int32_t   dataSize          = 0;        // Size of data array
   int32_t   count             = 0;        // The row count
 
+  // Construct a C-allocated nullable_varchar_vector from frovedis::words (order is preserved)
   static nullable_varchar_vector * from_words(const frovedis::words &src);
+
+  // Merge N nullable_varchar_vectors into 1 nullable_varchar_vector
+  static nullable_varchar_vector * merge(const nullable_varchar_vector * const * const inputs,
+                                         const size_t batches);
 
   // Explicitly force the generation of a default constructor
   nullable_varchar_vector() = default;

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/tuple_hash.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/tuple_hash.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Xpress AI.
+ * Copyright (c) 2022 Xpress AI.
  *
  * This file is part of Spark Cyclone.
  * See https://github.com/XpressAI/SparkCyclone for further info.

--- a/src/main/resources/com/nec/cyclone/cpp/examples.cpp
+++ b/src/main/resources/com/nec/cyclone/cpp/examples.cpp
@@ -1,4 +1,22 @@
-
+/*
+ * Copyright (c) 2021 Xpress AI.
+ *
+ * This file is part of Spark Cyclone.
+ * See https://github.com/XpressAI/SparkCyclone for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #include "cyclone/cyclone.hpp"
 #include "cyclone/transfer-definitions.hpp"
 #include "cyclone/tuple_hash.hpp"
@@ -39,7 +57,7 @@ nullable_varchar_vector * project_eval(const nullable_varchar_vector *input_0)  
   auto *output_0 = new nullable_varchar_vector(output_0_input_words);
 
   for ( int i = 0; i < output_0->count; i++ ) {
-    set_validity(output_0->validityBuffer, i, check_valid(input_0->validityBuffer, i));
+    output_0->set_validity(i, input_0->get_validity(i));
   }
 
   return output_0;
@@ -49,8 +67,8 @@ void filter_test() {
   std::vector<std::string> data { "AIR", "MAIL", "RAIL", "SHIP", "TRUCK", "REG AIR", "FOB" };
   std::vector<size_t> matching_ids { 1, 3, 5 };
 
-  const auto *input = new nullable_varchar_vector(data);
-  set_validity(input->validityBuffer, 3, 0);
+  auto *input = new nullable_varchar_vector(data);
+  input->set_validity(3, 0);
 
   std::cout << "================================================================================" << std::endl;
   std::cout << "FILTER TEST\n" << std::endl;
@@ -69,8 +87,8 @@ void filter_test() {
 void projection_test() {
   std::vector<std::string> data { "AIR", "MAIL", "RAIL", "SHIP", "TRUCK", "REG AIR", "FOB" };
 
-  const auto *input = new nullable_varchar_vector(data);
-  set_validity(input->validityBuffer, 3, 0);
+  auto *input = new nullable_varchar_vector(data);
+  input->set_validity(3, 0);
 
   std::cout << "================================================================================" << std::endl;
   std::cout << "PROJECTION TEST\n" << std::endl;
@@ -90,8 +108,8 @@ void bucket_grouping_test_fail() {
   std::vector<std::string> data { "AIR", "MAIL", "RAIL", "SHIP", "TRUCK", "REG AIR", "FOB" };
   std::vector<size_t> id_to_bucket { 0, 1, 0, 1, 0, 1, 0 };
 
-  const auto *input = new nullable_varchar_vector(data);
-  set_validity(input->validityBuffer, 3, 0);
+  auto *input = new nullable_varchar_vector(data);
+  input->set_validity(3, 0);
 
   auto output_0_input_words = input->to_words();
 
@@ -123,7 +141,7 @@ void bucket_grouping_test_fail() {
   auto o = 0;
   for (auto i = 0; i < id_to_bucket.size(); i++ ) {
     if (id_to_bucket[i]) {
-      set_validity(output_0->validityBuffer, o++, 1);
+      output_0->set_validity(o++, 1);
     }
   }
 
@@ -148,8 +166,8 @@ void bucket_grouping_test_pass() {
   std::vector<std::string> data { "AIR", "MAIL", "RAIL", "SHIP", "TRUCK", "REG AIR", "FOB" };
   std::vector<size_t> id_to_bucket { 0, 1, 0, 1, 0, 1, 0 };
 
-  const auto *input = new nullable_varchar_vector(data);
-  set_validity(input->validityBuffer, 3, 0);
+  auto *input = new nullable_varchar_vector(data);
+  input->set_validity(3, 0);
 
   auto output_0_input_words = input->to_words();
 
@@ -183,7 +201,7 @@ void bucket_grouping_test_pass() {
   auto o = 0;
   for (auto i = 0; i < id_to_bucket.size(); i++ ) {
     if (id_to_bucket[i]) {
-      set_validity(output_0->validityBuffer, o++, check_valid(input->validityBuffer, i));
+      output_0->set_validity(o++, input->get_validity(i));
     }
   }
 
@@ -208,14 +226,14 @@ void merge_test_pass() {
   // nullable_varchar_vector 1
   std::vector<std::string> data1 { "AIR", "MAIL", "RAIL", "SHIP", "TRUCK", "REG AIR", "FOB" };
   auto *input1 = new nullable_varchar_vector(data1);
-  set_validity(input1->validityBuffer, 3, 0);
+  input1->set_validity(3, 0);
 
   // nullable_varchar_vector 2
   std::vector<std::string> data2 { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
   auto *input2 = new nullable_varchar_vector(data2);
-  set_validity(input2->validityBuffer, 1, 0);
-  set_validity(input2->validityBuffer, 4, 0);
-  set_validity(input2->validityBuffer, 10, 0);
+  input2->set_validity(1, 0);
+  input2->set_validity(4, 0);
+  input2->set_validity(10, 0);
 
   auto batches = 2;
   nullable_varchar_vector **input_0_g = new nullable_varchar_vector* [batches];
@@ -236,7 +254,7 @@ void merge_test_pass() {
   auto o = 0;
   for (int b = 0; b < batches; b++) {
     for (int i = 0; i < input_0_g[b]->count; i++) {
-      set_validity(output_0->validityBuffer, o++, check_valid(input_0_g[b]->validityBuffer, i));
+      output_0->set_validity(o++, input_0_g[b]->get_validity(i));
     }
   }
 

--- a/src/main/resources/com/nec/cyclone/cpp/examples.cpp
+++ b/src/main/resources/com/nec/cyclone/cpp/examples.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Xpress AI.
+ * Copyright (c) 2022 Xpress AI.
  *
  * This file is part of Spark Cyclone.
  * See https://github.com/XpressAI/SparkCyclone for further info.

--- a/src/main/resources/com/nec/cyclone/cpp/tests/driver.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/driver.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Xpress AI.
+ * Copyright (c) 2022 Xpress AI.
  *
  * This file is part of Spark Cyclone.
  * See https://github.com/XpressAI/SparkCyclone for further info.

--- a/src/main/resources/com/nec/cyclone/cpp/tests/example_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/example_spec.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Xpress AI.
+ * Copyright (c) 2022 Xpress AI.
  *
  * This file is part of Spark Cyclone.
  * See https://github.com/XpressAI/SparkCyclone for further info.

--- a/src/main/resources/com/nec/cyclone/cpp/tests/nullable_scalar_vector_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/nullable_scalar_vector_spec.hpp
@@ -130,5 +130,29 @@ namespace cyclone::tests {
       CHECK(output[1]->equals(input->filter(matching_ids_1)));
       CHECK(output[2]->equals(input->filter(matching_ids_2)));
     }
+
+    TEST_CASE_TEMPLATE("Merge works for T=", T, int32_t, int64_t, float, double) {
+      std::vector<NullableScalarVec<T> *> inputs(3);
+
+      inputs[0] = new NullableScalarVec(std::vector<T> { 586, 951, 106, 318, 538 });
+      inputs[0]->set_validity(1, 0);
+      inputs[0]->set_validity(4, 0);
+
+      inputs[1] = new NullableScalarVec(std::vector<T> { 620, 553, 605 });
+      inputs[1]->set_validity(2, 0);
+
+      inputs[2] = new NullableScalarVec(std::vector<T> { 46, 726, 563, 515, });
+      inputs[2]->set_validity(3, 0);
+
+      auto *expected = new NullableScalarVec(std::vector<T> { 586, 951, 106, 318, 538, 620, 553, 605, 46, 726, 563, 515 });
+      expected->set_validity(1, 0);
+      expected->set_validity(4, 0);
+      expected->set_validity(7, 0);
+      expected->set_validity(11, 0);
+
+      const auto *output = NullableScalarVec<T>::merge(&inputs[0], 3);
+      CHECK(output != expected);
+      CHECK(output->equals(expected));
+    }
   }
 }

--- a/src/main/resources/com/nec/cyclone/cpp/tests/nullable_scalar_vector_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/nullable_scalar_vector_spec.hpp
@@ -26,11 +26,11 @@
 
 namespace cyclone::tests {
   TEST_SUITE("NullableScalarVec<T>") {
-    TEST_CASE_TEMPLATE("Equality checks work for T=", T, int32_t, int64_t, float, double) {
-      // Instantiate for int32_t
-      std::vector<T> raw { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 };
+    // Instantiate for each template case to be tested
+    template<class T> const std::vector<T> raw { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 };
 
-      auto *vec1 = new NullableScalarVec(raw);
+    TEST_CASE_TEMPLATE("Equality checks work for T=", T, int32_t, int64_t, float, double) {
+      auto *vec1 = new NullableScalarVec(raw<T>);
       vec1->set_validity(1, 0);
       vec1->set_validity(4, 0);
       vec1->set_validity(8, 0);
@@ -39,11 +39,11 @@ namespace cyclone::tests {
       auto *vec2 = new NullableScalarVec(std::vector<T> { 586, 951, 106, 318, 538, 620, 553 });
 
       // Different data
-      auto *vec3 = new NullableScalarVec(raw);
+      auto *vec3 = new NullableScalarVec(raw<T>);
       vec3->data[3] = 184;
 
       // Different validityBuffer
-      auto *vec4 = new NullableScalarVec(raw);
+      auto *vec4 = new NullableScalarVec(raw<T>);
       vec4->set_validity(3, 0);
 
       CHECK(vec1->equals(vec1));
@@ -54,7 +54,7 @@ namespace cyclone::tests {
 
     TEST_CASE_TEMPLATE("Check default works for T=", T, int32_t, int64_t, float, double) {
       auto *empty = new NullableScalarVec<T>;
-      auto *nonempty = new NullableScalarVec(std::vector<T> { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 });
+      auto *nonempty = new NullableScalarVec(raw<T>);
 
       CHECK(empty->is_default());
       CHECK(not nonempty->is_default());
@@ -63,7 +63,7 @@ namespace cyclone::tests {
     TEST_CASE_TEMPLATE("Reset works for T=", T, int32_t, int64_t, float, double) {
       auto *empty = new NullableScalarVec<T>;
 
-      auto *input = new NullableScalarVec(std::vector<T> { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 });
+      auto *input = new NullableScalarVec(raw<T>);
       input->set_validity(1, 0);
       input->set_validity(4, 0);
       input->set_validity(8, 0);
@@ -74,7 +74,7 @@ namespace cyclone::tests {
     }
 
     TEST_CASE_TEMPLATE("Clone works for T=", T, int32_t, int64_t, float, double) {
-      auto *input = new NullableScalarVec(std::vector<T> { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 });
+      auto *input = new NullableScalarVec(raw<T>);
       input->set_validity(1, 0);
       input->set_validity(4, 0);
       input->set_validity(8, 0);
@@ -82,6 +82,16 @@ namespace cyclone::tests {
       auto *output = input->clone();
       CHECK(output != input);
       CHECK(output->equals(input));
+    }
+
+    TEST_CASE_TEMPLATE("Get and Set validity bit works for T=", T, int32_t, int64_t, float, double) {
+      auto *input = new NullableScalarVec(raw<T>);
+
+      input->set_validity(4, 0);
+      CHECK(input->get_validity(4) == 0);
+
+      input->set_validity(4, 1);
+      CHECK(input->get_validity(4) == 1);
     }
 
     TEST_CASE_TEMPLATE("Filter works for T=", T, int32_t, int64_t, float, double) {

--- a/src/main/resources/com/nec/cyclone/cpp/tests/nullable_scalar_vector_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/nullable_scalar_vector_spec.hpp
@@ -84,6 +84,13 @@ namespace cyclone::tests {
       CHECK(output->equals(input));
     }
 
+    TEST_CASE_TEMPLATE("Hash value works for T=", T, int32_t, int64_t, float, double) {
+      auto *input = new NullableScalarVec(raw<T>);
+
+      const auto output = input->hash_at(3, 42);
+      CHECK(output == 31 * 42 + 318);
+    }
+
     TEST_CASE_TEMPLATE("Get and Set validity bit works for T=", T, int32_t, int64_t, float, double) {
       auto *input = new NullableScalarVec(raw<T>);
 

--- a/src/main/resources/com/nec/cyclone/cpp/tests/nullable_scalar_vector_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/nullable_scalar_vector_spec.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Xpress AI.
+ * Copyright (c) 2022 Xpress AI.
  *
  * This file is part of Spark Cyclone.
  * See https://github.com/XpressAI/SparkCyclone for further info.
@@ -27,7 +27,7 @@
 namespace cyclone::tests {
   TEST_SUITE("NullableScalarVec<T>") {
     // Instantiate for each template case to be tested
-    template<class T> const std::vector<T> raw { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 };
+    template<typename T> const std::vector<T> raw { 586, 951, 106, 318, 538, 620, 553, 605, 822, 941 };
 
     TEST_CASE_TEMPLATE("Equality checks work for T=", T, int32_t, int64_t, float, double) {
       auto *vec1 = new NullableScalarVec(raw<T>);

--- a/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Xpress AI.
+ * Copyright (c) 2022 Xpress AI.
  *
  * This file is part of Spark Cyclone.
  * See https://github.com/XpressAI/SparkCyclone for further info.

--- a/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.hpp
@@ -134,5 +134,29 @@ namespace cyclone::tests {
       CHECK(output[1]->equals(input->filter(matching_ids_1)));
       CHECK(output[2]->equals(input->filter(matching_ids_2)));
     }
+
+    TEST_CASE("Merge works") {
+      std::vector<nullable_varchar_vector *> inputs(3);
+
+      inputs[0] = new nullable_varchar_vector(std::vector<std::string> { "JAN", "FEB", "MAR", "APR", "MAY" });
+      inputs[0]->set_validity(1, 0);
+      inputs[0]->set_validity(4, 0);
+
+      inputs[1] = new nullable_varchar_vector(std::vector<std::string> { "MON", "", "WED" });
+      inputs[1]->set_validity(2, 0);
+
+      inputs[2] = new nullable_varchar_vector(std::vector<std::string> { "JUL", "AUG", "", "OCT" });
+      inputs[2]->set_validity(3, 0);
+
+      auto *expected = new nullable_varchar_vector(std::vector<std::string> { "JAN", "FEB", "MAR", "APR", "MAY", "MON", "", "WED", "JUL", "AUG", "", "OCT" });
+      expected->set_validity(1, 0);
+      expected->set_validity(4, 0);
+      expected->set_validity(7, 0);
+      expected->set_validity(11, 0);
+
+      const auto *output = nullable_varchar_vector::merge(&inputs[0], 3);
+      CHECK(output != expected);
+      CHECK(output->equals(expected));
+    }
   }
 }

--- a/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.hpp
@@ -86,7 +86,14 @@ namespace cyclone::tests {
       CHECK(output->equals(input));
     }
 
-    TEST_CASE("Get and Set validity bit works for T=") {
+    TEST_CASE("Hash value works") {
+      auto *input = new nullable_varchar_vector(std::vector<std::string> { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "", "OCT", "NOV", "DEC" });
+
+      const auto output = input->hash_at(3, 42);
+      CHECK(output == 31 * (31 * (31 * 42 + 'A') + 'P') + 'R');
+    }
+
+    TEST_CASE("Get and Set validity bit works") {
       auto *input = new nullable_varchar_vector(std::vector<std::string> { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "", "OCT", "NOV", "DEC" });
 
       input->set_validity(4, 0);

--- a/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.hpp
@@ -86,6 +86,16 @@ namespace cyclone::tests {
       CHECK(output->equals(input));
     }
 
+    TEST_CASE("Get and Set validity bit works for T=") {
+      auto *input = new nullable_varchar_vector(std::vector<std::string> { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "", "OCT", "NOV", "DEC" });
+
+      input->set_validity(4, 0);
+      CHECK(input->get_validity(4) == 0);
+
+      input->set_validity(4, 1);
+      CHECK(input->get_validity(4) == 1);
+    }
+
     TEST_CASE("Filter works") {
       // Include empty string value
       auto *input = new nullable_varchar_vector(std::vector<std::string> { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "", "SEP", "OCT", "NOV", "DEC" });

--- a/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
+++ b/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
@@ -93,7 +93,7 @@ object CFunctionGeneration {
         CodeLines
           .from(
             s"${outputName}->data[i] = ${cCode};",
-            s"set_validity($outputName->validityBuffer, i, 1);"
+            s"$outputName->set_validity(i, 1);"
           )
           .indented
       case Some(nullCheck) =>
@@ -103,11 +103,11 @@ object CFunctionGeneration {
             CodeLines
               .from(
                 s"${outputName}->data[i] = ${cCode};",
-                s"set_validity($outputName->validityBuffer, i, 1);"
+                s"$outputName->set_validity(i, 1);"
               )
               .indented,
             "} else {",
-            CodeLines.from(s"set_validity($outputName->validityBuffer, i, 0);").indented,
+            CodeLines.from(s"$outputName->set_validity(i, 0);").indented,
             "}"
           )
           .indented
@@ -669,15 +669,15 @@ object CFunctionGeneration {
           case (CScalarVector(inName, veType), CScalarVector(outputName, _)) =>
             CodeLines
               .from(
-                s"if(check_valid(${inName}->validityBuffer, idx[i])) {",
+                s"if (${inName}->get_validity(idx[i])) {",
                 CodeLines
                   .from(
                     s"$outputName->data[i] = $inName->data[idx[i]];",
-                    s"set_validity($outputName->validityBuffer, i, 1);"
+                    s"$outputName->set_validity(i, 1);"
                   )
                   .indented,
                 "} else {",
-                CodeLines.from(s"set_validity($outputName->validityBuffer, i, 0);").indented,
+                CodeLines.from(s"$outputName->set_validity(i, 0);").indented,
                 "}"
               )
               .indented
@@ -763,13 +763,13 @@ object CFunctionGeneration {
             CodeLines.forLoop("o", "matching_ids.size()") {
               CodeLines.from(
                 "int i = matching_ids[o];",
-                CodeLines.ifElseStatement(s"check_valid(${cVector.name}->validityBuffer, i)") {
+                CodeLines.ifElseStatement(s"${cVector.name}->get_validity(i)") {
                   List(
                     s"${varName}->data[o] = ${cVector.name}->data[i];",
-                    s"set_validity($varName->validityBuffer, o, 1);"
+                    s"$varName->set_validity(o, 1);"
                   )
                 } {
-                  s"set_validity($varName->validityBuffer, o, 0);"
+                  s"$varName->set_validity(o, 0);"
                 }
               )
             }
@@ -831,15 +831,15 @@ object CFunctionGeneration {
               case None =>
                 CodeLines.from(
                   s"""$outputName->data[i] = ${cExpr.cCode};""",
-                  s"set_validity($outputName->validityBuffer, i, 1);"
+                  s"$outputName->set_validity(i, 1);"
                 )
               case Some(notNullCheck) =>
                 CodeLines.from(
                   s"if ( $notNullCheck ) {",
                   s"""  $outputName->data[i] = ${cExpr.cCode};""",
-                  s"  set_validity($outputName->validityBuffer, i, 1);",
+                  s"  $outputName->set_validity(i, 1);",
                   "} else {",
-                  s"  set_validity($outputName->validityBuffer, i, 0);",
+                  s"  $outputName->set_validity(i, 0);",
                   "}"
                 )
             }
@@ -908,7 +908,7 @@ object CFunctionGeneration {
                   CodeLines
                     .from(
                       s"${outputName}->data[i] = ${ex.cCode};",
-                      s"set_validity($outputName->validityBuffer, i, 1);"
+                      s"$outputName->set_validity(i, 1);"
                     )
                     .indented
                 case Some(nullCheck) =>
@@ -918,11 +918,11 @@ object CFunctionGeneration {
                       CodeLines
                         .from(
                           s"${outputName}->data[i] = ${ex.cCode};",
-                          s"set_validity($outputName->validityBuffer, i, 1);"
+                          s"$outputName->set_validity(i, 1);"
                         )
                         .indented,
                       "} else {",
-                      CodeLines.from(s"set_validity($outputName->validityBuffer, i, 0);").indented,
+                      CodeLines.from(s"$outputName->set_validity(i, 0);").indented,
                       "}"
                     )
                     .indented
@@ -1068,7 +1068,7 @@ object CFunctionGeneration {
                     CodeLines
                       .from(
                         s"${outputName}->data[i] = ${ex.cCode};",
-                        s"set_validity($outputName->validityBuffer, i, 1);"
+                        s"$outputName->set_validity(i, 1);"
                       )
                       .indented
                   case Some(nullCheck) =>
@@ -1076,9 +1076,9 @@ object CFunctionGeneration {
                       .from(
                         s"if( ${nullCheck} ) {",
                         s"${outputName}->data[i] = ${ex.cCode};",
-                        s"set_validity($outputName->validityBuffer, i, 1);",
+                        s"$outputName->set_validity(i, 1);",
                         "} else {",
-                        s"set_validity($outputName->validityBuffer, i, 0);",
+                        s"$outputName->set_validity(i, 0);",
                         "}"
                       )
                       .indented
@@ -1100,7 +1100,7 @@ object CFunctionGeneration {
                     CodeLines
                       .from(
                         s"${outputName}->data[i] = ${ex.cCode};",
-                        s"set_validity($outputName->validityBuffer, i, 1);"
+                        s"$outputName->set_validity(i, 1);"
                       )
                       .indented
                   case Some(nullCheck) =>
@@ -1108,9 +1108,9 @@ object CFunctionGeneration {
                       .from(
                         s"if( ${nullCheck} ) {",
                         s"${outputName}->data[i] = ${ex.cCode};",
-                        s"set_validity($outputName->validityBuffer, i, 1);",
+                        s"$outputName->set_validity(i, 1);",
                         "} else {",
-                        s"set_validity($outputName->validityBuffer, i, 0);",
+                        s"$outputName->set_validity(i, 0);",
                         "}"
                       )
                       .indented

--- a/src/main/scala/com/nec/spark/agile/DeclarativeAggregationConverter.scala
+++ b/src/main/scala/com/nec/spark/agile/DeclarativeAggregationConverter.scala
@@ -230,7 +230,7 @@ object DeclarativeAggregationConverter {
                   CExpression(
                     cCode = s"${inputPrefix}_attr_${targetAttribute.name}->data[i]",
                     isNotNullCode = Some(
-                      s"check_valid(${inputPrefix}_attr_${targetAttribute.name}->validityBuffer, i)"
+                      s"${inputPrefix}_attr_${targetAttribute.name}->get_validity(i)"
                     )
                   )
               }

--- a/src/main/scala/com/nec/spark/agile/SparkExpressionToCExpression.scala
+++ b/src/main/scala/com/nec/spark/agile/SparkExpressionToCExpression.scala
@@ -286,7 +286,7 @@ object SparkExpressionToCExpression {
             isNotNullCode = if (ar.nullable) {
               val indexingExpr = ar.name.substring(0, ar.name.length - 1).split("""data(\[)""")
               Some(
-                s"check_valid(${ar.name.replaceAll("""data\[.*\]""", "validityBuffer")}, ${indexingExpr(indexingExpr.size - 1)})"
+                s"${ar.name.replaceAll("""data\[.*\]""", "")}get_validity(${indexingExpr(indexingExpr.size - 1)})"
               )
             } else None
           )

--- a/src/main/scala/com/nec/spark/agile/StringHole.scala
+++ b/src/main/scala/com/nec/spark/agile/StringHole.scala
@@ -252,7 +252,7 @@ object StringHole {
       }
       case object NotNullEvaluator extends SlowEvaluator {
         override def evaluate(refName: String): CExpression =
-          CExpression(cCode = s"check_valid(${refName}->validityBuffer, i)", isNotNullCode = None)
+          CExpression(cCode = s"${refName}->get_validity(i)", isNotNullCode = None)
       }
       final case class StartsWithEvaluator(theString: String) extends SlowEvaluator {
         override def evaluate(refName: String): CExpression = {

--- a/src/main/scala/com/nec/spark/agile/StringProducer.scala
+++ b/src/main/scala/com/nec/spark/agile/StringProducer.scala
@@ -89,13 +89,13 @@ object StringProducer {
           CodeLines.forLoop("g", s"${subset}.size()") {
             List(
               s"int i = ${subset}[g];",
-              s"set_validity(${outputName}->validityBuffer, g, check_valid(${inputName}->validityBuffer, i));"
+              s"${outputName}->set_validity(g, ${inputName}->get_validity(i));"
             )
           }
 
         case None =>
           CodeLines.forLoop("i", s"${outputName}->count") {
-            s"set_validity(${outputName}->validityBuffer, i, check_valid(${inputName}->validityBuffer, i));"
+            s"${outputName}->set_validity(i, ${inputName}->get_validity(i));"
           }
       }
     }
@@ -171,7 +171,7 @@ object StringProducer {
       }
 
     def validityForEach(idx: String): CodeLines =
-      CodeLines.from(s"set_validity($outputName->validityBuffer, $idx, 1);")
+      CodeLines.from(s"$outputName->set_validity($idx, 1);")
   }
 
   def produceVarChar(

--- a/src/main/scala/com/nec/spark/agile/join/GenericJoiner.scala
+++ b/src/main/scala/com/nec/spark/agile/join/GenericJoiner.scala
@@ -82,7 +82,7 @@ object GenericJoiner {
       CodeLines.forLoop("i", s"${inputIndices}.size()")(
         CodeLines.from(
           s"${outputName}->data[i] = ${inputName}->data[${inputIndices}[i]];",
-          s"set_validity(${outputName}->validityBuffer, i, check_valid(${inputName}->validityBuffer, ${inputIndices}[i]));"
+          s"${outputName}->set_validity(i, ${inputName}->get_validity(${inputIndices}[i]));"
         )
       )
     )

--- a/src/main/scala/com/nec/spark/agile/join/JoinByEquality.scala
+++ b/src/main/scala/com/nec/spark/agile/join/JoinByEquality.scala
@@ -99,7 +99,7 @@ final case class JoinByEquality(
                   CodeLines.forLoop("i", s"${in}.size()") {
                     CodeLines.from(
                       s"${nme}_idx->data[i] = ${in}[i];",
-                      s"set_validity(${nme}_idx->validityBuffer, i, 1);"
+                      s"${nme}_idx->set_validity(i, 1);"
                     )
                   }
                 )
@@ -122,7 +122,7 @@ final case class JoinByEquality(
                   CodeLines.forLoop("i", s"${in}.size()")(
                     CodeLines.from(
                       s"${nme}_idx->data[i] = ${in}[i];",
-                      s"set_validity(${nme}_idx->validityBuffer, i, 1);"
+                      s"${nme}_idx->set_validity(i, 1);"
                     )
                   )
                 )

--- a/src/main/scala/com/nec/ve/GroupingFunction.scala
+++ b/src/main/scala/com/nec/ve/GroupingFunction.scala
@@ -158,17 +158,18 @@ object GroupingFunction {
         /*
           Allocate the nullable_T_vector[] with size buckets
 
-          NOTE: This cast should not be correct, because we are allocating a T*
-          array (T**) but type-casting it to T*.  However, for some reason,
-          fixing this will lead an invalid free() later on.  Will need to
-          investigate fix this.
+          NOTE: This cast is incorrect, because we are allocating a T* array
+          (T**) but type-casting it to T*.  However, for some reason, fixing
+          this will lead an invalid free() later on.  Will need to investigate
+          and fix this in the future.
         */
+        s"// Allocate T*[] but cast to T* (incorrect but required to work correctly until a fix lands)",
         s"*${output.name} = static_cast<${output.veType.cVectorType} *>(malloc(sizeof(nullptr) * ${buckets}));",
         // Copy the pointers over
         CodeLines.forLoop("b", s"${buckets}") {
           s"${output.name}[b] = tmp[b];"
         },
-        // Free the array of pointers (but not the structs themselves)
+        // Free the array of temporary pointers (but not the structs themselves)
         "free(tmp);"
       )
     }

--- a/src/main/scala/com/nec/ve/GroupingFunction.scala
+++ b/src/main/scala/com/nec/ve/GroupingFunction.scala
@@ -1,55 +1,64 @@
 package com.nec.ve
 
 import com.nec.spark.agile.CExpressionEvaluation.CodeLines
+import com.nec.spark.agile.CFunction2
 import com.nec.spark.agile.CFunction2.CFunctionArgument
 import com.nec.spark.agile.CFunction2.CFunctionArgument.PointerPointer
-import com.nec.spark.agile.CFunctionGeneration.{CVector, VeScalarType, VeType}
-import com.nec.spark.agile.groupby.GroupByOutline
-import com.nec.spark.agile.{CFunction2, CFunctionGeneration, StringProducer}
-import com.nec.ve.GroupingFunction.DataDescription.KeyOrValue
+import com.nec.spark.agile.CFunctionGeneration.{CVector, VeType}
 
 object GroupingFunction {
-  final case class DataDescription(veType: VeType, keyOrValue: KeyOrValue)
+  val GroupAssignmentsId = "bucket_assignments"
+  val GroupCountsId = "bucket_counts"
 
-  object DataDescription {
-    sealed trait KeyOrValue {
-      def renderValue: String
-      def isKey: Boolean
-      def isValue: Boolean = !isKey
-    }
-    object KeyOrValue {
-      case object Key extends KeyOrValue {
-        override def renderValue: String = "key"
-        override def isKey: Boolean = true
-      }
-      case object Value extends KeyOrValue {
-        override def renderValue: String = "value"
-        override def isKey: Boolean = false
-      }
-    }
+  sealed trait KeyOrValue {
+    def render: String
   }
 
-  def computeBuckets(
-    cVectors: List[CVector],
-    groupingIdentifiers: String,
-    totalBuckets: Int
-  ): CodeLines = {
-    require(cVectors.nonEmpty, "cVectors is empty - perhaps an issue in checking the groups?")
+  case object Key extends KeyOrValue {
+    def render: String = "key"
+  }
 
+  case object Value extends KeyOrValue {
+    def render: String = "value"
+  }
+
+  final case class DataDescription(veType: VeType, kvType: KeyOrValue)
+}
+
+case class GroupingFunction(name: String,
+                            columns: List[GroupingFunction.DataDescription],
+                            nbuckets: Int) {
+  private[ve] val inputs = columns.zipWithIndex.map { case (GroupingFunction.DataDescription(veType, kvType), idx) =>
+    veType.makeCVector(s"${kvType.render}_${idx}")
+  }
+
+  private[ve] val outputs = columns.zipWithIndex.map { case (GroupingFunction.DataDescription(veType, kvType), idx) =>
+    veType.makeCVector(s"output_${kvType.render}_${idx}")
+  }
+
+  private[ve] val keycols = columns.zip(inputs).filter(_._1.kvType == GroupingFunction.Key).map(_._2)
+
+  private[ve] def arguments: List[CFunction2.CFunctionArgument] = {
+    inputs.map(PointerPointer(_)) ++
+      List(CFunctionArgument.Raw("int* sets")) ++
+      outputs.map(PointerPointer(_))
+  }
+
+  private[ve] def computeBucketAssignments: CodeLines = {
     CodeLines.from(
-      // Iniitalize the bucket_assignments table
-      s"std::vector<size_t> $groupingIdentifiers(${cVectors.head.name}[0]->count);",
+      // Initialize the bucket_assignments table
+      s"std::vector<size_t> ${GroupingFunction.GroupAssignmentsId}(${keycols.head.name}[0]->count);",
       CodeLines.scoped("Compute the index -> bucket mapping") {
         CodeLines.from(
           "#pragma _NEC vector",
-          CodeLines.forLoop("i", s"${cVectors.head.name}[0]->count") {
+          CodeLines.forLoop("i", s"${keycols.head.name}[0]->count") {
             CodeLines.from(
               // Initialize the hash
               s"int hash = 1;",
               // Compute the hash across all keys
-              cVectors.map { vec => s"hash = ${vec.name}[0]->hash_at(i, hash);" },
+              keycols.map { vec => s"hash = ${vec.name}[0]->hash_at(i, hash);" },
               // Assign the bucket based on the hash
-              s"${groupingIdentifiers}[i] = abs(hash % ${totalBuckets});"
+              s"${GroupingFunction.GroupAssignmentsId}[i] = abs(hash % ${nbuckets});"
             )
           }
         )
@@ -57,24 +66,22 @@ object GroupingFunction {
     )
   }
 
-  def computeBucketSizes(
-    groupingIdentifiers: String,
-    bucketToCount: String,
-    totalBuckets: Int
-  ): CodeLines = {
+  private[ve] def computeBucketCounts: CodeLines = {
     CodeLines.from(
       // Iniitalize the bucket_counts table
-      s"std::vector<size_t> $bucketToCount(${totalBuckets});",
+      s"std::vector<size_t> ${GroupingFunction.GroupCountsId}(${nbuckets});",
       CodeLines.scoped("Compute the value counts for each bucket") {
         CodeLines.from(
           "#pragma _NEC vector",
-          CodeLines.forLoop("g", s"${totalBuckets}") {
+          CodeLines.forLoop("g", s"${nbuckets}") {
             CodeLines.from(
               s"size_t count = 0;",
-              CodeLines.forLoop("i", s"${groupingIdentifiers}.size()") {
-                s"count += (${groupingIdentifiers}[i] == g);"
+              // Count the assignments that equal g
+              CodeLines.forLoop("i", s"${GroupingFunction.GroupAssignmentsId}.size()") {
+                s"count += (${GroupingFunction.GroupAssignmentsId}[i] == g);"
               },
-              s"${bucketToCount}[g] = count;"
+              // Assign to the counts table
+              s"${GroupingFunction.GroupCountsId}[g] = count;"
             )
           }
         )
@@ -82,12 +89,7 @@ object GroupingFunction {
     )
   }
 
-  def cloneCVecStmt(output: CVector, input: CVector): CodeLines = {
-    require(
-      output.veType == input.veType,
-      "Cannot clone cVector - input and output VeTypes are not the same!"
-    )
-
+  private[ve] def cloneCVecStmt(output: CVector, input: CVector): CodeLines = {
     CodeLines.scoped(s"Clone ${input.name}[0] over to ${output.name}[0]") {
       List(
         // Allocate the nullable_T_vector[] with size 1
@@ -98,73 +100,26 @@ object GroupingFunction {
     }
   }
 
-  def groupData(data: List[DataDescription], totalBuckets: Int) = {
-    if (data.count(_.keyOrValue.isKey) <= 0) {
-      /*
-        In the case where there are no input key columns, we simply clone the
-        input data to the output pointers.
-       */
-      groupDataNoKeyColumns(data)
-
-    } else {
-      groupDataNormal(data, totalBuckets)
-    }
-  }
-
-  def groupDataNoKeyColumns(data: List[DataDescription]): CFunction2 = {
-    val inputs = data.zipWithIndex.map { case (DataDescription(veType, isKey), idx) =>
-      veType.makeCVector(s"${isKey.renderValue}_${idx}")
-    }
-
-    val outputs = data.zipWithIndex.map { case (DataDescription(veType, isKey), idx) =>
-      veType.makeCVector(s"output_${isKey.renderValue}_${idx}")
-    }
-
-    val arguments = inputs.map(PointerPointer(_)) ++
-      List(CFunctionArgument.Raw("int* sets")) ++
-      outputs.map(PointerPointer(_))
-
-    CFunction2(
-      arguments,
-      CodeLines.from(
-        "// Write out the number of buckets",
-        s"sets[0] = 1;",
-        "",
-        (outputs, inputs).zipped.map(cloneCVecStmt(_, _))
-      )
-    )
-  }
-
-  def copyVecToBucketsStmt(
-    output: CVector,
-    input: CVector,
-    buckets: Int,
-    idToBucket: String,
-    bucketToCount: String
-  ): CodeLines = {
-    require(
-      output.veType == input.veType,
-      "Cannot copy cVector values to their buckets - input and output VeTypes are not the same!"
-    )
-
+  private[ve] def copyVecToBucketsStmt(output: CVector, input: CVector): CodeLines = {
     CodeLines.scoped(
       s"Copy elements of ${input.name}[0] to their respective buckets in ${output.name}"
     ) {
       CodeLines.from(
         // Perform the bucketing and get back T** (array of pointers)
-        s"auto ** tmp = ${input.name}[0]->bucket(${bucketToCount}, ${idToBucket});",
+        s"auto ** tmp = ${input.name}[0]->bucket(${GroupingFunction.GroupCountsId}, ${GroupingFunction.GroupAssignmentsId});",
         /*
           Allocate the nullable_T_vector[] with size buckets
 
           NOTE: This cast is incorrect, because we are allocating a T* array
           (T**) but type-casting it to T*.  However, for some reason, fixing
-          this will lead an invalid free() later on.  Will need to investigate
-          and fix this in the future.
+          this will lead an invalid free() later on - this is likely due to an
+          error in how we define function call from the Spark side.  Will need
+          to investigate and fix this in the future.
         */
         s"// Allocate T*[] but cast to T* (incorrect but required to work correctly until a fix lands)",
-        s"*${output.name} = static_cast<${output.veType.cVectorType} *>(malloc(sizeof(nullptr) * ${buckets}));",
+        s"*${output.name} = static_cast<${output.veType.cVectorType} *>(malloc(sizeof(nullptr) * ${nbuckets}));",
         // Copy the pointers over
-        CodeLines.forLoop("b", s"${buckets}") {
+        CodeLines.forLoop("b", s"${nbuckets}") {
           s"${output.name}[b] = tmp[b];"
         },
         // Free the array of temporary pointers (but not the structs themselves)
@@ -173,44 +128,30 @@ object GroupingFunction {
     }
   }
 
-  def groupDataNormal(data: List[DataDescription], totalBuckets: Int): CFunction2 = {
-    val inputs = data.zipWithIndex.map { case (DataDescription(veType, isKey), idx) =>
-      veType.makeCVector(s"${isKey.renderValue}_$idx")
-    }
-
-    val outputs = data.zipWithIndex.map { case (DataDescription(veType, isKey), idx) =>
-      veType.makeCVector(s"output_${isKey.renderValue}_$idx")
-    }
-
-    val arguments = inputs.map(PointerPointer(_)) ++
-      List(CFunctionArgument.Raw("int* sets")) ++
-      outputs.map(PointerPointer(_))
-
-    CFunction2(
-      arguments = arguments,
-      body = CodeLines.from(
-        // Compute the bucket assignments
-        computeBuckets(
-          cVectors = data.zip(inputs).filter(_._1.keyOrValue.isKey).map(_._2),
-          groupingIdentifiers = "bucket_assignments",
-          totalBuckets = totalBuckets
-        ),
-        "",
-        // Compute the bucket sizes
-        computeBucketSizes(
-          groupingIdentifiers = "bucket_assignments",
-          bucketToCount = "bucket_counts",
-          totalBuckets = totalBuckets
-        ),
-        "",
+  def render: CFunction2 = {
+    val body = if (keycols.isEmpty) {
+      CodeLines.from(
         "// Write out the number of buckets",
-        s"sets[0] = ${totalBuckets};",
+        s"sets[0] = 1;",
         "",
-        // Copy the elements to their respective buckets
-        (outputs, inputs).zipped.map(
-          copyVecToBucketsStmt(_, _, totalBuckets, "bucket_assignments", "bucket_counts")
-        )
+        (outputs, inputs).zipped.map(cloneCVecStmt(_, _))
       )
-    )
+
+    } else {
+      CodeLines.from(
+        computeBucketAssignments,
+        computeBucketCounts,
+        "// Write out the number of buckets",
+        s"sets[0] = ${nbuckets};",
+        "",
+        (outputs, inputs).zipped.map(copyVecToBucketsStmt(_, _))
+      )
+    }
+
+    CFunction2(arguments, body)
+  }
+
+  def toCodeLines: CodeLines = {
+    render.toCodeLines(name)
   }
 }

--- a/src/main/scala/com/nec/ve/MergerFunction.scala
+++ b/src/main/scala/com/nec/ve/MergerFunction.scala
@@ -19,8 +19,9 @@ object MergerFunction {
 
           NOTE: This cast is incorrect, because we are allocating a T* array
           (T**) but type-casting it to T*.  However, for some reason, fixing
-          this will lead an invalid free() later on.  Will need to investigate
-          and fix this in the future.
+          this will lead an invalid free() later on - this is likely due to an
+          error in how we define function call from the Spark side.  Will need
+          to investigate and fix this in the future.
         */
         s"// Allocate T*[] but cast to T* (incorrect but required to work correctly until a fix lands)",
         s"*${out} = static_cast<${vetype.cVectorType}*>(malloc(sizeof(nullptr)));",

--- a/src/main/scala/com/nec/ve/MergerFunction.scala
+++ b/src/main/scala/com/nec/ve/MergerFunction.scala
@@ -32,7 +32,7 @@ object MergerFunction {
           "auto o = 0;",
           CodeLines.forLoop("b", "batches") {
             CodeLines.forLoop("i", s"${in}[b]->count") {
-              s"set_validity(${tmp}->validityBuffer, o++, check_valid(${in}[b]->validityBuffer, i));"
+              s"${tmp}->set_validity(o++, ${in}[b]->get_validity(i));"
             }
           }
         )
@@ -52,7 +52,7 @@ object MergerFunction {
                 // Copy value over
                 s"${tmp}->data[o] = ${in}[b]->data[i];",
                 // Preserve validity bits across merges
-                s"set_validity(${tmp}->validityBuffer, o++, check_valid(${in}[b]->validityBuffer, i));"
+                s"${tmp}->set_validity(o++, ${in}[b]->get_validity(i));"
               )
             }
           }

--- a/src/main/scala/com/nec/ve/MergerFunction.scala
+++ b/src/main/scala/com/nec/ve/MergerFunction.scala
@@ -12,63 +12,20 @@ object MergerFunction {
     val out = s"output_${index}_g"
     val tmp = s"output_${index}"
 
-    val mergeStmt = vetype match {
-      case VeString =>
-        CodeLines.from(
-          // Declare std::vector<frovedis::words>
-          s"std::vector<frovedis::words> ${tmp}_multi_words(batches);",
-          // Loop over the batches
-          CodeLines.forLoop("b", "batches") {
-            // Copy each nullable_varchar_vector over
-            s"${tmp}_multi_words[b] = ${in}[b]->to_words();"
-          },
-          "",
-          // Perform merge using frovedis
-          s"frovedis::words ${tmp}_merged = frovedis::merge_multi_words(${tmp}_multi_words);",
-          // Convert back to nullable_varchar_vector
-          s"""new (${tmp}) nullable_varchar_vector(${tmp}_merged);""",
-          "",
-          // Initialize index counter
-          "auto o = 0;",
-          CodeLines.forLoop("b", "batches") {
-            CodeLines.forLoop("i", s"${in}[b]->count") {
-              s"${tmp}->set_validity(o++, ${in}[b]->get_validity(i));"
-            }
-          }
-        )
-
-      case scalar: VeScalarType =>
-        CodeLines.from(
-          // Initialize the mullable_T_vector
-          GroupByOutline.initializeScalarVector(scalar, tmp, "rows"),
-          "",
-          // Initialize index counter
-          "auto o = 0;",
-          // Loop over the batches
-          CodeLines.forLoop("b", "batches") {
-            // Loop over all values in each batch
-            CodeLines.forLoop("i", s"${in}[b]->count") {
-              List(
-                // Copy value over
-                s"${tmp}->data[o] = ${in}[b]->data[i];",
-                // Preserve validity bits across merges
-                s"${tmp}->set_validity(o++, ${in}[b]->get_validity(i));"
-              )
-            }
-          }
-        )
-    }
-
     CodeLines.scoped(s"Merge ${in}[...] into ${out}[0]") {
       CodeLines.from(
-        // Allocate the nullable_T_vector[]
+        /*
+          Allocate the nullable_T_vector[] with size buckets
+
+          NOTE: This cast is incorrect, because we are allocating a T* array
+          (T**) but type-casting it to T*.  However, for some reason, fixing
+          this will lead an invalid free() later on.  Will need to investigate
+          and fix this in the future.
+        */
+        s"// Allocate T*[] but cast to T* (incorrect but required to work correctly until a fix lands)",
         s"*${out} = static_cast<${vetype.cVectorType}*>(malloc(sizeof(nullptr)));",
-        // Allocate new mullable_T_vector
-        s"${out}[0] = static_cast<${vetype.cVectorType}*>(malloc(sizeof(${vetype.cVectorType})));",
-        // Set a temporary pointer
-        s"auto *${tmp} = ${out}[0];",
-        "",
-        mergeStmt
+        // Merge inputs and assign output to pointer
+        s"${out}[0] = ${vetype.cVectorType}::merge(${in}, batches);",
       )
     }
   }

--- a/src/test/scala/com/nec/cmake/eval/LongBigIntRetrieveSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/LongBigIntRetrieveSpec.scala
@@ -45,7 +45,7 @@ final class LongBigIntRetrieveSpec extends AnyFreeSpec {
               "v->data = static_cast<int64_t*>(malloc(v->count * sizeof(int64_t)));",
               "v->validityBuffer = static_cast<uint64_t*>(calloc(frovedis::ceil_div(size_t(v->count), size_t(64)), sizeof(uint64_t)));",
               "v->data[0] = 123;",
-              "set_validity(v->validityBuffer, 0, 1); ",
+              "v->set_validity(0, 1); ",
               "return 0;",
               """ }"""
             )

--- a/src/test/scala/com/nec/cmake/eval/RealExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/RealExpressionEvaluationSpec.scala
@@ -385,23 +385,23 @@ final class RealExpressionEvaluationSpec extends AnyFreeSpec {
       (
         TypedCExpression2(
           VeScalarType.veNullableDouble,
-          CExpression("input_0->data[i]", Some("check_valid(input_0->validityBuffer, i)"))
+          CExpression("input_0->data[i]", Some("input_0->get_validity(i)"))
         ),
         TypedCExpression2(
           VeScalarType.veNullableDouble,
-          CExpression("input_1->data[i]", Some("check_valid(input_1->validityBuffer, i)"))
+          CExpression("input_1->data[i]", Some("input_1->get_validity(i)"))
         )
       )
     )(
       (
         TypedGroupByExpression[Option[Double]](
           GroupByProjection(
-            CExpression("input_0->data[i]", Some("check_valid(input_0->validityBuffer, i)"))
+            CExpression("input_0->data[i]", Some("input_0->get_validity(i)"))
           )
         ),
         TypedGroupByExpression[Double](
           GroupByProjection(
-            CExpression("input_1->data[i] + 1", Some("check_valid(input_1->validityBuffer, i)"))
+            CExpression("input_1->data[i] + 1", Some("input_1->get_validity(i)"))
           )
         ),
         TypedGroupByExpression[Option[Double]](
@@ -410,7 +410,7 @@ final class RealExpressionEvaluationSpec extends AnyFreeSpec {
               CExpression(
                 "input_2->data[i] - input_0->data[i]",
                 Some(
-                  "check_valid(input_0->validityBuffer, i) && check_valid(input_2->validityBuffer, i)"
+                  "input_0->get_validity(i) && input_2->get_validity(i)"
                 )
               )
             )

--- a/src/test/scala/com/nec/cmake/eval/SparkToVeAggregatorSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/SparkToVeAggregatorSpec.scala
@@ -100,13 +100,13 @@ final class SparkToVeAggregatorSpec extends AnyFreeSpec {
           CExpression(
             "((output_attr_sum_nullable) + (input_attr_sum->data[i]))",
             Some(
-              "(output_attr_sum_nullable_is_set && check_valid(input_attr_sum->validityBuffer, i))"
+              "(output_attr_sum_nullable_is_set && input_attr_sum->get_validity(i))"
             )
           ),
           CExpression(
             "((output_attr_count_nullable) + (input_attr_count->data[i]))",
             Some(
-              "(output_attr_count_nullable_is_set && check_valid(input_attr_count->validityBuffer, i))"
+              "(output_attr_count_nullable_is_set && input_attr_count->get_validity(i))"
             )
           )
         )

--- a/src/test/scala/com/nec/ve/ArrowTransferCheck.scala
+++ b/src/test/scala/com/nec/ve/ArrowTransferCheck.scala
@@ -6,8 +6,6 @@ import com.nec.arrow.WithTestAllocator
 import com.nec.spark.agile.CFunctionGeneration.VeScalarType.VeNullableDouble
 import com.nec.spark.agile.CFunctionGeneration.{VeScalarType, VeString}
 import com.nec.util.RichVectors.{RichFloat8, RichVarCharVector}
-import com.nec.ve.GroupingFunction.DataDescription
-import com.nec.ve.GroupingFunction.DataDescription.KeyOrValue
 import com.nec.ve.PureVeFunctions.{DoublingFunction, PartitioningFunction}
 import com.nec.ve.VeColBatch.{VeBatchOfBatches, VeColVector}
 import com.nec.ve.VeProcess.OriginalCallingContext
@@ -129,18 +127,17 @@ final class ArrowTransferCheck extends AnyFreeSpec with WithVeProcess with VeKer
   }
 
   "Partition data by some means (simple Int partitioning in this case) (PIN)" in {
-    compiledWithHeaders(
-      GroupingFunction
-        .groupData(
-          data = List(
-            DataDescription(VeScalarType.VeNullableDouble, KeyOrValue.Key),
-            DataDescription(VeString, KeyOrValue.Key),
-            DataDescription(VeScalarType.VeNullableDouble, KeyOrValue.Value)
-          ),
-          totalBuckets = 2
-        ),
-      "f"
-    ) { path =>
+    val function = GroupingFunction(
+      "f",
+      List(
+        GroupingFunction.DataDescription(VeScalarType.VeNullableDouble, GroupingFunction.Key),
+        GroupingFunction.DataDescription(VeString, GroupingFunction.Key),
+        GroupingFunction.DataDescription(VeScalarType.VeNullableDouble, GroupingFunction.Value)
+      ),
+      2
+    )
+
+    compiledWithHeaders(function.render, function.name) { path =>
       val lib = veProcess.loadLibrary(path)
       WithTestAllocator { implicit alloc =>
         withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>

--- a/src/test/scala/com/nec/ve/PureVeFunctions.scala
+++ b/src/test/scala/com/nec/ve/PureVeFunctions.scala
@@ -17,7 +17,7 @@ object PureVeFunctions {
             GroupByOutline.initializeScalarVector(VeScalarType.VeNullableDouble, "o", "input[0]->count"),
             "for ( int i = 0; i < input[0]->count; i++ ) {",
             CodeLines
-              .from("o->data[i] = input[0]->data[i] * 2;", "set_validity(o->validityBuffer, i, 1);")
+              .from("o->data[i] = input[0]->data[i] * 2;", "o->set_validity(i, 1);")
               .indented,
             "}"
           )


### PR DESCRIPTION
Summary:

1. Updated the C++ code generation to use `get_validity()` and `set_validity()` member functions instead of their non-member function variants.  This paves the way for encapsulating operations on `nullable_T_vector`s, so that the C++ code generation can be simplified.
2. Move the `merge` implementation to C++ for the `nullable_T_vector` types.
3. Simplified the `MergerFunction` to use the native C++ implementation for `merge` instead of generating code
4. Fix the hash generation/bucketing inside `GroupingFunction` and simplified its associated C++ code generation
5. Reformat `GroupingFunction` as a case class instead of as a singleton method so that we can eventually work with higher level abstractions.

Generated code for `MergerFunction` has been simplified from [this example](https://gist.github.com/q10/2cf4bad04f090758ba29f347bcffb844) to [this example](https://gist.github.com/q10/66a25d41976eb716af0949f6345c34ad).

Example code for the fixed hash generation / bucketing code for `GroupingFunction` can be found [here](https://gist.github.com/q10/53fe9cb35f4b636a6979bf5a77e8134b).