### PR TITLE
Run benchmark multiple times, output average time.

### DIFF
--- a/tests/tpchbench/run_ve.sh
+++ b/tests/tpchbench/run_ve.sh
@@ -7,6 +7,7 @@ time $SPARK_HOME/bin/spark-submit \
     --num-executors=8 --executor-cores=1 --executor-memory=8G \
     --deploy-mode cluster \
     --name TPC-H_VE_$1 \
+    --conf spark.sql.codegen.wholeStage=false \
     --conf spark.com.nec.spark.ncc.path=/opt/nec/ve/bin/ncc \
     --jars /opt/cyclone/spark-cyclone-sql-plugin.jar \
     --conf spark.executor.extraClassPath=/opt/cyclone/spark-cyclone-sql-plugin.jar \
@@ -20,5 +21,7 @@ time $SPARK_HOME/bin/spark-submit \
     --conf spark.com.nec.spark.sort-on-ve=false \
     --conf spark.com.nec.spark.filter-on-ve=false \
     --conf spark.com.nec.spark.project-on-ve=false \
+    --conf spark.com.nec.spark.exchange-on-ve=false \
+    --conf spark.com.nec.spark.join-on-ve=false \
     target/scala-2.12/tpchbench_2.12-0.0.1.jar \
     $1 $2


### PR DESCRIPTION
This will allow us to se the average run time of each query when the so file is cached.  (And also show us if our so file caching is not working right.)

