### PR TITLE
Add VEHints to enable/disable options per-query.

### DIFF
--- a/src/main/scala/com/nec/spark/LocalVeoExtension.scala
+++ b/src/main/scala/com/nec/spark/LocalVeoExtension.scala
@@ -20,16 +20,15 @@
 package com.nec.spark
 
 import com.nec.spark.LocalVeoExtension.compilerRule
-import com.nec.spark.planning.{
-  CombinedCompilationColumnarRule,
-  ParallelCompilationColumnarRule,
-  VERewriteStrategy,
-  VeColumnarRule,
-  VeRewriteStrategyOptions
-}
+import com.nec.spark.planning.hints._
+import com.nec.spark.planning.{CombinedCompilationColumnarRule, VERewriteStrategy, VeColumnarRule, VeRewriteStrategyOptions}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnresolvedHint}
+import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.ColumnarRule
+import org.apache.spark.sql.types.BooleanType
 import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
 
 object LocalVeoExtension extends LazyLogging {
@@ -49,5 +48,27 @@ final class LocalVeoExtension extends (SparkSessionExtensions => Unit) with Logg
     })
     sparkSessionExtensions.injectColumnar(compilerRule)
     sparkSessionExtensions.injectColumnar(_ => new VeColumnarRule)
+
+    class MyRule extends Rule[LogicalPlan] {
+      override def apply(plan: LogicalPlan): LogicalPlan = {
+        plan.resolveOperatorsUp { case (h: UnresolvedHint) =>
+          (h.name, h.parameters) match {
+            case ("SORT_ON_VE", Seq(Literal(bool: Boolean, BooleanType))) => SortOnVe(h.child, bool)
+            case ("PROJECT_ON_VE", Seq(Literal(bool: Boolean, BooleanType))) => ProjectOnVe(h.child, bool)
+            case ("FILTER_ON_VE", Seq(Literal(bool: Boolean, BooleanType)))=> FilterOnVe(h.child, bool)
+            case ("AGGREGATE_ON_VE", Seq(Literal(bool: Boolean, BooleanType)))=> AggregateOnVe(h.child, bool)
+            case ("EXCHANGE_ON_VE", Seq(Literal(bool: Boolean, BooleanType)))=> ExchangeOnVe(h.child, bool)
+            case ("FAIL_FAST", Seq(Literal(bool: Boolean, BooleanType)))=> FailFast(h.child, bool)
+            case ("JOIN_ON_VE", Seq(Literal(bool: Boolean, BooleanType)))=> JoinOnVe(h.child, bool)
+            case ("AMPLIFY_BATCHES", Seq(Literal(bool: Boolean, BooleanType)))=> AmplifyBatches(h.child, bool)
+            case ("SKIP_VE", Seq(Literal(bool: Boolean, BooleanType)))=> SkipVe(h.child, bool)
+          }
+        }
+      }
+    }
+
+    sparkSessionExtensions.injectPostHocResolutionRule(sparkSession => {
+      new MyRule()
+    })
   }
 }

--- a/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
+++ b/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
@@ -11,7 +11,8 @@ final case class VeRewriteStrategyOptions(
   passThroughProject: Boolean,
   failFast: Boolean,
   joinOnVe: Boolean,
-  amplifyBatches: Boolean
+  amplifyBatches: Boolean,
+  rewriteEnabled: Boolean
 )
 
 object VeRewriteStrategyOptions {
@@ -55,7 +56,11 @@ object VeRewriteStrategyOptions {
       amplifyBatches = sparkConf
         .getOption(key = "spark.com.nec.spark.amplify-batches")
         .map(_.toBoolean)
-        .getOrElse(default.amplifyBatches)
+        .getOrElse(default.amplifyBatches),
+      rewriteEnabled = sparkConf
+        .getOption(key = "spark.com.nec.spark.rewrite-enabled")
+        .map(_.toBoolean)
+        .getOrElse(default.rewriteEnabled)
     )
   }
 
@@ -70,6 +75,7 @@ object VeRewriteStrategyOptions {
       passThroughProject = false,
       failFast = false,
       joinOnVe = false,
-      amplifyBatches = true
+      amplifyBatches = true,
+      rewriteEnabled = true
     )
 }

--- a/src/main/scala/com/nec/spark/planning/hints/VeHint.scala
+++ b/src/main/scala/com/nec/spark/planning/hints/VeHint.scala
@@ -1,0 +1,18 @@
+package com.nec.spark.planning.hints
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
+
+sealed abstract class VeHint(child: LogicalPlan) extends UnaryNode {
+  override def output: Seq[Attribute] = child.output
+}
+
+case class SortOnVe(child: LogicalPlan, enabled: Boolean) extends VeHint(child)
+case class ProjectOnVe(child: LogicalPlan, enabled: Boolean) extends VeHint(child)
+case class FilterOnVe(child: LogicalPlan, enabled: Boolean) extends VeHint(child)
+case class AggregateOnVe(child: LogicalPlan, enabled: Boolean) extends VeHint(child)
+case class ExchangeOnVe(child: LogicalPlan, enabled: Boolean) extends VeHint(child)
+case class FailFast(child: LogicalPlan, enabled: Boolean) extends VeHint(child)
+case class JoinOnVe(child: LogicalPlan, enabled: Boolean) extends VeHint(child)
+case class AmplifyBatches(child: LogicalPlan, enabled: Boolean) extends VeHint(child)
+case class SkipVe(child: LogicalPlan, enabled: Boolean) extends VeHint(child)

--- a/src/test/scala/com/nec/cmake/DynamicCSqlExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/cmake/DynamicCSqlExpressionEvaluationSpec.scala
@@ -20,27 +20,21 @@
 package com.nec.cmake
 
 import com.eed3si9n.expecty.Expecty.expect
-import com.nec.native.NativeEvaluator.CNativeEvaluator
 import com.nec.spark.SparkAdditions
 import com.nec.spark.SparkCycloneExecutorPlugin.CloseAutomatically
-import com.nec.spark.planning.VERewriteStrategy
+import com.nec.spark.planning.plans.OneStageEvaluationPlan
 import com.nec.testing.SampleSource
-import com.nec.testing.SampleSource.{SampleColA, SampleColB, SampleColC, SampleColD, makeCsvNumsMultiColumn, makeCsvNumsMultiColumnJoin}
+import com.nec.testing.SampleSource._
 import com.nec.testing.Testing.DataSize.SanityCheckSize
 import com.typesafe.scalalogging.LazyLogging
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import org.apache.spark.sql.{Dataset, SparkSession}
+import org.scalactic.{Prettifier, source}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-import org.apache.spark.sql.internal.SQLConf.CODEGEN_FALLBACK
-import org.apache.spark.sql.{Dataset, SparkSession}
-import org.scalactic.{Prettifier, source}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import java.time.Instant
-import java.time.temporal.TemporalUnit
-import scala.math.Ordered.orderingToOrdered
-import com.nec.spark.planning.VeColumnarRule
-import com.nec.spark.planning.plans.OneStageEvaluationPlan
 
 abstract class DynamicCSqlExpressionEvaluationSpec
   extends AnyFreeSpec
@@ -974,6 +968,15 @@ abstract class DynamicCSqlExpressionEvaluationSpec
       s"select max(b) from values (1, timestamp '${a}'), (2, timestamp '${b}'), (3, timestamp '${c}') as tab1(a, b)"
     sparkSession.sql(sql).debugSqlHere { ds =>
       assert(ds.as[Instant].collect().toList == List(c))
+    }
+  }
+
+  s"VE-Hints are supported" in withSparkSession2(configuration) { sparkSession =>
+    import sparkSession.implicits._
+    val sql =
+      s"select /*+ COALESCE(1),SORT_ON_VE(true) */ max(a) from values (1), (2), (3) as tab1(a)"
+    sparkSession.sql(sql).debugSqlHere { ds =>
+      assert(ds.as[Int].collect().toList == List(3))
     }
   }
 


### PR DESCRIPTION
Allows you to add Spark SQL hints that allow you to control the *on-ve configuration options on a per-query basis.

I.E.

```
      select /*+ SORT_ON_VE(true) */ max(a) from values (1), (2), (3) as tab1(a)

```

https://github.com/XpressAI/SparkCyclone/blob/495901bf7ba1a3200ea2e41d63b724921a6096da/src/main/scala/com/nec/spark/LocalVeoExtension.scala#L56-L64