### PR TITLE
[cpp] Move sorting and hashing down to C++

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "cyclone/transfer-definitions.hpp"
+#include "cyclone/cyclone_sort.hpp"
 #include "cyclone/cyclone_utils.hpp"
 #include "frovedis/text/dict.hpp"
 #include "frovedis/text/words.hpp"

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_sort.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_sort.hpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 Xpress AI.
+ *
+ * This file is part of Spark Cyclone.
+ * See https://github.com/XpressAI/SparkCyclone for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#pragma once
+
+// Disable for nc++ for now because it is unable to compile this unit
+// Currently results in: `nc++: Internal Error: Unknown statement kind.`
+#ifndef __NEC__
+
+#include "frovedis/core/radix_sort.hpp"
+#include <tuple>
+#include <vector>
+
+namespace cyclone {
+  namespace {
+    template <std::size_t I, typename... Ts>
+    void sort_by_ith_element(const std::vector<std::tuple<Ts...>> &elements,
+                             std::vector<size_t> &sorted_indices) {
+      // Fetch the Ith type of the tuple
+      using Type = std::tuple_element_t<I, std::tuple<Ts...>>;
+
+      // Get all the Ith values from the vector of tuples
+      std::vector<Type> temp(elements.size());
+      for (auto i = 0; i < elements.size(); i++) {
+        temp[i] = std::get<I>(elements[sorted_indices[i]]);
+      }
+
+      // Sort the Ith values of the tuples
+      frovedis::radix_sort(temp, sorted_indices);
+
+      // Repeat the sort if needed
+      if constexpr (I > 0) {
+        sort_by_ith_element<I - 1, Ts...>(elements, sorted_indices);
+      }
+    }
+  }
+
+  template <typename... Ts>
+  std::vector<size_t> sort_tuples(const std::vector<std::tuple<Ts...>> &elements) {
+    // Initialize the sorted indices
+    std::vector<size_t> sorted_indices(elements.size());
+    for (auto i = 0; i < elements.size(); i++) {
+      sorted_indices[i] = i;
+    }
+
+    // Apply sort from the N-1th to 0th element of the tuples,
+    // which will update the sorted indices
+    sort_by_ith_element<sizeof...(Ts) - 1, Ts...>(elements, sorted_indices);
+
+    // Return the sorted indices
+    return sorted_indices;
+  }
+}
+
+#endif

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
@@ -49,21 +49,7 @@ namespace cyclone {
     return output;
   }
 
-  // Print out a tuple
-  template<typename Ch, typename Tr, typename T>
-  auto& operator<<(std::basic_ostream<Ch, Tr> &stream,
-                   std::vector<T> const &vec) {
-    std::basic_stringstream<Ch, Tr> tmp;
-    tmp << "[ ";
-    for (const auto &elem : vec) {
-      tmp << elem << ", ";
-    }
-    tmp.seekp(-2, tmp.cur);
-    tmp << " ]";
-    return stream << tmp.str();
-  }
-
-  // Print out a tuple
+  // Print out a std::tuple to ostream
   template<typename Ch, typename Tr, typename... Ts>
   auto& operator<<(std::basic_ostream<Ch, Tr> &stream,
                    std::tuple<Ts...> const &tup) {
@@ -76,6 +62,22 @@ namespace cyclone {
     );
     tmp.seekp(-2, tmp.cur);
     tmp << ")";
+    return stream << tmp.str();
+  }
+
+  // Print out a std::vector to ostream
+  // Define this AFTER defining operator<< for std::tuple
+  // so that we can print std::vector<std::tuple<Ts...>>
+  template<typename Ch, typename Tr, typename T>
+  auto& operator<<(std::basic_ostream<Ch, Tr> &stream,
+                   std::vector<T> const &vec) {
+    std::basic_stringstream<Ch, Tr> tmp;
+    tmp << "[ ";
+    for (const auto &elem : vec) {
+      tmp << elem << ", ";
+    }
+    tmp.seekp(-2, tmp.cur);
+    tmp << " ]";
     return stream << tmp.str();
   }
 }

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
@@ -196,7 +196,7 @@ NullableScalarVec<T> * NullableScalarVec<T>::filter(const std::vector<size_t> &m
 
   // Preserve the validityBuffer across the filter
   #pragma _NEC vector
-  for (int o = 0; o < matching_ids.size(); o++) {
+  for (auto o = 0; o < matching_ids.size(); o++) {
     // Fetch the original index
     int i = matching_ids[o];
 
@@ -217,14 +217,14 @@ NullableScalarVec<T> ** NullableScalarVec<T>::bucket(const std::vector<size_t> &
   auto **output = static_cast<NullableScalarVec<T> **>(malloc(sizeof(T *) * bucket_counts.size()));
 
   // Loop over each bucket
-  for (int b = 0; b < bucket_counts.size(); b++) {
+  for (auto b = 0; b < bucket_counts.size(); b++) {
     // Generate the list of indexes where the bucket assignment is b
     std::vector<size_t> matching_ids(bucket_counts[b]);
     {
       // This loop will be vectorized on the VE as vector compress instruction (`vcp`)
       size_t pos = 0;
       #pragma _NEC vector
-      for (int i = 0; i < bucket_assignments.size(); i++) {
+      for (auto i = 0; i < bucket_assignments.size(); i++) {
         if (bucket_assignments[i] == b) {
           matching_ids[pos++] = i;
         }
@@ -244,7 +244,7 @@ NullableScalarVec<T> * NullableScalarVec<T>::merge(const NullableScalarVec<T> * 
   // Count the total number of elements
   size_t rows = 0;
   #pragma _NEC vector
-  for (int b = 0; b < batches; b++) {
+  for (auto b = 0; b < batches; b++) {
     rows += inputs[b]->count;
   }
 
@@ -259,8 +259,8 @@ NullableScalarVec<T> * NullableScalarVec<T>::merge(const NullableScalarVec<T> * 
   // Copy the data and preserve the validityBuffer across the merge
   auto o = 0;
   #pragma _NEC ivdep
-  for (int b = 0; b < batches; b++) {
-    for (int i = 0; i < inputs[b]->count; i++) {
+  for (auto b = 0; b < batches; b++) {
+    for (auto i = 0; i < inputs[b]->count; i++) {
       output->data[o] = inputs[b]->data[i];
       output->set_validity(o++, inputs[b]->get_validity(i));
     }

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -161,7 +161,7 @@ frovedis::words nullable_varchar_vector::to_words() const {
 
   // Set the starts
   output.starts.resize(count);
-  for (int i = 0; i < count; i++) {
+  for (auto i = 0; i < count; i++) {
     output.starts[i] = offsets[i];
   }
   // Set the chars
@@ -337,7 +337,7 @@ nullable_varchar_vector * nullable_varchar_vector::filter(const std::vector<size
 
   // Preserve the validityBuffer across the filter
   #pragma _NEC vector
-  for (int g = 0; g < matching_ids.size(); g++) {
+  for (auto g = 0; g < matching_ids.size(); g++) {
     // Fetch the original index
     int i = matching_ids[g];
 
@@ -354,14 +354,14 @@ nullable_varchar_vector ** nullable_varchar_vector::bucket(const std::vector<siz
   auto ** output = static_cast<nullable_varchar_vector **>(malloc(sizeof(nullable_varchar_vector *) * bucket_counts.size()));
 
   // Loop over each bucket
-  for (int b = 0; b < bucket_counts.size(); b++) {
+  for (auto b = 0; b < bucket_counts.size(); b++) {
     // Generate the list of indexes where the bucket assignment is b
     std::vector<size_t> matching_ids(bucket_counts[b]);
     {
       // This loop will be vectorized on the VE as vector compress instruction (`vcp`)
       size_t pos = 0;
       #pragma _NEC vector
-      for (int i = 0; i < bucket_assignments.size(); i++) {
+      for (auto i = 0; i < bucket_assignments.size(); i++) {
         if (bucket_assignments[i] == b) {
           matching_ids[pos++] = i;
         }
@@ -381,7 +381,7 @@ nullable_varchar_vector * nullable_varchar_vector::merge(const nullable_varchar_
   // Construct std::vector<frovedis::words> from the inputs
   std::vector<frovedis::words> multi_words(batches);
   #pragma _NEC vector
-  for (int b = 0; b < batches; b++) {
+  for (auto b = 0; b < batches; b++) {
     multi_words[b] = inputs[b]->to_words();
   }
 
@@ -391,8 +391,8 @@ nullable_varchar_vector * nullable_varchar_vector::merge(const nullable_varchar_
   // Preserve the validityBuffer across the merge
   auto o = 0;
   #pragma _NEC ivdep
-  for (int b = 0; b < batches; b++) {
-    for (int i = 0; i < inputs[b]->count; i++) {
+  for (auto b = 0; b < batches; b++) {
+    for (auto i = 0; i < inputs[b]->count; i++) {
       output->set_validity(o++, inputs[b]->get_validity(i));
     }
   }

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -375,6 +375,19 @@ nullable_varchar_vector ** nullable_varchar_vector::bucket(const std::vector<siz
   return output;
 }
 
+const std::vector<int64_t> nullable_varchar_vector::hash_vec() const {
+  // Allocate vec
+  std::vector<int64_t> output(count);
+
+  // Assign the hash of each string in the nullable_varchar_vector
+  #pragma _NEC vector
+  for (auto i = 0; i < count; i++) {
+    output[i] = hash_at(i, 1);
+  }
+
+  return output;
+}
+
 nullable_varchar_vector * nullable_varchar_vector::merge(const nullable_varchar_vector * const * const inputs,
                                                          const size_t batches) {
 

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
@@ -93,8 +93,8 @@ struct NullableScalarVec {
   void print() const;
 
   // Compute the hash of the value at a given index, starting with a given seed
-  inline int32_t hash_at(const size_t idx,
-                         const int32_t seed) const {
+  inline int64_t hash_at(const size_t idx,
+                         const int64_t seed) const {
     return 31 * seed + data[idx];
   }
 
@@ -188,13 +188,16 @@ struct nullable_varchar_vector {
   void print() const;
 
   // Compute the hash of the value at a given index, starting with a given seed
-  inline int32_t hash_at(const size_t idx,
-                         int32_t seed) const {
+  inline int64_t hash_at(const size_t idx,
+                         int64_t seed) const {
     for (int x = offsets[idx]; x < offsets[idx] + lengths[idx]; x++) {
       seed = 31 * seed + data[x];
     }
     return seed;
   }
+
+  // Compute a vector of hashes corresponding to the values of the nullable_varchar_vector
+  const std::vector<int64_t> hash_vec() const;
 
   // Set the validity value of the vector at the given index
   inline void set_validity(const size_t idx,

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
@@ -80,6 +80,7 @@ struct NullableScalarVec {
   // C pseudo-destructor (to be called before `free()` for object instances created by `malloc()`)
   void reset();
 
+  // Set the count to size, and allocate memory for data and validityBuffer
   void resize(const size_t size);
 
   // C implementation of a C++ move assignment

--- a/src/main/resources/com/nec/cyclone/cpp/examples.cpp
+++ b/src/main/resources/com/nec/cyclone/cpp/examples.cpp
@@ -22,6 +22,7 @@
 #include "frovedis/core/set_operations.hpp"
 #include "frovedis/core/utility.hpp"
 #include "frovedis/dataframe/join.hpp"
+#include <array>
 #include <bitset>
 #include <cmath>
 #include <iostream>
@@ -105,8 +106,6 @@ void projection_test() {
 }
 
 void test_sort() {
-  #ifndef __NEC__
-
   const std::vector<std::tuple<int32_t, float, int64_t, double>> elements {
     std::make_tuple(1, 2.106764f,   2ll, 2.029292l),
     std::make_tuple(0, 7.29214f,    3ll, 1.6248848l),
@@ -114,20 +113,31 @@ void test_sort() {
     std::make_tuple(2, 2.1760006f,  6ll, 7.483787l),
   };
 
-  const auto sorted_indices = sort_tuples(elements);
+  const auto sorted_indices = sort_tuples(elements, std::array<int, 4> {{ 1, 1, 1, 1 }});
 
   std::cout << "================================================================================" << std::endl;
   std::cout << "SORT TEST\n" << std::endl;
   std::cout << sorted_indices << std::endl;
   std::cout << "================================================================================" << std::endl;
 
-  #endif
-
   return;
+}
+
+constexpr std::array<int, 3> example1 {{ 42, 55, 67 }};
+
+template<size_t N, const std::array<int, N> &arr>
+void print_array() {
+  for (auto i = 0; i < N; i++) {
+    std::cout << arr[i] << std::endl;
+  }
 }
 
 int main() {
   projection_test();
   filter_test();
   test_sort();
+
+  print_array<3, example1>();
+  static constexpr std::array<int, 3> example2 {{ 100, 99, 98 }};
+  print_array<3, example2>();
 }

--- a/src/main/resources/com/nec/cyclone/cpp/examples.cpp
+++ b/src/main/resources/com/nec/cyclone/cpp/examples.cpp
@@ -18,8 +18,6 @@
  *
  */
 #include "cyclone/cyclone.hpp"
-#include "cyclone/transfer-definitions.hpp"
-#include "cyclone/tuple_hash.hpp"
 #include "frovedis/core/radix_sort.hpp"
 #include "frovedis/core/set_operations.hpp"
 #include "frovedis/core/utility.hpp"
@@ -30,6 +28,8 @@
 #include <string>
 #include <tuple>
 #include <vector>
+
+using namespace cyclone;
 
 nullable_varchar_vector * project_eval(const nullable_varchar_vector *input_0)  {
   auto output_0_input_words = input_0->to_words();
@@ -104,7 +104,28 @@ void projection_test() {
   return;
 }
 
+void test_sort() {
+  #ifndef __NEC__
+
+  const std::vector<std::tuple<int32_t, float, int64_t, double>> elements {
+    std::make_tuple(0, 7.29214f,    3ll, 9.850428l),
+    std::make_tuple(0, 5.1007037f,  2ll, 2.1967127l),
+  };
+
+  const auto sorted_indices = sort_tuples(elements);
+
+  std::cout << "================================================================================" << std::endl;
+  std::cout << "SORT TEST\n" << std::endl;
+  std::cout << sorted_indices << std::endl;
+  std::cout << "================================================================================" << std::endl;
+
+  #endif
+
+  return;
+}
+
 int main() {
   projection_test();
   filter_test();
+  test_sort();
 }

--- a/src/main/resources/com/nec/cyclone/cpp/examples.cpp
+++ b/src/main/resources/com/nec/cyclone/cpp/examples.cpp
@@ -108,8 +108,10 @@ void test_sort() {
   #ifndef __NEC__
 
   const std::vector<std::tuple<int32_t, float, int64_t, double>> elements {
-    std::make_tuple(0, 7.29214f,    3ll, 9.850428l),
-    std::make_tuple(0, 5.1007037f,  2ll, 2.1967127l),
+    std::make_tuple(1, 2.106764f,   2ll, 2.029292l),
+    std::make_tuple(0, 7.29214f,    3ll, 1.6248848l),
+    std::make_tuple(2, 4.0789514f,  3ll, 5.4606824l),
+    std::make_tuple(2, 2.1760006f,  6ll, 7.483787l),
   };
 
   const auto sorted_indices = sort_tuples(elements);

--- a/src/main/resources/com/nec/cyclone/cpp/tests/cyclone_sort_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/cyclone_sort_spec.hpp
@@ -19,9 +19,6 @@
  */
 #pragma once
 
-// Disable for nc++ for now
-#ifndef __NEC__
-
 #include "cyclone/cyclone.hpp"
 #include "tests/doctest.h"
 #include <tuple>
@@ -51,48 +48,70 @@ namespace cyclone::tests {
     std::make_tuple(0, 7.5230184f,  6ll, 2.865592l)
   };
 
-  TEST_CASE("Tuple sort works") {
-    // Manually sort the tuples by the N-1th, N-2th, ... 0th elements
-    std::vector<size_t> expected(elements.size());
-    {
-      for (int i = 0; i < elements.size(); i++) {
-        expected[i] = i;
+  TEST_SUITE("std::tuple sort") {
+    TEST_CASE("Tuple sort works") {
+      // Manually sort the tuples by the N-1th, N-2th, ... 0th elements
+      std::vector<size_t> expected(elements.size());
+      {
+        for (int i = 0; i < elements.size(); i++) {
+          expected[i] = i;
+        }
+
+        {
+          std::vector<double> temp(elements.size());
+          for (auto i = 0; i < elements.size(); i++) {
+            temp[i] = std::get<3>(elements[expected[i]]);
+          }
+          frovedis::radix_sort(temp, expected);
+        }
+        {
+          std::vector<int64_t> temp(elements.size());
+          for (auto i = 0; i < elements.size(); i++) {
+            temp[i] = std::get<2>(elements[expected[i]]);
+          }
+          frovedis::radix_sort(temp, expected);
+        }
+        {
+          std::vector<float> temp(elements.size());
+          for (auto i = 0; i < elements.size(); i++) {
+            temp[i] = std::get<1>(elements[expected[i]]);
+          }
+          frovedis::radix_sort(temp, expected);
+        }
+        {
+          std::vector<int32_t> temp(elements.size());
+          for (auto i = 0; i < elements.size(); i++) {
+            temp[i] = std::get<0>(elements[expected[i]]);
+          }
+          frovedis::radix_sort(temp, expected);
+        }
       }
 
-      {
-        std::vector<double> temp(elements.size());
-        for (auto i = 0; i < elements.size(); i++) {
-          temp[i] = std::get<3>(elements[expected[i]]);
-        }
-        frovedis::radix_sort(temp, expected);
-      }
-      {
-        std::vector<int64_t> temp(elements.size());
-        for (auto i = 0; i < elements.size(); i++) {
-          temp[i] = std::get<2>(elements[expected[i]]);
-        }
-        frovedis::radix_sort(temp, expected);
-      }
-      {
-        std::vector<float> temp(elements.size());
-        for (auto i = 0; i < elements.size(); i++) {
-          temp[i] = std::get<1>(elements[expected[i]]);
-        }
-        frovedis::radix_sort(temp, expected);
-      }
-      {
-        std::vector<int32_t> temp(elements.size());
-        for (auto i = 0; i < elements.size(); i++) {
-          temp[i] = std::get<0>(elements[expected[i]]);
-        }
-        frovedis::radix_sort(temp, expected);
-      }
+      // Perform the same sorting using template function generation
+      const auto sorted_indices1 = cyclone::sort_tuples(elements, std::array<int, 4> {{ 1, 1, 1, 1 }});
+      // Perform a different sorting, where the 0th elementh is sorted in DESC order
+      const auto sorted_indices2 = cyclone::sort_tuples(elements, std::array<int, 4> {{ 0, 1, 1, 1 }});
+
+      CHECK(sorted_indices1 == expected);
+      CHECK(sorted_indices2 != expected);
     }
 
-    // Perform the same sorting using template function generation
-    const auto sorted_indices = cyclone::sort_tuples(elements);
-    CHECK(sorted_indices == expected);
+    TEST_CASE("Tuple sort works for empty tuples") {
+      const std::vector<std::tuple<>> elements {
+        std::tuple<>(),
+        std::tuple<>(),
+        std::tuple<>()
+      };
+
+      std::vector<size_t> expected(elements.size());
+      {
+        for (int i = 0; i < elements.size(); i++) {
+          expected[i] = i;
+        }
+      }
+
+      const auto sorted_indices = cyclone::sort_tuples(elements, std::array<int, 0> {{ }});
+      CHECK(sorted_indices == expected);
+    }
   }
 }
-
-#endif

--- a/src/main/resources/com/nec/cyclone/cpp/tests/cyclone_sort_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/cyclone_sort_spec.hpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022 Xpress AI.
+ *
+ * This file is part of Spark Cyclone.
+ * See https://github.com/XpressAI/SparkCyclone for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#pragma once
+
+// Disable for nc++ for now
+#ifndef __NEC__
+
+#include "cyclone/cyclone.hpp"
+#include "tests/doctest.h"
+#include <tuple>
+#include <vector>
+
+namespace cyclone::tests {
+  const std::vector<std::tuple<int32_t, float, int64_t, double>> elements {
+    std::make_tuple(0, 7.29214f,    3ll, 9.850428l),
+    std::make_tuple(0, 5.1007037f,  2ll, 2.1967127l),
+    std::make_tuple(1, 2.106764f,   2ll, 2.029292l),
+    std::make_tuple(0, 7.29214f,    3ll, 1.6248848l),
+    std::make_tuple(2, 4.0789514f,  3ll, 5.4606824l),
+    std::make_tuple(2, 2.1760006f,  6ll, 7.483787l),
+    std::make_tuple(1, 4.6863422f,  3ll, 1.2526741l),
+    std::make_tuple(1, 7.768214f,   6ll, 5.3003526l),
+    std::make_tuple(2, 7.5028214f,  2ll, 9.859546l),
+    std::make_tuple(2, 3.648821f,   1ll, 3.5679564l),
+    std::make_tuple(1, 3.7641335f,  5ll, 0.024474824l),
+    std::make_tuple(2, 8.525803f,   7ll, 3.0891323l),
+    std::make_tuple(1, 2.5747693f,  4ll, 7.011116l),
+    std::make_tuple(2, 0.57439226f, 5ll, 7.136852l),
+    std::make_tuple(0, 2.5966463f,  2ll, 9.806966l),
+    std::make_tuple(0, 6.291629f,   0ll, 5.715928l),
+    std::make_tuple(1, 0.5641213f,  4ll, 0.5068447l),
+    std::make_tuple(0, 9.341458f,   4ll, 4.637736l),
+    std::make_tuple(0, 7.292144f,   3ll, 2.9226866l),
+    std::make_tuple(0, 7.5230184f,  6ll, 2.865592l)
+  };
+
+  TEST_CASE("Tuple sort works") {
+    // Manually loop-sorting the tuple elements
+    std::vector<size_t> expected(elements.size());
+    {
+      for (int i = 0; i < elements.size(); i++) {
+        expected[i] = i;
+      }
+
+      {
+        std::vector<double> temp(elements.size());
+        for (auto i = 0; i < elements.size(); i++) {
+          temp[i] = std::get<3>(elements[expected[i]]);
+        }
+        frovedis::radix_sort(temp, expected);
+      }
+      {
+        std::vector<int64_t> temp(elements.size());
+        for (auto i = 0; i < elements.size(); i++) {
+          temp[i] = std::get<2>(elements[expected[i]]);
+        }
+        frovedis::radix_sort(temp, expected);
+      }
+      {
+        std::vector<float> temp(elements.size());
+        for (auto i = 0; i < elements.size(); i++) {
+          temp[i] = std::get<1>(elements[expected[i]]);
+        }
+        frovedis::radix_sort(temp, expected);
+      }
+      {
+        std::vector<int32_t> temp(elements.size());
+        for (auto i = 0; i < elements.size(); i++) {
+          temp[i] = std::get<0>(elements[expected[i]]);
+        }
+        frovedis::radix_sort(temp, expected);
+      }
+    }
+
+    // Automatically generated sorting
+    const auto sorted_indices = cyclone::sort_tuples(elements);
+    CHECK(sorted_indices == expected);
+  }
+}
+
+#endif

--- a/src/main/resources/com/nec/cyclone/cpp/tests/cyclone_sort_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/cyclone_sort_spec.hpp
@@ -52,7 +52,7 @@ namespace cyclone::tests {
   };
 
   TEST_CASE("Tuple sort works") {
-    // Manually loop-sorting the tuple elements
+    // Manually sort the tuples by the N-1th, N-2th, ... 0th elements
     std::vector<size_t> expected(elements.size());
     {
       for (int i = 0; i < elements.size(); i++) {
@@ -89,7 +89,7 @@ namespace cyclone::tests {
       }
     }
 
-    // Automatically generated sorting
+    // Perform the same sorting using template function generation
     const auto sorted_indices = cyclone::sort_tuples(elements);
     CHECK(sorted_indices == expected);
   }

--- a/src/main/resources/com/nec/cyclone/cpp/tests/driver.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/driver.cc
@@ -22,6 +22,7 @@
 
 // Include all the specs to be run
 #include "tests/example_spec.hpp"
+#include "tests/cyclone_sort_spec.hpp"
 #include "tests/cyclone_utils_spec.hpp"
 #include "tests/nullable_scalar_vector_spec.hpp"
 #include "tests/nullable_varchar_vector_spec.hpp"

--- a/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.hpp
@@ -116,8 +116,23 @@ namespace cyclone::tests {
     TEST_CASE("Hash value works") {
       auto *input = new nullable_varchar_vector(std::vector<std::string> { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "", "OCT", "NOV", "DEC" });
 
-      const auto output = input->hash_at(3, 42);
-      CHECK(output == 31 * (31 * (31 * 42 + 'A') + 'P') + 'R');
+      const auto seed = 42;
+      const auto output = input->hash_at(3, seed);
+      CHECK(output == 31 * (31 * (31 * seed + 'A') + 'P') + 'R');
+    }
+
+    TEST_CASE("Hash vector generation works") {
+      auto *input = new nullable_varchar_vector(std::vector<std::string> { "JAN", "FEB", "MAR" });
+
+      const auto seed = 1;
+      std::vector<int64_t> expected {
+        31 * (31 * (31 * seed + 'J') + 'A') + 'N',
+        31 * (31 * (31 * seed + 'F') + 'E') + 'B',
+        31 * (31 * (31 * seed + 'M') + 'A') + 'R'
+      };
+
+      const auto output = input->hash_vec();
+      CHECK(output == expected);
     }
 
     TEST_CASE("Get and Set validity bit works") {

--- a/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
+++ b/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
@@ -438,7 +438,6 @@ object CFunctionGeneration {
     }
 
   val KeyHeaders = CodeLines.from(
-    """#include "cyclone/transfer-definitions.hpp"""",
     """#include "cyclone/cyclone.hpp"""",
     """#include "cyclone/tuple_hash.hpp"""",
     "#include <bitset>",
@@ -459,7 +458,6 @@ object CFunctionGeneration {
   ) {
     def toCodeLinesSPtr(functionName: String): CodeLines = CodeLines.from(
       """#include "cyclone/cyclone.hpp"""",
-      """#include "cyclone/transfer-definitions.hpp"""",
       """#include "cyclone/tuple_hash.hpp"""",
       """#include "frovedis/core/radix_sort.hpp"""",
       """#include "frovedis/core/set_operations.hpp"""",
@@ -477,7 +475,6 @@ object CFunctionGeneration {
 
     def toCodeLinesS(functionName: String): CodeLines = CodeLines.from(
       """#include "cyclone/cyclone.hpp"""",
-      """#include "cyclone/transfer-definitions.hpp"""",
       """#include "cyclone/tuple_hash.hpp"""",
       """#include "frovedis/core/radix_sort.hpp"""",
       """#include "frovedis/core/set_operations.hpp"""",
@@ -497,7 +494,6 @@ object CFunctionGeneration {
     def toCodeLinesPF(functionName: String): CodeLines = {
       CodeLines.from(
         """#include "cyclone/cyclone.hpp"""",
-        """#include "cyclone/transfer-definitions.hpp"""",
         """#include "frovedis/text/dict.hpp"""",
         "#include <bitset>",
         "#include <string>",
@@ -510,7 +506,6 @@ object CFunctionGeneration {
     def toCodeLinesG(functionName: String): CodeLines = {
       CodeLines.from(
         """#include "cyclone/cyclone.hpp"""",
-        """#include "cyclone/transfer-definitions.hpp"""",
         """#include "cyclone/tuple_hash.hpp"""",
         """#include "frovedis/text/datetime_utility.hpp"""",
         """#include "frovedis/text/dict.hpp"""",

--- a/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
+++ b/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
@@ -652,7 +652,7 @@ object CFunctionGeneration {
               CodeLines.forLoop("i", "input_0->count") {
                 s"temp[i] = std::get<${idx}>(sorting_vec[idx[i]]);"
               },
-              s"${sortFn}(temp.data(), idx.data(), temp.size());"
+              s"${sortFn}(temp, idx);"
             )
           }
         },

--- a/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
+++ b/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
@@ -603,16 +603,25 @@ object CFunctionGeneration {
     val sortOutput = sort.data.map { case CScalarVector(name, veType) =>
       CScalarVector(name.replaceAllLiterally("input", "output"), veType)
     }
-    val sortingTypes = sort.sorts
-      .flatMap(sortExpression =>
-        List(
-          (sortExpression.typedExpression.veType.cScalarType, sortExpression.sortOrdering),
-          ("int", sortExpression.sortOrdering)
-        )
+    val sortingTypes = sort.sorts.flatMap { sortExpression =>
+      List(
+        (sortExpression.typedExpression.veType.cScalarType, sortExpression.sortOrdering),
+        ("int", sortExpression.sortOrdering)
       )
-    val sortingTuple = sort.sorts
-      .flatMap(veScalar => List(veScalar.typedExpression.veType.cScalarType, "int"))
-      .mkString("std::tuple<", ", ", ">")
+    }
+
+    val sortingTuple = sort.sorts.flatMap { veScalar =>
+      List(veScalar.typedExpression.veType.cScalarType, "int")
+    }.mkString("std::tuple<", ", ", ">")
+
+    val sortOrder = sortingTypes.map { case (_, order) =>
+        order match {
+          case Ascending => 1
+          case Descending => 0
+        }
+      }
+      .mkString(s"std::array<int, ${sortingTypes.size}> {{ ", ", ", " }}")
+
     CFunction(
       inputs = sort.data,
       outputs = sortOutput,
@@ -635,22 +644,8 @@ object CFunctionGeneration {
           }
           .mkString("(", ",", ")")};",
         "}",
-        sortingTypes.zipWithIndex.reverse.map { case ((dataType, order), idx) =>
-          CodeLines.scoped(s"Sort by element ${idx} of the tuple") {
-            val sortFn = order match {
-              case Ascending  => "frovedis::radix_sort"
-              case Descending => "frovedis::radix_sort_desc"
-            }
-
-            CodeLines.from(
-              s"std::vector<${dataType}> temp(input_0->count);",
-              CodeLines.forLoop("i", "input_0->count") {
-                s"temp[i] = std::get<${idx}>(sorting_vec[idx[i]]);"
-              },
-              s"${sortFn}(temp, idx);"
-            )
-          }
-        },
+        s"idx = cyclone::sort_tuples(sorting_vec, ${sortOrder});",
+        "",
         "// prevent deallocation of input vector -- it is deallocated by the caller",
         s"for(int i = 0; i < input_0->count; i++) {",
         sort.data.zip(sortOutput).map {

--- a/src/main/scala/com/nec/spark/agile/CppResource.scala
+++ b/src/main/scala/com/nec/spark/agile/CppResource.scala
@@ -69,6 +69,7 @@ object CppResource {
     "frovedis/text/words.hpp",
     "cyclone/cyclone.cc",
     "cyclone/cyclone.hpp",
+    "cyclone/cyclone_sort.hpp",
     "cyclone/cyclone_utils.hpp",
     "cyclone/nullable_scalar_vector.cc",
     "cyclone/nullable_varchar_vector.cc",

--- a/src/main/scala/com/nec/ve/GroupingFunction.scala
+++ b/src/main/scala/com/nec/ve/GroupingFunction.scala
@@ -60,7 +60,7 @@ case class GroupingFunction(name: String,
           CodeLines.forLoop("i", s"${keycols.head.name}[0]->count") {
             CodeLines.from(
               // Initialize the hash
-              s"int hash = 1;",
+              s"int64_t hash = 1;",
               // Compute the hash across all keys
               keycols.map { vec => s"hash = ${vec.name}[0]->hash_at(i, hash);" },
               // Assign the bucket based on the hash

--- a/src/test/scala/com/nec/cmake/eval/LongBigIntRetrieveSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/LongBigIntRetrieveSpec.scala
@@ -34,7 +34,6 @@ final class LongBigIntRetrieveSpec extends AnyFreeSpec {
 
       val cLib = CMakeBuilder.buildC(
         List(
-          """#include "cyclone/transfer-definitions.hpp"""",
           """#include "cyclone/cyclone.hpp"""",
           """#include <math.h>""",
           "\n\n",

--- a/src/test/scala/com/nec/cmake/eval/RealExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/cmake/eval/RealExpressionEvaluationSpec.scala
@@ -1114,7 +1114,6 @@ object RealExpressionEvaluationSpec extends LazyLogging {
 
     val generatedSource = CodeLines.from(
       """#include "cyclone/cyclone.hpp"""",
-      """#include "cyclone/transfer-definitions.hpp"""",
       filterFn.toCodeLines
     )
 


### PR DESCRIPTION
Summary:

- Move generic tuple sort to the C++ level using variadic templates and template function recursion
- Update the existing nullable_T_vector `hash_at()` functions to use `int64_t`
- Implement `hash_vec()` for nullable_varchar_vector to get a vector of hash values for each value in the vector
- Implement the new C++ code into the grouping routines