### PR TITLE
Refactor VERewriteStrategy

### DIFF
--- a/src/main/scala/com/nec/spark/LocalVeoExtension.scala
+++ b/src/main/scala/com/nec/spark/LocalVeoExtension.scala
@@ -49,7 +49,7 @@ final class LocalVeoExtension extends (SparkSessionExtensions => Unit) with Logg
     sparkSessionExtensions.injectColumnar(compilerRule)
     sparkSessionExtensions.injectColumnar(_ => new VeColumnarRule)
 
-    class MyRule extends Rule[LogicalPlan] {
+    class VeHintResolutionRule extends Rule[LogicalPlan] {
       override def apply(plan: LogicalPlan): LogicalPlan = {
         plan.resolveOperatorsUp { case (h: UnresolvedHint) =>
           (h.name, h.parameters) match {
@@ -68,7 +68,7 @@ final class LocalVeoExtension extends (SparkSessionExtensions => Unit) with Logg
     }
 
     sparkSessionExtensions.injectPostHocResolutionRule(sparkSession => {
-      new MyRule()
+      new VeHintResolutionRule()
     })
   }
 }

--- a/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
+++ b/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
@@ -546,7 +546,7 @@ final case class VERewriteStrategy(options: VeRewriteStrategyOptions)
       val filterFn = FilterFunction(
         s"filter_${functionPrefix}",
         VeFilter(
-          stringVectorComputations = StringHole.process(condition.transform(replacer)).flatMap(_.stringParts).toList.distinct,
+          stringVectorComputations = StringHole.process(condition.transform(replacer)).toList.flatMap(_.stringParts).distinct,
           data = data,
           condition = cond
         )

--- a/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
+++ b/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
@@ -26,7 +26,7 @@ import com.nec.spark.agile.SparkExpressionToCExpression._
 import com.nec.spark.agile.groupby.ConvertNamedExpression.{computeAggregate, mapGroupingExpression}
 import com.nec.spark.agile.groupby.GroupByOutline.GroupingKey
 import com.nec.spark.agile.groupby.{ConvertNamedExpression, GroupByOutline, GroupByPartialGenerator, GroupByPartialToFinalGenerator}
-import com.nec.spark.agile.join.JoinMatcher
+import com.nec.spark.agile.join.{GenericJoiner, JoinMatcher}
 import com.nec.spark.agile.{CFunctionGeneration, SparkExpressionToCExpression, StringHole}
 import com.nec.spark.planning.TransformUtil.RichTreeNode
 import com.nec.spark.planning.VERewriteStrategy.{GroupPrefix, HashExchangeBuckets, InputPrefix, SequenceList}
@@ -39,15 +39,13 @@ import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, HyperLogLogPlusPlus}
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, NamedExpression, SortOrder}
 import org.apache.spark.sql.catalyst.plans.logical
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Sort}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Sort}
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.execution.exchange.{REPARTITION, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.{FilterExec, SparkPlan}
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.{SparkSession, Strategy}
-
-import scala.collection.immutable
 
 object VERewriteStrategy {
   implicit class SequenceList[A, B](l: List[Either[A, B]]) {
@@ -70,14 +68,9 @@ final case class VERewriteStrategy(options: VeRewriteStrategyOptions)
 
   import com.github.ghik.silencer.silent
 
-  def rewriteWithOptions(child: LogicalPlan, options: VeRewriteStrategyOptions): immutable.Seq[SparkPlan] = {
-    val ret = VERewriteStrategy(options).apply(child)
-    collection.immutable.Seq(ret :_*)
-  }
-
   @silent
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = {
-    def functionPrefix: String = s"eval_${Math.abs(plan.toString.hashCode())}"
+    val functionPrefix: String = s"eval_${Math.abs(plan.toString.hashCode())}"
 
     if (options.rewriteEnabled) {
       log.debug(
@@ -85,647 +78,676 @@ final case class VERewriteStrategy(options: VeRewriteStrategyOptions)
           .map(_.dataType)}; options = ${options}"
       )
 
-      def res: immutable.Seq[SparkPlan] = plan match {
-        /* Apply Hints */
-        case SortOnVe(child, enabled) =>      rewriteWithOptions(child, options.copy(enableVeSorting = enabled))
-        case ProjectOnVe(child, enabled) =>   rewriteWithOptions(child, options.copy(projectOnVe = enabled))
-        case FilterOnVe(child, enabled) =>    rewriteWithOptions(child, options.copy(filterOnVe = enabled))
-        case AggregateOnVe(child, enabled) => rewriteWithOptions(child, options.copy(aggregateOnVe = enabled))
-        case ExchangeOnVe(child, enabled) =>  rewriteWithOptions(child, options.copy(exchangeOnVe = enabled))
-        case FailFast(child, enabled) =>      rewriteWithOptions(child, options.copy(failFast = enabled))
-        case JoinOnVe(child, enabled) =>      rewriteWithOptions(child, options.copy(joinOnVe = enabled))
-        case AmplifyBatches(child, enabled) =>rewriteWithOptions(child, options.copy(amplifyBatches = enabled))
-        case SkipVe(child, enabled) =>        rewriteWithOptions(child, options.copy(rewriteEnabled = enabled))
-
-
-        case imr @ InMemoryRelation(_, cb, oo)
-            if cb.serializer
-              .isInstanceOf[CycloneCacheBase] =>
-          SparkSession.active.sessionState.planner.InMemoryScans
-            .apply(imr)
-            .flatMap(sp =>
-              List(
-                VectorEngineToSparkPlan(
-                  VeFetchFromCachePlan(
-                    sp,
-                    cb.serializer
-                      .asInstanceOf[CycloneCacheBase]
-                  )
-                )
-              )
-            )
-            .toList
-        case JoinMatcher(JoinMatcher(leftChild, rightChild, inputsLeft, inputsRight, genericJoiner))
-            if options.joinOnVe =>
-          val functionName = s"join_${functionPrefix}"
-
-          val exchangeFunctionL = GroupingFunction(
-            s"exchange_l_${functionPrefix}",
-            inputsLeft.map { vec =>
-              GroupingFunction.DataDescription(
-                vec.veType,
-                if (genericJoiner.joins.flatMap(_.vecs).contains(vec)) GroupingFunction.Key
-                else GroupingFunction.Value
-              )
-            },
-            HashExchangeBuckets
-          )
-
-          val exchangeFunctionR = GroupingFunction(
-            s"exchange_r_${functionPrefix}",
-            inputsRight.map { vec =>
-              GroupingFunction.DataDescription(
-                vec.veType,
-                if (genericJoiner.joins.flatMap(_.vecs).contains(vec)) GroupingFunction.Key
-                else GroupingFunction.Value
-              )
-            },
-            HashExchangeBuckets
-          )
-
-          val code = CodeLines
-            .from(
-              CFunctionGeneration.KeyHeaders,
-              exchangeFunctionL.toCodeLines,
-              exchangeFunctionR.toCodeLines
-            )
-
-          val joinPlan = VectorEngineJoinPlan(
-            outputExpressions = leftChild.output ++ rightChild.output,
-            joinFunction = VeFunction(
-              veFunctionStatus = {
-                val produceIndicesFName = s"produce_indices_${functionName}"
-                VeFunctionStatus.SourceCode(
-                  CodeLines
-                    .from(
-                      CFunctionGeneration.KeyHeaders,
-                      genericJoiner.cFunctionExtra.toCodeLinesNoHeader(produceIndicesFName),
-                      genericJoiner
-                        .cFunction(produceIndicesFName)
-                        .toCodeLinesNoHeaderOutPtr2(functionName)
-                    )
-                    .cCode
-                )
-              },
-              functionName = functionName,
-              namedResults = genericJoiner.outputs.map(_.cVector)
-            ),
-            left = VeHashExchangePlan(
-              exchangeFunction = VeFunction(
-                veFunctionStatus = VeFunctionStatus.SourceCode(code.cCode),
-                functionName = exchangeFunctionL.name,
-                namedResults = inputsLeft
-              ),
-              child = SparkToVectorEnginePlan(planLater(leftChild))
-            ),
-            right = VeHashExchangePlan(
-              exchangeFunction = VeFunction(
-                veFunctionStatus = VeFunctionStatus.SourceCode(code.cCode),
-                functionName = exchangeFunctionR.name,
-                namedResults = inputsRight
-              ),
-              child = SparkToVectorEnginePlan(planLater(rightChild))
-            )
-          )
-
-          val amplifyFn = MergerFunction(
-            s"amplify_${functionName}",
-            genericJoiner.outputs.map(_.cVector.veType)
-          )
-
-          val maybeAmplifiedJoinPlan =
-            if (options.amplifyBatches)
-              VeAmplifyBatchesPlan(
-                amplifyFunction = VeFunction(
-                  veFunctionStatus = VeFunctionStatus
-                    .SourceCode(
-                      CodeLines
-                        .from(
-                          CFunctionGeneration.KeyHeaders,
-                          amplifyFn.toCodeLines
-                        )
-                        .cCode
-                    ),
-                  functionName = amplifyFn.name,
-                  namedResults = genericJoiner.outputs.map(_.cVector)
-                ),
-                child = joinPlan
-              )
-            else joinPlan
-
-          List(VectorEngineToSparkPlan(maybeAmplifiedJoinPlan))
-        case f @ logical.Filter(condition, child) if options.filterOnVe =>
-          implicit val fallback: EvalFallback = EvalFallback.noOp
-
-          val replacer =
-            SparkExpressionToCExpression.referenceReplacer(InputPrefix, child.output.toList)
-          val planE = for {
-            cond <- eval(condition.transform(replacer).transform(StringHole.transform))
-            data = child.output.toList.zipWithIndex.map { case (att, idx) =>
-              sparkTypeToVeType(att.dataType).makeCVector(s"${InputPrefix}$idx")
-            }
-          } yield {
-            val filterFn = FilterFunction(
-              s"filter_${functionPrefix}",
-              VeFilter(
-                stringVectorComputations = StringHole
-                  .process(condition.transform(replacer))
-                  .toList
-                  .flatMap(_.stringParts)
-                  .distinct,
-                data = data,
-                condition = cond
-              )
-            )
-
-            val amplifyFn = MergerFunction(
-              s"amplify_${filterFn.name}",
-              data.map(_.veType)
-            )
-
-            val filterPlan = VeOneStageEvaluationPlan(
-              outputExpressions = f.output,
-              veFunction = VeFunction(
-                veFunctionStatus =
-                  VeFunctionStatus.SourceCode(filterFn.toCodeLines.cCode),
-                functionName = filterFn.name,
-                namedResults = filterFn.outputs
-              ),
-              child = SparkToVectorEnginePlan(planLater(child))
-            )
-
-            List(
-              VectorEngineToSparkPlan(
-                if (options.amplifyBatches)
-                  VeAmplifyBatchesPlan(
-                    amplifyFunction = VeFunction(
-                      veFunctionStatus = VeFunctionStatus
-                        .SourceCode(
-                          CodeLines
-                            .from(
-                              CFunctionGeneration.KeyHeaders,
-                              amplifyFn.toCodeLines
-                            )
-                            .cCode
-                        ),
-                      functionName = amplifyFn.name,
-                      namedResults = data
-                    ),
-                    child = filterPlan
-                  )
-                else filterPlan
-              )
-            )
-          }
-
-          planE.fold(
-            e =>
-              sys.error(
-                s"Could not map ${e} (${e.getClass} ${Option(e)
-                  .collect { case a: AttributeReference => a.dataType }}); input is ${child.output.toList}, condition is ${condition}"
-              ),
-            identity
-          )
-        case f @ logical.Filter(cond, imr @ InMemoryRelation(output, cb, oo))
-            if cb.serializer
-              .isInstanceOf[CycloneCacheBase] =>
-          SparkSession.active.sessionState.planner.InMemoryScans
-            .apply(imr)
-            .flatMap(sp =>
-              List(
-                FilterExec(
-                  cond,
-                  VectorEngineToSparkPlan(
-                    VeFetchFromCachePlan(
-                      sp,
-                      cb.serializer
-                        .asInstanceOf[CycloneCacheBase]
-                    )
-                  )
-                )
-              )
-            )
-            .toList
-
-        case logical.Project(projectList, child) if projectList.nonEmpty && options.projectOnVe =>
-          implicit val fallback: EvalFallback = EvalFallback.noOp
-          val nonIdentityProjections =
-            if (options.passThroughProject)
-              projectList.filter(_.isInstanceOf[AttributeReference])
-            else projectList
-
-          val planE = for {
-            outputs <- nonIdentityProjections.toList.zipWithIndex.map { case (att, idx) =>
-              val referenced = replaceReferences(InputPrefix, plan.inputSet.toList, att)
-              if (referenced.dataType == StringType)
-                evalString(referenced).map(stringProducer =>
-                  Left(
-                    NamedStringExpression(name = s"output_${idx}", stringProducer = stringProducer)
-                  )
-                )
-              else
-                eval(referenced).map { cexp =>
-                  Right(
-                    NamedTypedCExpression(
-                      name = s"output_${idx}",
-                      sparkTypeToScalarVeType(att.dataType),
-                      cExpression = cexp
-                    )
-                  )
-                }
-            }.sequence
-          } yield {
-            val fName = s"project_${functionPrefix}"
-            val cF = renderProjection(
-              VeProjection(
-                inputs = child.output.toList.zipWithIndex.map { case (att, idx) =>
-                  sparkTypeToVeType(att.dataType).makeCVector(s"${InputPrefix}${idx}")
-                },
-                outputs = outputs
-              )
-            )
-            List(VectorEngineToSparkPlan(if (options.passThroughProject) {
-              VeProjectEvaluationPlan(
-                outputExpressions = projectList,
-                veFunction = VeFunction(
-                  veFunctionStatus = VeFunctionStatus.SourceCode(cF.toCodeLinesSPtr(fName).cCode),
-                  functionName = fName,
-                  namedResults = cF.outputs
-                ),
-                child = SparkToVectorEnginePlan(planLater(child))
-              )
-            } else {
-              VeOneStageEvaluationPlan(
-                outputExpressions = projectList,
-                veFunction = VeFunction(
-                  veFunctionStatus = VeFunctionStatus.SourceCode(cF.toCodeLinesSPtr(fName).cCode),
-                  functionName = fName,
-                  namedResults = cF.outputs
-                ),
-                child = SparkToVectorEnginePlan(planLater(child))
-              )
-            }))
-          }
-
-          planE.fold(e => sys.error(s"Could not map ${e}"), identity)
-
-        case logical.Aggregate(groupingExpressions, aggregateExpressions, child)
-          if options.aggregateOnVe && child.output.nonEmpty && aggregateExpressions.nonEmpty &&
-              ! {
-                aggregateExpressions
-                  .collect {
-                    case ae: AggregateExpression           => ae
-                    case Alias(ae: AggregateExpression, _) => ae
-                  }
-                  .exists { ae =>
-                    /** HyperLogLog++ or Distinct not supported * */
-                    ae.aggregateFunction.isInstanceOf[HyperLogLogPlusPlus] || ae.isDistinct
-                  }
-              } =>
-          implicit val fallback: EvalFallback = EvalFallback.noOp
-
-          val groupingExpressionsKeys: List[(GroupingKey, Expression)] =
-            groupingExpressions.zipWithIndex.map { case (e, i) =>
-              (
-                GroupingKey(
-                  name = s"${GroupPrefix}${i}",
-                  veType = SparkExpressionToCExpression.sparkTypeToVeType(e.dataType)
-                ),
-                e
-              )
-            }.toList
-
-          val referenceReplacer =
-            SparkExpressionToCExpression.referenceReplacer(
-              prefix = InputPrefix,
-              inputs = child.output.toList
-            )
-
-          val inputsList = child.output.zipWithIndex.map { case (att, id) =>
-            sparkTypeToVeType(att.dataType).makeCVector(s"${InputPrefix}${id}")
-          }.toList
-
-          val stringHoledAggregateExpressions = aggregateExpressions.map(namedExpression =>
-            namedExpression.transformSelf(referenceReplacer).transformSelf(StringHole.transform)
-          )
-
-          val evaluationPlanE: Either[String, SparkPlan] = for {
-            projections <- stringHoledAggregateExpressions.zipWithIndex
-              .map { case (ne, i) =>
-                ConvertNamedExpression
-                  .mapNamedExp(
-                    namedExpression = ne,
-                    idx = i,
-                    referenceReplacer = referenceReplacer,
-                    childAttributes = child.output
-                  )
-                  .map(_.right.toSeq)
-              }
-              .toList
-              .sequence
-              .map(_.flatten)
-            aggregates <-
-              stringHoledAggregateExpressions.zipWithIndex
-                .map { case (ne, i) =>
-                  ConvertNamedExpression
-                    .mapNamedExp(
-                      namedExpression = ne,
-                      idx = i,
-                      referenceReplacer = referenceReplacer,
-                      childAttributes = child.output
-                    )
-                    .map(_.left.toSeq)
-                }
-                .toList
-                .sequence
-                .map(_.flatten)
-            validateNamedOutput = { namedExp_ : NamedExpression =>
-              val namedExp = namedExp_ match {
-                case Alias(child, _) => child
-                case _               => namedExp_
-              }
-              projections
-                .collectFirst {
-                  case (pk, `namedExp`)           => Left(pk)
-                  case (pk, Alias(`namedExp`, _)) => Left(pk)
-                }
-                .orElse {
-                  aggregates.collectFirst {
-                    case (agg, `namedExp`) =>
-                      Right(agg)
-                    case (agg, Alias(`namedExp`, _)) =>
-                      Right(agg)
-                  }
-                }
-                .toRight(
-                  s"Unmatched output: ${namedExp}; type ${namedExp.getClass}; Spark type ${namedExp.dataType}. Have aggregates: ${aggregates
-                    .mkString(",")}"
-                )
-            }
-            finalOutputs <- stringHoledAggregateExpressions
-              .map(validateNamedOutput)
-              .toList
-              .sequence
-            stagedGroupBy = GroupByOutline(
-              groupingKeys = groupingExpressionsKeys.map { case (gk, _) => gk },
-              finalOutputs = finalOutputs
-            )
-            computedGroupingKeys <-
-              groupingExpressionsKeys.map { case (gk, exp) =>
-                mapGroupingExpression(exp, referenceReplacer)
-                  .map(e => gk -> e)
-              }.sequence
-            stringHoles = projections.flatMap { case (sp, p) =>
-              StringHole.process(p.transform(referenceReplacer))
-            } ++ aggregates.flatMap { case (sa, exp) =>
-              StringHole.process(exp.transform(referenceReplacer))
-            }
-            computedProjections <- projections.map { case (sp, p) =>
-              ConvertNamedExpression
-                .doProj(p.transform(referenceReplacer).transform(StringHole.transform))
-                .map(r => sp -> r)
-            }.sequence
-            computedAggregates <- aggregates.map { case (sa, exp) =>
-              computeAggregate(exp.transform(referenceReplacer))
-                .map(r => sa -> r)
-            }.sequence
-            groupByPartialGenerator = GroupByPartialGenerator(
-              finalGenerator = GroupByPartialToFinalGenerator(
-                stagedGroupBy = stagedGroupBy,
-                computedAggregates = computedAggregates
-              ),
-              computedGroupingKeys = computedGroupingKeys,
-              computedProjections = computedProjections,
-              stringVectorComputations = stringHoles.flatMap(_.stringParts).distinct
-            )
-            partialCFunction = groupByPartialGenerator.createPartial(inputs = inputsList)
-            _ <-
-              if (partialCFunction.outputs.toSet.size == partialCFunction.outputs.size) Right(())
-              else
-                Left(
-                  s"Expected to have distinct outputs from a PF, got: ${partialCFunction.outputs}"
-                )
-            ff = groupByPartialGenerator.finalGenerator.createFinal
-
-            dataDescriptions = {
-              child.output.map { expx =>
-                val contained =
-                  groupingExpressions.exists(exp =>
-                    exp == expx || exp.collect { case `expx` => exp }.nonEmpty
-                  ) ||
-                    groupingExpressions
-                      .collect { case ar: AttributeReference => ar.exprId }
-                      .toSet
-                      .contains(expx.exprId)
-
-                GroupingFunction.DataDescription(
-                  sparkTypeToVeType(expx.dataType),
-                  if (contained) GroupingFunction.Key else GroupingFunction.Value
-                )
-              }
-            }
-            exchangeFunction = GroupingFunction(
-              s"exchange_${functionPrefix}",
-              dataDescriptions.toList,
-              HashExchangeBuckets
-            )
-            partialName = s"partial_$functionPrefix"
-            finalName = s"final_$functionPrefix"
-
-            mergeFn = MergerFunction(
-              s"merge_$functionPrefix",
-              partialCFunction.outputs.map(_.veType)
-            )
-
-            amplifyFn = MergerFunction(
-              s"amplify_${functionPrefix}",
-              ff.outputs.map(_.veType)
-            )
-
-            code = CodeLines
-              .from(
-                partialCFunction.toCodeLinesSPtr(partialName),
-                ff.toCodeLinesNoHeaderOutPtr2(finalName),
-                exchangeFunction.toCodeLines,
-                mergeFn.toCodeLines,
-                if (options.amplifyBatches) amplifyFn.toCodeLines else CodeLines.empty
-              )
-
-          } yield {
-            val exchangePlan =
-              /*
-                TODO: Optimize in the future so that we don't need to copy the
-                input to output vectors at all if:
-
-                  dataDescriptions.count(_.keyOrValue.isKey) <= 0
-               */
-              if (options.exchangeOnVe) {
-                VeHashExchangePlan(
-                  exchangeFunction = VeFunction(
-                    veFunctionStatus = VeFunctionStatus.SourceCode(code.cCode),
-                    functionName = exchangeFunction.name,
-                    namedResults = partialCFunction.inputs
-                  ),
-                  child = SparkToVectorEnginePlan(planLater(child))
-                )
-              } else {
-                SparkToVectorEnginePlan(
-                  ShuffleExchangeExec(
-                    outputPartitioning =
-                      HashPartitioning(expressions = groupingExpressions, numPartitions = 8),
-                    child = planLater(child),
-                    shuffleOrigin = REPARTITION
-                  )
-                )
-              }
-
-            val pag = VePartialAggregate(
-              partialFunction = VeFunction(
-                veFunctionStatus = VeFunctionStatus.SourceCode(code.cCode),
-                functionName = partialName,
-                namedResults = partialCFunction.outputs
-              ),
-              child = exchangePlan,
-              expectedOutputs = partialCFunction.outputs
-                .map(_.veType)
-                .zipWithIndex
-                .map { case (veType, i) =>
-                  import org.apache.spark.sql.catalyst.expressions._
-                  // quick hack before doing something more proper
-                  AttributeReference(
-                    s"${veType}_${i}",
-                    SparkExpressionToCExpression.likelySparkType(veType)
-                  )()
-                }
-            )
-
-            val flt = VeFlattenPartition(
-              flattenFunction = VeFunction(
-                veFunctionStatus = VeFunctionStatus.SourceCode(code.cCode),
-                functionName = mergeFn.name,
-                namedResults = partialCFunction.outputs
-              ),
-              child = pag
-            )
-
-            val finalAggregate = VeFinalAggregate(
-              expectedOutputs = aggregateExpressions,
-              finalFunction = VeFunction(
-                veFunctionStatus = VeFunctionStatus.SourceCode(code.cCode),
-                functionName = finalName,
-                namedResults = ff.outputs
-              ),
-              child = flt
-            )
-
-            VectorEngineToSparkPlan(
-              if (options.amplifyBatches)
-                VeAmplifyBatchesPlan(
-                  amplifyFunction = VeFunction(
-                    veFunctionStatus = VeFunctionStatus
-                      .SourceCode(code.cCode),
-                    functionName = amplifyFn.name,
-                    namedResults = ff.outputs
-                  ),
-                  child = finalAggregate
-                )
-              else
-                finalAggregate
-            )
-          }
-
-          val evaluationPlan = evaluationPlanE.fold(sys.error, identity)
-          List(evaluationPlan)
-        case s @ Sort(orders, global, child)
-            if options.enableVeSorting && !child.output
-              .map(_.dataType)
-              .toSet
-              .contains(StringType) /* String is not supported by Sort yet */ => {
-          val inputsList = child.output.zipWithIndex.map { case (att, id) =>
-            sparkTypeToScalarVeType(att.dataType)
-              .makeCVector(s"${InputPrefix}${id}")
-              .asInstanceOf[CScalarVector]
-          }.toList
-
-          implicit val fallback: EvalFallback = EvalFallback.noOp
-          val orderingExpressions = orders
-            .map { case SortOrder(child, direction, _, _) =>
-              eval(replaceReferences(InputPrefix, plan.inputSet.toList, child))
-                .map(elem =>
-                  VeSortExpression(
-                    TypedCExpression2(sparkTypeToScalarVeType(child.dataType), elem),
-                    sparkSortDirectionToSortOrdering(direction)
-                  )
-                )
-            }
-            .toList
-            .sequence
-            .fold(
-              expr =>
-                sys.error(s"Failed to match expression ${expr}, with inputs ${plan.inputSet}"),
-              identity
-            )
-
-          val veSort = VeSort(inputsList, orderingExpressions)
-          val code = CFunctionGeneration.renderSort(veSort)
-
-          val sortFName = s"sort_${functionPrefix}"
-
-          List(
-            VectorEngineToSparkPlan(
-              VeOneStageEvaluationPlan(
-                outputExpressions = s.output,
-                veFunction = VeFunction(
-                  veFunctionStatus =
-                    VeFunctionStatus.SourceCode(code.toCodeLinesSPtr(sortFName).cCode),
-                  functionName = sortFName,
-                  namedResults = code.outputs
-                ),
-                child = SparkToVectorEnginePlan(planLater(child))
-              )
-            )
-          )
-        }
-        case _ => Nil
-      }
-
       if (options.failFast) {
-        val x = res
+        val x = rewritePlan(functionPrefix, plan)
         if (x.isEmpty)
           logger.debug(s"Didn't rewrite")
         else
           logger.debug(s"Rewrote it to ==> ${x}")
         x
       } else {
-        try res
+        try rewritePlan(functionPrefix, plan)
         catch {
           case e: Throwable =>
             logger.error(s"Could not map plan ${plan} because of: ${e}", e)
+            /* TODO: WHY??? */
             plan match {
-              case f @ logical.Filter(cond, imr @ InMemoryRelation(output, cb, oo))
-                  if cb.serializer
-                    .isInstanceOf[CycloneCacheBase] =>
-                SparkSession.active.sessionState.planner.InMemoryScans
-                  .apply(imr)
-                  .flatMap(sp =>
-                    List(
-                      FilterExec(
-                        cond,
-                        VectorEngineToSparkPlan(
-                          VeFetchFromCachePlan(
-                            sp,
-                            cb.serializer
-                              .asInstanceOf[CycloneCacheBase]
-                          )
-                        )
-                      )
-                    )
-                  )
-                  .toList
+              case logical.Filter(cond, imr @ InMemoryRelation(_, cb, _))
+                if cb.serializer.isInstanceOf[CycloneCacheBase] =>
+                inMemoryFilterPlan(cond, imr)
+
               case _ => Nil
             }
         }
       }
     } else Nil
+  }
+
+  private def rewritePlan(functionPrefix: String, plan: LogicalPlan) = plan match {
+    /* Apply Hints */
+    case SortOnVe(child, enabled) =>      rewriteWithOptions(child, options.copy(enableVeSorting = enabled))
+    case ProjectOnVe(child, enabled) =>   rewriteWithOptions(child, options.copy(projectOnVe = enabled))
+    case FilterOnVe(child, enabled) =>    rewriteWithOptions(child, options.copy(filterOnVe = enabled))
+    case AggregateOnVe(child, enabled) => rewriteWithOptions(child, options.copy(aggregateOnVe = enabled))
+    case ExchangeOnVe(child, enabled) =>  rewriteWithOptions(child, options.copy(exchangeOnVe = enabled))
+    case FailFast(child, enabled) =>      rewriteWithOptions(child, options.copy(failFast = enabled))
+    case JoinOnVe(child, enabled) =>      rewriteWithOptions(child, options.copy(joinOnVe = enabled))
+    case AmplifyBatches(child, enabled) =>rewriteWithOptions(child, options.copy(amplifyBatches = enabled))
+    case SkipVe(child, enabled) =>        rewriteWithOptions(child, options.copy(rewriteEnabled = enabled))
+
+    /* Plan rewriting */
+    case imr @ InMemoryRelation(_, cb, _)
+      if cb.serializer.isInstanceOf[CycloneCacheBase] =>
+      fetchFromCachePlan(imr)
+
+    case logical.Filter(cond, imr @ InMemoryRelation(_, cb, _))
+      if cb.serializer.isInstanceOf[CycloneCacheBase] =>
+      inMemoryFilterPlan(cond, imr)
+
+    case f @ logical.Filter(condition, child) if options.filterOnVe =>
+      filterPlan(functionPrefix, f, condition, child)
+
+    case JoinMatcher(JoinMatcher(leftChild, rightChild, inputsLeft, inputsRight, genericJoiner))
+      if options.joinOnVe =>
+      joinPlan(functionPrefix, leftChild, rightChild, inputsLeft, inputsRight, genericJoiner)
+
+    case logical.Project(projectList, child)
+      if projectList.nonEmpty && options.projectOnVe =>
+      projectPlan(functionPrefix, plan, projectList, child)
+
+    case logical.Aggregate(groupingExpressions, aggregateExpressions, child)
+      if options.aggregateOnVe && child.output.nonEmpty && aggregateExpressions.nonEmpty &&
+        isSupportedAggregationExpression(aggregateExpressions) =>
+      exchangePlan(functionPrefix, groupingExpressions, aggregateExpressions, child)
+
+    case s @ Sort(orders, _, child)
+      if options.enableVeSorting && isSupportedSortType(child) =>
+      sortPlan(functionPrefix, plan, s, orders, child)
+
+    case _ => Nil
+  }
+
+  private def sortPlan(functionPrefix: String, plan: LogicalPlan, s: Sort, orders: Seq[SortOrder], child: LogicalPlan) = {
+    val inputsList = child.output.zipWithIndex.map { case (att, id) =>
+      sparkTypeToScalarVeType(att.dataType)
+        .makeCVector(s"${InputPrefix}${id}")
+        .asInstanceOf[CScalarVector]
+    }.toList
+
+    implicit val fallback: EvalFallback = EvalFallback.noOp
+    val orderingExpressions = orders
+      .map { case SortOrder(child, direction, _, _) =>
+        eval(replaceReferences(InputPrefix, plan.inputSet.toList, child))
+          .map(elem =>
+            VeSortExpression(
+              TypedCExpression2(sparkTypeToScalarVeType(child.dataType), elem),
+              sparkSortDirectionToSortOrdering(direction)
+            )
+          )
+      }
+      .toList
+      .sequence
+      .fold(
+        expr =>
+          sys.error(s"Failed to match expression ${expr}, with inputs ${plan.inputSet}"),
+        identity
+      )
+
+    val veSort = VeSort(inputsList, orderingExpressions)
+    val code = CFunctionGeneration.renderSort(veSort)
+
+    val sortFName = s"sort_${functionPrefix}"
+
+    List(
+      VectorEngineToSparkPlan(
+        VeOneStageEvaluationPlan(
+          outputExpressions = s.output,
+          veFunction = VeFunction(
+            veFunctionStatus =
+              VeFunctionStatus.SourceCode(code.toCodeLinesSPtr(sortFName).cCode),
+            functionName = sortFName,
+            namedResults = code.outputs
+          ),
+          child = SparkToVectorEnginePlan(planLater(child))
+        )
+      )
+    )
+  }
+
+  /**
+   *  String is not supported by Sort yet
+   */
+  private def isSupportedSortType(child: LogicalPlan) = !child.output.map(_.dataType).toSet.contains(StringType)
+
+  private def exchangePlan(functionPrefix: String, groupingExpressions: Seq[Expression], aggregateExpressions: Seq[NamedExpression], child: LogicalPlan) = {
+    implicit val fallback: EvalFallback = EvalFallback.noOp
+
+    val groupingExpressionsKeys: List[(GroupingKey, Expression)] =
+      groupingExpressions.zipWithIndex.map { case (e, i) =>
+        (
+          GroupingKey(
+            name = s"${GroupPrefix}${i}",
+            veType = SparkExpressionToCExpression.sparkTypeToVeType(e.dataType)
+          ),
+          e
+        )
+      }.toList
+
+    val referenceReplacer =
+      SparkExpressionToCExpression.referenceReplacer(
+        prefix = InputPrefix,
+        inputs = child.output.toList
+      )
+
+    val inputsList = child.output.zipWithIndex.map { case (att, id) =>
+      sparkTypeToVeType(att.dataType).makeCVector(s"${InputPrefix}${id}")
+    }.toList
+
+    val stringHoledAggregateExpressions = aggregateExpressions.map(namedExpression =>
+      namedExpression.transformSelf(referenceReplacer).transformSelf(StringHole.transform)
+    )
+
+    val evaluationPlanE: Either[String, SparkPlan] = for {
+      projections <- stringHoledAggregateExpressions.zipWithIndex
+        .map { case (ne, i) =>
+          ConvertNamedExpression
+            .mapNamedExp(
+              namedExpression = ne,
+              idx = i,
+              referenceReplacer = referenceReplacer,
+              childAttributes = child.output
+            )
+            .map(_.right.toSeq)
+        }
+        .toList
+        .sequence
+        .map(_.flatten)
+      aggregates <-
+        stringHoledAggregateExpressions.zipWithIndex
+          .map { case (ne, i) =>
+            ConvertNamedExpression
+              .mapNamedExp(
+                namedExpression = ne,
+                idx = i,
+                referenceReplacer = referenceReplacer,
+                childAttributes = child.output
+              )
+              .map(_.left.toSeq)
+          }
+          .toList
+          .sequence
+          .map(_.flatten)
+      validateNamedOutput = { namedExp_ : NamedExpression =>
+        val namedExp = namedExp_ match {
+          case Alias(child, _) => child
+          case _ => namedExp_
+        }
+        projections
+          .collectFirst {
+            case (pk, `namedExp`) => Left(pk)
+            case (pk, Alias(`namedExp`, _)) => Left(pk)
+          }
+          .orElse {
+            aggregates.collectFirst {
+              case (agg, `namedExp`) =>
+                Right(agg)
+              case (agg, Alias(`namedExp`, _)) =>
+                Right(agg)
+            }
+          }
+          .toRight(
+            s"Unmatched output: ${namedExp}; type ${namedExp.getClass}; Spark type ${namedExp.dataType}. Have aggregates: ${
+              aggregates
+                .mkString(",")
+            }"
+          )
+      }
+      finalOutputs <- stringHoledAggregateExpressions
+        .map(validateNamedOutput)
+        .toList
+        .sequence
+      stagedGroupBy = GroupByOutline(
+        groupingKeys = groupingExpressionsKeys.map { case (gk, _) => gk },
+        finalOutputs = finalOutputs
+      )
+      computedGroupingKeys <-
+        groupingExpressionsKeys.map { case (gk, exp) =>
+          mapGroupingExpression(exp, referenceReplacer)
+            .map(e => gk -> e)
+        }.sequence
+      stringHoles = projections.flatMap { case (sp, p) =>
+        StringHole.process(p.transform(referenceReplacer))
+      } ++ aggregates.flatMap { case (sa, exp) =>
+        StringHole.process(exp.transform(referenceReplacer))
+      }
+      computedProjections <- projections.map { case (sp, p) =>
+        ConvertNamedExpression
+          .doProj(p.transform(referenceReplacer).transform(StringHole.transform))
+          .map(r => sp -> r)
+      }.sequence
+      computedAggregates <- aggregates.map { case (sa, exp) =>
+        computeAggregate(exp.transform(referenceReplacer))
+          .map(r => sa -> r)
+      }.sequence
+      groupByPartialGenerator = GroupByPartialGenerator(
+        finalGenerator = GroupByPartialToFinalGenerator(
+          stagedGroupBy = stagedGroupBy,
+          computedAggregates = computedAggregates
+        ),
+        computedGroupingKeys = computedGroupingKeys,
+        computedProjections = computedProjections,
+        stringVectorComputations = stringHoles.flatMap(_.stringParts).distinct
+      )
+      partialCFunction = groupByPartialGenerator.createPartial(inputs = inputsList)
+      _ <-
+        if (partialCFunction.outputs.toSet.size == partialCFunction.outputs.size) Right(())
+        else
+          Left(
+            s"Expected to have distinct outputs from a PF, got: ${partialCFunction.outputs}"
+          )
+      ff = groupByPartialGenerator.finalGenerator.createFinal
+
+      dataDescriptions = {
+        child.output.map { expx =>
+          val contained =
+            groupingExpressions.exists(exp =>
+              exp == expx || exp.collect { case `expx` => exp }.nonEmpty
+            ) ||
+              groupingExpressions
+                .collect { case ar: AttributeReference => ar.exprId }
+                .toSet
+                .contains(expx.exprId)
+
+          GroupingFunction.DataDescription(
+            sparkTypeToVeType(expx.dataType),
+            if (contained) GroupingFunction.Key else GroupingFunction.Value
+          )
+        }
+      }
+      exchangeFunction = GroupingFunction(
+        s"exchange_${functionPrefix}",
+        dataDescriptions.toList,
+        HashExchangeBuckets
+      )
+      partialName = s"partial_$functionPrefix"
+      finalName = s"final_$functionPrefix"
+
+      mergeFn = MergerFunction(
+        s"merge_$functionPrefix",
+        partialCFunction.outputs.map(_.veType)
+      )
+
+      amplifyFn = MergerFunction(
+        s"amplify_${functionPrefix}",
+        ff.outputs.map(_.veType)
+      )
+
+      code = CodeLines
+        .from(
+          partialCFunction.toCodeLinesSPtr(partialName),
+          ff.toCodeLinesNoHeaderOutPtr2(finalName),
+          exchangeFunction.toCodeLines,
+          mergeFn.toCodeLines,
+          if (options.amplifyBatches) amplifyFn.toCodeLines else CodeLines.empty
+        )
+
+    } yield {
+      val exchangePlan =
+      /*
+                TODO: Optimize in the future so that we don't need to copy the
+                input to output vectors at all if:
+
+                  dataDescriptions.count(_.keyOrValue.isKey) <= 0
+               */
+        if (options.exchangeOnVe) {
+          VeHashExchangePlan(
+            exchangeFunction = VeFunction(
+              veFunctionStatus = VeFunctionStatus.SourceCode(code.cCode),
+              functionName = exchangeFunction.name,
+              namedResults = partialCFunction.inputs
+            ),
+            child = SparkToVectorEnginePlan(planLater(child))
+          )
+        } else {
+          SparkToVectorEnginePlan(
+            ShuffleExchangeExec(
+              outputPartitioning =
+                HashPartitioning(expressions = groupingExpressions, numPartitions = 8),
+              child = planLater(child),
+              shuffleOrigin = REPARTITION
+            )
+          )
+        }
+
+      val pag = VePartialAggregate(
+        partialFunction = VeFunction(
+          veFunctionStatus = VeFunctionStatus.SourceCode(code.cCode),
+          functionName = partialName,
+          namedResults = partialCFunction.outputs
+        ),
+        child = exchangePlan,
+        expectedOutputs = partialCFunction.outputs
+          .map(_.veType)
+          .zipWithIndex
+          .map { case (veType, i) =>
+            import org.apache.spark.sql.catalyst.expressions._
+            // quick hack before doing something more proper
+            AttributeReference(
+              s"${veType}_${i}",
+              SparkExpressionToCExpression.likelySparkType(veType)
+            )()
+          }
+      )
+
+      val flt = VeFlattenPartition(
+        flattenFunction = VeFunction(
+          veFunctionStatus = VeFunctionStatus.SourceCode(code.cCode),
+          functionName = mergeFn.name,
+          namedResults = partialCFunction.outputs
+        ),
+        child = pag
+      )
+
+      val finalAggregate = VeFinalAggregate(
+        expectedOutputs = aggregateExpressions,
+        finalFunction = VeFunction(
+          veFunctionStatus = VeFunctionStatus.SourceCode(code.cCode),
+          functionName = finalName,
+          namedResults = ff.outputs
+        ),
+        child = flt
+      )
+
+      VectorEngineToSparkPlan(
+        if (options.amplifyBatches)
+          VeAmplifyBatchesPlan(
+            amplifyFunction = VeFunction(
+              veFunctionStatus = VeFunctionStatus
+                .SourceCode(code.cCode),
+              functionName = amplifyFn.name,
+              namedResults = ff.outputs
+            ),
+            child = finalAggregate
+          )
+        else
+          finalAggregate
+      )
+    }
+
+    val evaluationPlan = evaluationPlanE.fold(sys.error, identity)
+    List(evaluationPlan)
+  }
+
+  private def isSupportedAggregationExpression(aggregateExpressions: Seq[NamedExpression]) = {
+    !aggregateExpressions
+      .collect {
+        case ae: AggregateExpression => ae
+        case Alias(ae: AggregateExpression, _) => ae
+      }
+      .exists { ae =>
+        /** HyperLogLog++ or Distinct not supported * */
+        ae.aggregateFunction.isInstanceOf[HyperLogLogPlusPlus] || ae.isDistinct
+      }
+  }
+
+  private def projectPlan(functionPrefix: String, plan: LogicalPlan, projectList: Seq[NamedExpression], child: LogicalPlan) = {
+    implicit val fallback: EvalFallback = EvalFallback.noOp
+    val nonIdentityProjections =
+      if (options.passThroughProject)
+        projectList.filter(_.isInstanceOf[AttributeReference])
+      else projectList
+
+    val planE = for {
+      outputs <- nonIdentityProjections.toList.zipWithIndex.map { case (att, idx) =>
+        val referenced = replaceReferences(InputPrefix, plan.inputSet.toList, att)
+        if (referenced.dataType == StringType)
+          evalString(referenced).map(stringProducer =>
+            Left(
+              NamedStringExpression(name = s"output_${idx}", stringProducer = stringProducer)
+            )
+          )
+        else
+          eval(referenced).map { cexp =>
+            Right(
+              NamedTypedCExpression(
+                name = s"output_${idx}",
+                sparkTypeToScalarVeType(att.dataType),
+                cExpression = cexp
+              )
+            )
+          }
+      }.sequence
+    } yield {
+      val fName = s"project_${functionPrefix}"
+      val cF = renderProjection(
+        VeProjection(
+          inputs = child.output.toList.zipWithIndex.map { case (att, idx) =>
+            sparkTypeToVeType(att.dataType).makeCVector(s"${InputPrefix}${idx}")
+          },
+          outputs = outputs
+        )
+      )
+      List(VectorEngineToSparkPlan(if (options.passThroughProject) {
+        VeProjectEvaluationPlan(
+          outputExpressions = projectList,
+          veFunction = VeFunction(
+            veFunctionStatus = VeFunctionStatus.SourceCode(cF.toCodeLinesSPtr(fName).cCode),
+            functionName = fName,
+            namedResults = cF.outputs
+          ),
+          child = SparkToVectorEnginePlan(planLater(child))
+        )
+      } else {
+        VeOneStageEvaluationPlan(
+          outputExpressions = projectList,
+          veFunction = VeFunction(
+            veFunctionStatus = VeFunctionStatus.SourceCode(cF.toCodeLinesSPtr(fName).cCode),
+            functionName = fName,
+            namedResults = cF.outputs
+          ),
+          child = SparkToVectorEnginePlan(planLater(child))
+        )
+      }))
+    }
+
+    planE.fold(e => sys.error(s"Could not map ${e}"), identity)
+  }
+
+  private def inMemoryFilterPlan(cond: Expression, imr: InMemoryRelation) = {
+    SparkSession.active.sessionState.planner.InMemoryScans
+      .apply(imr)
+      .flatMap(sp =>
+        List(
+          FilterExec(
+            cond,
+            VectorEngineToSparkPlan(
+              VeFetchFromCachePlan(
+                sp,
+                imr.cacheBuilder.serializer
+                  .asInstanceOf[CycloneCacheBase]
+              )
+            )
+          )
+        )
+      )
+      .toList
+  }
+
+  private def filterPlan(functionPrefix: String, f: Filter, condition: Expression, child: LogicalPlan) = {
+    implicit val fallback: EvalFallback = EvalFallback.noOp
+
+    val replacer =
+      SparkExpressionToCExpression.referenceReplacer(InputPrefix, child.output.toList)
+    val planE = for {
+      cond <- eval(condition.transform(replacer).transform(StringHole.transform))
+      data = child.output.toList.zipWithIndex.map { case (att, idx) =>
+        sparkTypeToVeType(att.dataType).makeCVector(s"${InputPrefix}$idx")
+      }
+    } yield {
+      val filterFn = FilterFunction(
+        s"filter_${functionPrefix}",
+        VeFilter(
+          stringVectorComputations = StringHole
+            .process(condition.transform(replacer))
+            .toList
+            .flatMap(_.stringParts)
+            .distinct,
+          data = data,
+          condition = cond
+        )
+      )
+
+      val amplifyFn = MergerFunction(
+        s"amplify_${filterFn.name}",
+        data.map(_.veType)
+      )
+
+      val filterPlan = VeOneStageEvaluationPlan(
+        outputExpressions = f.output,
+        veFunction = VeFunction(
+          veFunctionStatus =
+            VeFunctionStatus.SourceCode(filterFn.toCodeLines.cCode),
+          functionName = filterFn.name,
+          namedResults = filterFn.outputs
+        ),
+        child = SparkToVectorEnginePlan(planLater(child))
+      )
+
+      List(
+        VectorEngineToSparkPlan(
+          if (options.amplifyBatches)
+            VeAmplifyBatchesPlan(
+              amplifyFunction = VeFunction(
+                veFunctionStatus = VeFunctionStatus
+                  .SourceCode(
+                    CodeLines
+                      .from(
+                        CFunctionGeneration.KeyHeaders,
+                        amplifyFn.toCodeLines
+                      )
+                      .cCode
+                  ),
+                functionName = amplifyFn.name,
+                namedResults = data
+              ),
+              child = filterPlan
+            )
+          else filterPlan
+        )
+      )
+    }
+
+    planE.fold(
+      e =>
+        sys.error(
+          s"Could not map ${e} (${e.getClass} ${
+            Option(e)
+              .collect { case a: AttributeReference => a.dataType }
+          }); input is ${child.output.toList}, condition is ${condition}"
+        ),
+      identity
+    )
+  }
+
+  private def joinPlan(functionPrefix: String, leftChild: LogicalPlan, rightChild: LogicalPlan, inputsLeft: List[CVector], inputsRight: List[CVector], genericJoiner: GenericJoiner) = {
+    val functionName = s"join_${functionPrefix}"
+
+    val exchangeFunctionL = GroupingFunction(
+      s"exchange_l_${functionPrefix}",
+      inputsLeft.map { vec =>
+        GroupingFunction.DataDescription(
+          vec.veType,
+          if (genericJoiner.joins.flatMap(_.vecs).contains(vec)) GroupingFunction.Key
+          else GroupingFunction.Value
+        )
+      },
+      HashExchangeBuckets
+    )
+
+    val exchangeFunctionR = GroupingFunction(
+      s"exchange_r_${functionPrefix}",
+      inputsRight.map { vec =>
+        GroupingFunction.DataDescription(
+          vec.veType,
+          if (genericJoiner.joins.flatMap(_.vecs).contains(vec)) GroupingFunction.Key
+          else GroupingFunction.Value
+        )
+      },
+      HashExchangeBuckets
+    )
+
+    val code = CodeLines
+      .from(
+        CFunctionGeneration.KeyHeaders,
+        exchangeFunctionL.toCodeLines,
+        exchangeFunctionR.toCodeLines
+      )
+
+    val joinPlan = VectorEngineJoinPlan(
+      outputExpressions = leftChild.output ++ rightChild.output,
+      joinFunction = VeFunction(
+        veFunctionStatus = {
+          val produceIndicesFName = s"produce_indices_${functionName}"
+          VeFunctionStatus.SourceCode(
+            CodeLines
+              .from(
+                CFunctionGeneration.KeyHeaders,
+                genericJoiner.cFunctionExtra.toCodeLinesNoHeader(produceIndicesFName),
+                genericJoiner
+                  .cFunction(produceIndicesFName)
+                  .toCodeLinesNoHeaderOutPtr2(functionName)
+              )
+              .cCode
+          )
+        },
+        functionName = functionName,
+        namedResults = genericJoiner.outputs.map(_.cVector)
+      ),
+      left = VeHashExchangePlan(
+        exchangeFunction = VeFunction(
+          veFunctionStatus = VeFunctionStatus.SourceCode(code.cCode),
+          functionName = exchangeFunctionL.name,
+          namedResults = inputsLeft
+        ),
+        child = SparkToVectorEnginePlan(planLater(leftChild))
+      ),
+      right = VeHashExchangePlan(
+        exchangeFunction = VeFunction(
+          veFunctionStatus = VeFunctionStatus.SourceCode(code.cCode),
+          functionName = exchangeFunctionR.name,
+          namedResults = inputsRight
+        ),
+        child = SparkToVectorEnginePlan(planLater(rightChild))
+      )
+    )
+
+    val amplifyFn = MergerFunction(
+      s"amplify_${functionName}",
+      genericJoiner.outputs.map(_.cVector.veType)
+    )
+
+    val maybeAmplifiedJoinPlan =
+      if (options.amplifyBatches)
+        VeAmplifyBatchesPlan(
+          amplifyFunction = VeFunction(
+            veFunctionStatus = VeFunctionStatus
+              .SourceCode(
+                CodeLines
+                  .from(
+                    CFunctionGeneration.KeyHeaders,
+                    amplifyFn.toCodeLines
+                  )
+                  .cCode
+              ),
+            functionName = amplifyFn.name,
+            namedResults = genericJoiner.outputs.map(_.cVector)
+          ),
+          child = joinPlan
+        )
+      else joinPlan
+
+    List(VectorEngineToSparkPlan(maybeAmplifiedJoinPlan))
+  }
+
+  private def fetchFromCachePlan(imr: InMemoryRelation) = {
+    SparkSession.active.sessionState.planner.InMemoryScans
+      .apply(imr)
+      .flatMap(sp =>
+        List(
+          VectorEngineToSparkPlan(
+            VeFetchFromCachePlan(
+              sp,
+              imr.cacheBuilder.serializer
+                .asInstanceOf[CycloneCacheBase]
+            )
+          )
+        )
+      )
+      .toList
+  }
+
+  private def rewriteWithOptions(child: LogicalPlan, options: VeRewriteStrategyOptions) = {
+    val ret = VERewriteStrategy(options).apply(child)
+    Seq(ret :_*)
   }
 }

--- a/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
+++ b/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
@@ -70,6 +70,11 @@ final case class VERewriteStrategy(options: VeRewriteStrategyOptions)
 
   import com.github.ghik.silencer.silent
 
+  def rewriteWithOptions(child: LogicalPlan, options: VeRewriteStrategyOptions): immutable.Seq[SparkPlan] = {
+    val ret = VERewriteStrategy(options).apply(child)
+    collection.immutable.Seq(ret :_*)
+  }
+
   @silent
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = {
     def functionPrefix: String = s"eval_${Math.abs(plan.toString.hashCode())}"
@@ -81,34 +86,17 @@ final case class VERewriteStrategy(options: VeRewriteStrategyOptions)
       )
 
       def res: immutable.Seq[SparkPlan] = plan match {
-        case SortOnVe(child, enabled) =>
-          val ret = VERewriteStrategy(options.copy(enableVeSorting = enabled)).apply(child)
-          collection.immutable.Seq(ret :_*)
-        case ProjectOnVe(child, enabled) =>
-          val ret = VERewriteStrategy(options.copy(projectOnVe = enabled)).apply(child)
-          collection.immutable.Seq(ret :_*)
-        case FilterOnVe(child, enabled) =>
-          val ret = VERewriteStrategy(options.copy(filterOnVe = enabled)).apply(child)
-          collection.immutable.Seq(ret :_*)
-        case AggregateOnVe(child, enabled) =>
-          val ret = VERewriteStrategy(options.copy(aggregateOnVe = enabled)).apply(child)
-          collection.immutable.Seq(ret :_*)
-        case ExchangeOnVe(child, enabled) =>
-          val ret = VERewriteStrategy(options.copy(exchangeOnVe = enabled)).apply(child)
-          collection.immutable.Seq(ret :_*)
-        case FailFast(child, enabled) =>
-          val ret = VERewriteStrategy(options.copy(failFast = enabled)).apply(child)
-          collection.immutable.Seq(ret :_*)
-        case JoinOnVe(child, enabled) =>
-          println(s"JoinOnVe($enabled)")
-          val ret = VERewriteStrategy(options.copy(joinOnVe = enabled)).apply(child)
-          collection.immutable.Seq(ret :_*)
-        case AmplifyBatches(child, enabled) =>
-          val ret = VERewriteStrategy(options.copy(amplifyBatches = enabled)).apply(child)
-          collection.immutable.Seq(ret :_*)
-        case SkipVe(child, enabled) =>
-          val ret = VERewriteStrategy(options.copy(rewriteEnabled = !enabled)).apply(child)
-          collection.immutable.Seq(ret :_*)
+        /* Apply Hints */
+        case SortOnVe(child, enabled) =>      rewriteWithOptions(child, options.copy(enableVeSorting = enabled))
+        case ProjectOnVe(child, enabled) =>   rewriteWithOptions(child, options.copy(projectOnVe = enabled))
+        case FilterOnVe(child, enabled) =>    rewriteWithOptions(child, options.copy(filterOnVe = enabled))
+        case AggregateOnVe(child, enabled) => rewriteWithOptions(child, options.copy(aggregateOnVe = enabled))
+        case ExchangeOnVe(child, enabled) =>  rewriteWithOptions(child, options.copy(exchangeOnVe = enabled))
+        case FailFast(child, enabled) =>      rewriteWithOptions(child, options.copy(failFast = enabled))
+        case JoinOnVe(child, enabled) =>      rewriteWithOptions(child, options.copy(joinOnVe = enabled))
+        case AmplifyBatches(child, enabled) =>rewriteWithOptions(child, options.copy(amplifyBatches = enabled))
+        case SkipVe(child, enabled) =>        rewriteWithOptions(child, options.copy(rewriteEnabled = enabled))
+
 
         case imr @ InMemoryRelation(_, cb, oo)
             if cb.serializer

--- a/src/main/scala/com/nec/spark/planning/VeFunction.scala
+++ b/src/main/scala/com/nec/spark/planning/VeFunction.scala
@@ -1,5 +1,6 @@
 package com.nec.spark.planning
 
+import com.nec.spark.agile.CExpressionEvaluation.CodeLines
 import com.nec.spark.agile.CFunctionGeneration.{CVector, VeType}
 import com.nec.spark.planning.LibLocation.LibLocation
 import com.nec.spark.planning.VeFunction.VeFunctionStatus
@@ -7,6 +8,8 @@ import com.nec.spark.planning.VeFunction.VeFunctionStatus
 object VeFunction {
   sealed trait VeFunctionStatus
   object VeFunctionStatus {
+    def fromCodeLines(lines: CodeLines): SourceCode = SourceCode(lines.cCode)
+
     final case class SourceCode(sourceCode: String) extends VeFunctionStatus {
       override def toString: String = super.toString.take(25)
     }


### PR DESCRIPTION
The huge pattern match in VERewriteStrategy makes it very hard to navigate the file. 

This refactors this and pulls the result of those case matches into their own methods.

While at it, I've also deduplicated some low hanging duplicate code warnings. 