### PR TITLE
Implement `ProjectionFunction`

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
@@ -122,9 +122,10 @@ struct NullableScalarVec {
   // Returns a deep copy of this NullableScalarVec<T>
   NullableScalarVec<T> * clone() const;
 
-  // Returns a filtered deep copy of the NullableScalarVec<T> that contains only
-  // elements whose original index value is in the matching_ids
-  NullableScalarVec<T> * filter(const std::vector<size_t> &matching_ids) const;
+  // Returns a deep copy of the NullableScalarVec<T> that contains only elements
+  // whose original index value is in the selected_ids.  This method can be used
+  // to either filter out and/or re-order elements of the original NullableScalarVec<T>.
+  NullableScalarVec<T> * select(const std::vector<size_t> &selected_ids) const;
 
   // Create N new NullableScalarVec<T>'s and copy values over to them based on
   // the bucket_assignments
@@ -239,9 +240,11 @@ struct nullable_varchar_vector {
   // Returns a deep copy of this nullable_varchar_vector
   nullable_varchar_vector * clone() const;
 
-  // Returns a filtered deep copy of the NullableScalarVec<T> that contains only
-  // elements whose original index value is in the matching_ids
-  nullable_varchar_vector * filter(const std::vector<size_t> &matching_ids) const;
+  // Returns a deep copy of the nullable_varchar_vector that contains only
+  // elements whose original index value is in the selected_ids.  This method
+  // can be used to either filter out and/or re-order elements of the original
+  // nullable_varchar_vector.
+  nullable_varchar_vector * select(const std::vector<size_t> &selected_ids) const;
 
   // Create N new nullable_varchar_vector's and copy values over to them based
   // on the bucket_assignments

--- a/src/main/resources/com/nec/cyclone/cpp/examples.cpp
+++ b/src/main/resources/com/nec/cyclone/cpp/examples.cpp
@@ -66,7 +66,7 @@ nullable_varchar_vector * project_eval(const nullable_varchar_vector *input_0)  
 
 void filter_test() {
   std::vector<std::string> data { "AIR", "MAIL", "RAIL", "SHIP", "TRUCK", "REG AIR", "FOB" };
-  std::vector<size_t> matching_ids { 1, 3, 5 };
+  std::vector<size_t> selected_ids { 1, 3, 5 };
 
   auto *input = new nullable_varchar_vector(data);
   input->set_validity(3, 0);
@@ -77,7 +77,7 @@ void filter_test() {
   std::cout << "Original nullable_varchar_vector:" << std::endl;
   input->print();
 
-  const auto *output = input->filter(matching_ids);
+  const auto *output = input->select(selected_ids);
   std::cout << "Filtered nullable_varchar_vector:" << std::endl;
   output->print();
 
@@ -154,6 +154,11 @@ int main() {
   // filter_test();
   // test_sort1();
   // test_sort2();
+  // test_lambda();
 
-  test_lambda();
+  // const auto *input = new nullable_varchar_vector(std::vector<std::string> { "foo1", "bar2", "foobar3", "baz4", "buz5", "faa6" });
+  const auto *input = new nullable_int_vector(std::vector<int32_t> { 0, 1, 2, 3, 4, 5 });
+  const auto *output = input->select(std::vector<size_t> { 5, 1, 3, 2 });
+  input->print();
+  output->print();
 }

--- a/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.hpp
@@ -192,22 +192,46 @@ namespace cyclone::tests {
       CHECK(input->validity_vec() == expected);
     }
 
-    TEST_CASE("Filter works") {
+    TEST_CASE("Select works") {
       // Include empty string value
       auto *input = new nullable_varchar_vector(std::vector<std::string> { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "", "SEP", "OCT", "NOV", "DEC" });
       input->set_validity(1, 0);
       input->set_validity(4, 0);
       input->set_validity(10, 0);
 
-      const std::vector<size_t> matching_ids { 1, 2, 4, 7, 11 };
+      const std::vector<size_t> selected_ids { 1, 2, 4, 7, 11 };
 
       auto *expected = new nullable_varchar_vector(std::vector<std::string> { "FEB", "MAR", "MAY", "", "DEC" });
       expected->set_validity(0, 0);
       expected->set_validity(2, 0);
 
-      auto *output = input->filter(matching_ids);
+      const auto *output = input->select(selected_ids);
       CHECK(output != input);
       CHECK(output->equals(expected));
+    }
+
+    TEST_CASE("Select works (for nullable_varchar_vector backed by a compressed data encoding)") {
+      std::vector<int32_t> input { 0, 1, 2, 3, 3, 4 };
+      const auto condition = [&] (const size_t i) -> bool {
+        return input[i] % 2 == 0;
+      };
+
+      auto *vec = nullable_varchar_vector::from_binary_choice(input.size(), condition, "YES", "NO");
+      vec->set_validity(0, 0);
+      vec->set_validity(2, 0);
+
+      auto *expected1 = new nullable_varchar_vector(std::vector<std::string> { "YES", "NO", "YES", "NO", "NO", "YES" });
+      expected1->set_validity(0, 0);
+      expected1->set_validity(2, 0);
+      CHECK(vec->equivalent_to(expected1));
+
+      const std::vector<size_t> selected_ids { 5, 2, 4, 0 };
+      const auto *output = vec->select(selected_ids);
+
+      auto *expected2 = new nullable_varchar_vector(std::vector<std::string> { "YES", "YES", "NO", "YES" });
+      expected2->set_validity(1, 0);
+      expected2->set_validity(3, 0);
+      CHECK(output->equivalent_to(expected2));
     }
 
     TEST_CASE("Bucket works") {
@@ -222,13 +246,13 @@ namespace cyclone::tests {
 
       auto **output = input->bucket(bucket_counts, bucket_assignments);
 
-      const std::vector<size_t> matching_ids_0 { 2, 6, 11 };
-      const std::vector<size_t> matching_ids_1 { 0, 3, 4, 10 };
-      const std::vector<size_t> matching_ids_2 { 1, 5, 7, 8, 9 };
+      const std::vector<size_t> selected_ids_0 { 2, 6, 11 };
+      const std::vector<size_t> selected_ids_1 { 0, 3, 4, 10 };
+      const std::vector<size_t> selected_ids_2 { 1, 5, 7, 8, 9 };
 
-      CHECK(output[0]->equals(input->filter(matching_ids_0)));
-      CHECK(output[1]->equals(input->filter(matching_ids_1)));
-      CHECK(output[2]->equals(input->filter(matching_ids_2)));
+      CHECK(output[0]->equals(input->select(selected_ids_0)));
+      CHECK(output[1]->equals(input->select(selected_ids_1)));
+      CHECK(output[2]->equals(input->select(selected_ids_2)));
     }
 
     TEST_CASE("Merge works") {

--- a/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
+++ b/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
@@ -667,40 +667,6 @@ object CFunctionGeneration {
     )
   }
 
-  def renderProjection(
-    projection: VeProjection[
-      CVector,
-      Either[NamedStringExpression, NamedTypedCExpression]
-    ]
-  ): CFunction = CFunction(
-    inputs = projection.inputs,
-    outputs = projection.outputs.map {
-      case Right(NamedTypedCExpression(outname, veType, _)) =>
-        CScalarVector(outname, veType)
-      case Left(NamedStringExpression(outname, _)) =>
-        CVarChar(outname)
-    },
-    body = projection.outputs.map {
-      case Left(NamedStringExpression(outname, producer: FrovedisStringProducer)) =>
-        producer.produce(outname, "input_0->count", "i")
-
-      case Right(NamedTypedCExpression(outname, vetype, cexpr)) =>
-        CodeLines.scoped(s"Project onto ${outname}") {
-          CodeLines.from(
-            s"${outname}->resize(input_0->count);",
-            "#pragma _NEC vector",
-            CodeLines.forLoop("i", "input_0->count") {
-              List(
-                s"bool validity = ${cexpr.isNotNullCode.getOrElse("1")};",
-                s"$outname->data[i] = ${cexpr.cCode};",
-                s"$outname->set_validity(i, validity);"
-              )
-            }
-          )
-        }
-    }
-  )
-
   def renderInnerJoin(
     veInnerJoin: VeInnerJoin[CVector, TypedCExpression2, TypedCExpression2, NamedJoinExpression]
   ): CFunction = {

--- a/src/main/scala/com/nec/spark/agile/groupby/GroupByPartialGenerator.scala
+++ b/src/main/scala/com/nec/spark/agile/groupby/GroupByPartialGenerator.scala
@@ -75,7 +75,9 @@ final case class GroupByPartialGenerator(
     r: Either[StringReference, TypedCExpression2]
   ): CodeLines = r match {
     case Left(StringReference(sr)) =>
-      CodeLines.from(s"partial_str_${stagedProjection.name}->move_assign_from(${sr}->filter(matching_ids));")
+      CodeLines.from(
+        s"partial_str_${stagedProjection.name}->move_assign_from(${sr}->select(matching_ids));"
+      )
     case Right(TypedCExpression2(veType, cExpression)) =>
       CodeLines.from(
         GroupByOutline.initializeScalarVector(
@@ -150,7 +152,9 @@ final case class GroupByPartialGenerator(
         ProductionTriplet(
           init = CodeLines.empty,
           forEach = CodeLines.empty,
-          complete = CodeLines.from(s"partial_str_${groupingKey.name}->move_assign_from(${sr}->filter(matching_ids));")
+          complete = CodeLines.from(
+            s"partial_str_${groupingKey.name}->move_assign_from(${sr}->select(matching_ids));"
+          )
         )
     }
 

--- a/src/main/scala/com/nec/spark/agile/join/GenericJoiner.scala
+++ b/src/main/scala/com/nec/spark/agile/join/GenericJoiner.scala
@@ -36,10 +36,9 @@ final case class GenericJoiner(
       }.mkString(", ")});",
       s"const auto left_idx_std = left_idx.size_t_data_vec();",
       s"const auto right_idx_std = right_idx.size_t_data_vec();",
-      outputs.map {
-        case FilteredOutput(output, source) =>
-          val indicesName = if (inputsLeft.contains(source)) "left_idx_std" else "right_idx_std"
-          CodeLines.from(s"${output}->move_assign_from(${source.name}->filter(${indicesName}));")
+      outputs.map { case FilteredOutput(output, source) =>
+        val indicesName = if (inputsLeft.contains(source)) "left_idx_std" else "right_idx_std"
+        CodeLines.from(s"${output}->move_assign_from(${source.name}->select(${indicesName}));")
       }
     )
   )

--- a/src/main/scala/com/nec/ve/ProjectionFunction.scala
+++ b/src/main/scala/com/nec/ve/ProjectionFunction.scala
@@ -1,0 +1,91 @@
+package com.nec.ve
+
+import com.nec.spark.agile.CExpressionEvaluation.CodeLines
+import com.nec.spark.agile.CFunction2
+import com.nec.spark.agile.CFunction2.CFunctionArgument
+import com.nec.spark.agile.CFunctionGeneration.{
+  CScalarVector,
+  CVarChar,
+  CVector,
+  NamedStringExpression,
+  NamedTypedCExpression
+}
+import com.nec.spark.agile.StringProducer.FrovedisStringProducer
+
+case class ProjectionFunction(
+  name: String,
+  data: List[CVector],
+  expressions: List[Either[NamedStringExpression, NamedTypedCExpression]]
+) {
+  require(data.nonEmpty, "Expected Projection to have at least one data column")
+  require(expressions.nonEmpty, "Expected Projection to have at least one projection expression")
+
+  lazy val inputs: List[CVector] = {
+    data.map { vec => vec.withNewName(s"${vec.name}_m") }
+  }
+
+  lazy val outputs: List[CVector] = {
+    expressions.map {
+      case Right(NamedTypedCExpression(name, vetype, _)) =>
+        CScalarVector(name, vetype)
+
+      case Left(NamedStringExpression(name, _)) =>
+        CVarChar(name)
+    }
+  }
+
+  lazy val arguments: List[CFunction2.CFunctionArgument] = {
+    inputs.map(CFunctionArgument.PointerPointer(_)) ++
+      outputs.map { vec => CFunctionArgument.PointerPointer(vec.withNewName(s"${vec.name}_mo")) }
+  }
+
+  private[ve] def inputPtrDeclStmts: CodeLines = {
+    (data, inputs).zipped.map { case (dvec, ivec) =>
+      s"${dvec.declarePointer} = ${ivec.name}[0];"
+    }
+  }
+
+  private[ve] def outputPtrDeclStmts: CodeLines = {
+    outputs.map { ovec =>
+      CodeLines.from(
+        s"${ovec.declarePointer} = ${ovec.veType.cVectorType}::allocate();",
+        s"*${ovec.name}_mo = ${ovec.name};"
+      )
+    }
+  }
+
+  def projectionStmt(
+    expression: Either[NamedStringExpression, NamedTypedCExpression]
+  ): CodeLines = {
+    expression match {
+      case Left(NamedStringExpression(outname, producer: FrovedisStringProducer)) =>
+        producer.produce(outname, s"${data.head.name}->count", "i")
+
+      case Right(NamedTypedCExpression(outname, vetype, cexpr)) =>
+        CodeLines.scoped(s"Project onto ${outname}") {
+          CodeLines.from(
+            s"${outname}->resize(${data.head.name}->count);",
+            "#pragma _NEC vector",
+            CodeLines.forLoop("i", s"${data.head.name}->count") {
+              List(
+                s"bool validity = ${cexpr.isNotNullCode.getOrElse("1")};",
+                s"$outname->data[i] = ${cexpr.cCode};",
+                s"$outname->set_validity(i, validity);"
+              )
+            }
+          )
+        }
+    }
+  }
+
+  def render: CFunction2 = {
+    CFunction2(
+      arguments,
+      CodeLines.from(inputPtrDeclStmts, "", outputPtrDeclStmts, "", expressions.map(projectionStmt))
+    )
+  }
+
+  def toCodeLines: CodeLines = {
+    render.toCodeLines(name)
+  }
+}


### PR DESCRIPTION
Summary:

- Move `renderProjection()` over to a proper `ProjectionFunction` class abstraction
- Rename `nullable_T_vector::filter()` to `nullable_T_vector::select()` as the same function can be used for returning a `nullable_T_vector` of the same elements re-ordered.  Add unit tests to test this specific feature.  This will be used for the simplification of `renderSort()` in a subsequent PR
- Fix a small bug with code generation for joins, where both the left and right exchange functions have the same function name
- Run the periodic `scalafmt` cleanup