### PR TITLE
Remove redundant Spark-VE-Spark and VE-Spark-VE conversions.

### DIFF
--- a/src/main/scala/com/nec/spark/LocalVeoExtension.scala
+++ b/src/main/scala/com/nec/spark/LocalVeoExtension.scala
@@ -21,6 +21,7 @@ package com.nec.spark
 
 import com.nec.spark.LocalVeoExtension.compilerRule
 import com.nec.spark.planning.hints._
+import com.nec.spark.planning.plans.{SparkToVectorEnginePlan, VectorEngineToSparkPlan}
 import com.nec.spark.planning.{CombinedCompilationColumnarRule, VERewriteStrategy, VeColumnarRule, VeRewriteStrategyOptions}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.internal.Logging
@@ -69,6 +70,19 @@ final class LocalVeoExtension extends (SparkSessionExtensions => Unit) with Logg
 
     sparkSessionExtensions.injectPostHocResolutionRule(sparkSession => {
       new MyRule()
+    })
+
+    sparkSessionExtensions.injectQueryStagePrepRule(_ => {
+      plan => {
+        plan transform {
+          case VectorEngineToSparkPlan(SparkToVectorEnginePlan(child)) => {
+            child
+          }
+          case SparkToVectorEnginePlan(VectorEngineToSparkPlan(child)) => {
+            child
+          }
+        }
+      }
     })
   }
 }


### PR DESCRIPTION
Some queries like 2, or 5 could have a lot of these redundant conversions if the right options are used.

![image](https://user-images.githubusercontent.com/122480/155848207-79dcd477-d401-42c1-8795-0a88c92debff.png)
