### PR TITLE
Replace std::max and std::min with MIN/MAX macros.

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
@@ -81,3 +81,6 @@ namespace cyclone {
     return stream << tmp.str();
   }
 }
+
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))

--- a/src/main/scala/com/nec/spark/agile/SparkExpressionToCExpression.scala
+++ b/src/main/scala/com/nec/spark/agile/SparkExpressionToCExpression.scala
@@ -22,31 +22,7 @@ package com.nec.spark.agile
 import com.nec.spark.agile.CFunctionGeneration._
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions.aggregate.NoOp
-import org.apache.spark.sql.catalyst.expressions.{
-  Alias,
-  Attribute,
-  AttributeReference,
-  BinaryOperator,
-  CaseWhen,
-  Cast,
-  Coalesce,
-  Divide,
-  ExprId,
-  Expression,
-  Greatest,
-  If,
-  IsNaN,
-  IsNotNull,
-  IsNull,
-  KnownFloatingPointNormalized,
-  Least,
-  Like,
-  Literal,
-  Not,
-  SortDirection,
-  Sqrt,
-  Year
-}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, BinaryOperator, CaseWhen, Cast, Coalesce, Divide, ExprId, Expression, Greatest, If, IsNaN, IsNotNull, IsNull, KnownFloatingPointNormalized, Least, Literal, Not, SortDirection, Sqrt, Year}
 import org.apache.spark.sql.catalyst.optimizer.NormalizeNaNAndZero
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -358,13 +334,13 @@ object SparkExpressionToCExpression {
         val fails = children.map(exp => eval(exp)).flatMap(_.left.toOption)
         fails.headOption.toLeft {
           val oks = children.map(exp => eval(exp)).flatMap(_.right.toOption)
-          FlatToNestedFunction.runWhenNotNull(items = oks.toList, function = "std::max")
+          FlatToNestedFunction.runWhenNotNull(items = oks.toList, function = "MAX")
         }
       case Least(children) =>
         val fails = children.map(exp => eval(exp)).flatMap(_.left.toOption)
         fails.headOption.toLeft {
           val oks = children.map(exp => eval(exp)).flatMap(_.right.toOption)
-          FlatToNestedFunction.runWhenNotNull(items = oks.toList, function = "std::min")
+          FlatToNestedFunction.runWhenNotNull(items = oks.toList, function = "MIN")
         }
       case Cast(child, IntegerType, _) =>
         eval(child).map { childExpression =>

--- a/src/test/scala/com/nec/spark/agile/FlatToNestedFunctionTest.scala
+++ b/src/test/scala/com/nec/spark/agile/FlatToNestedFunctionTest.scala
@@ -25,12 +25,12 @@ import org.scalatest.freespec.AnyFreeSpec
 final class FlatToNestedFunctionTest extends AnyFreeSpec {
   "It works for 3" in {
     assert(
-      FlatToNestedFunction.nest(Seq("a", "b", "c"), "std::max") == s"std::max(a, std::max(b, c))"
+      FlatToNestedFunction.nest(Seq("a", "b", "c"), "MAX") == s"MAX(a, MAX(b, c))"
     )
   }
 
   "It works for 2" in {
-    assert(FlatToNestedFunction.nest(Seq("a", "b"), "std::max") == s"std::max(a, b)")
+    assert(FlatToNestedFunction.nest(Seq("a", "b"), "MAX") == s"MAX(a, b)")
   }
 
   "In case of 2 items, it checks their nulls" in {
@@ -40,9 +40,9 @@ final class FlatToNestedFunctionTest extends AnyFreeSpec {
           CExpression(cCode = "a", isNotNullCode = Some("1")),
           CExpression(cCode = "b", isNotNullCode = Some("2"))
         ),
-        function = "std::max"
+        function = "MAX"
       ) == CExpression(
-        cCode = "(1 && 2) ? (std::max(a, b)) : (1 ? a : b)",
+        cCode = "(1 && 2) ? (MAX(a, b)) : (1 ? a : b)",
         isNotNullCode = Some("1 || 2")
       )
     )
@@ -54,8 +54,8 @@ final class FlatToNestedFunctionTest extends AnyFreeSpec {
           CExpression(cCode = "a", isNotNullCode = None),
           CExpression(cCode = "b", isNotNullCode = Some("2"))
         ),
-        function = "std::max"
-      ) == CExpression(cCode = "(2) ? (std::max(a, b)) : a", isNotNullCode = None)
+        function = "MAX"
+      ) == CExpression(cCode = "(2) ? (MAX(a, b)) : a", isNotNullCode = None)
     )
   }
 }


### PR DESCRIPTION
Fixes "Vectorization obstructive function reference.: max/min" messages.