### PR TITLE
reorganizes VERDD code and adds Filter (wip)

### DIFF
--- a/rddbench/src/main/scala/RDDBench.scala
+++ b/rddbench/src/main/scala/RDDBench.scala
@@ -17,7 +17,7 @@ object RDDBench {
 
     println("Making numbers")
     val numbers = (1 to (1000000)).toArray
-    val rdd = sc.parallelize(numbers).repartition(8)
+    val rdd = sc.parallelize(numbers).repartition(8).persist()
 
     println("Making VeRDD")
     val verdd = toVectorizedRDD(rdd)

--- a/src/main/scala/com/nec/arrow/colvector/BytePointerColVector.scala
+++ b/src/main/scala/com/nec/arrow/colvector/BytePointerColVector.scala
@@ -15,7 +15,7 @@ import org.apache.spark.sql.execution.vectorized.OffHeapColumnVector
 import org.apache.spark.sql.types.{IntegerType, StringType}
 import org.apache.spark.sql.util.ArrowUtilsExposed.RichSmallIntVector
 import org.apache.spark.sql.vectorized.ColumnVector
-import org.bytedeco.javacpp.{BytePointer, IntPointer, LongPointer}
+import org.bytedeco.javacpp.{BytePointer, DoublePointer, IntPointer, LongPointer, Pointer}
 
 import java.nio.ByteBuffer
 
@@ -289,5 +289,23 @@ object BytePointerColVector {
         variableSize = None
       )
     )
+
+    def fromPointer[T <: Pointer](pointer: T, validityBuffer: LongPointer)
+                                 (implicit source: VeColVectorSource): BytePointerColVector = {
+      BytePointerColVector(
+        GenericColVector(
+          source = source,
+          numItems = pointer.limit().toInt,
+          name = s"ip-${pointer.address()}",
+          veType = VeScalarType.veNullableInt,
+          container = None,
+          buffers = List(
+            Option(new BytePointer(pointer)),
+            Option(new BytePointer(validityBuffer))
+          ),
+          variableSize = None
+        )
+      )
+  }
 
 }

--- a/src/main/scala/com/nec/ve/FilteredVeRDD.scala
+++ b/src/main/scala/com/nec/ve/FilteredVeRDD.scala
@@ -1,0 +1,15 @@
+package com.nec.ve
+
+import com.nec.spark.agile.core.CFunction2
+import com.nec.spark.agile.CFunctionGeneration.CVector
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+
+class FilteredVeRDD[T: ClassTag](prev: VeRDD[T], func: CFunction2, soPath: String, outputs: List[CVector])
+  extends VeRDD[T](prev) {
+
+  // TODO: filter
+  override def getVectorData(): RDD[VeColBatch] = prev.getVectorData()
+
+}

--- a/src/main/scala/com/nec/ve/MappedVeRDD.scala
+++ b/src/main/scala/com/nec/ve/MappedVeRDD.scala
@@ -1,5 +1,6 @@
 package com.nec.ve
 
+import com.nec.native.CppTranspiler
 import com.nec.spark.SparkCycloneDriverPlugin
 import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
 import com.nec.spark.agile.CFunctionGeneration
@@ -7,129 +8,69 @@ import com.nec.spark.agile.CFunctionGeneration.CVector
 import com.nec.spark.agile.core.CFunction2
 import com.nec.spark.agile.core.CFunction2.CFunctionArgument.PointerPointer
 import com.nec.spark.agile.core.CFunction2.DefaultHeaders
-import org.apache.arrow.memory.RootAllocator
-import org.apache.arrow.vector.IntVector
+import org.apache.spark.rdd.RDD
 
 import java.nio.file.Paths
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
-class MappedVeRDD(rdd: VeRDD[Int], func: CFunction2, soPath: String, outputs: List[CVector]) extends VeRDD[Int](rdd) {
-  def vereduce[U:ClassTag](expr: Expr[(Int, Int) => Int]): Int = {
-    println("vereduce got expr: " + showRaw(expr.tree))
+//class MappedVeRDD(prev: VeRDD[Int], func: CFunction2, soPath: String, outputs: List[CVector]) extends VeRDD[Int](prev) {
+
+class MappedVeRDD[T: ClassTag](prev: VeRDD[T], expr: Expr[T => T]) extends VeRDD[T](prev) {
+  @transient val transpiler: CppTranspiler.type = CppTranspiler
+
+  @Override
+  def getVectorData(): RDD[VeColBatch] = {
+
+    val start1 = System.nanoTime()
+
+    // TODO: calculate only as needed, cache
+
+    // TODO: for inspection, remove when done
+    println("vemap got expr: " + showRaw(expr.tree))
+
+    // TODO: Get AST (Expr) from symbol table, when necessary
+    // val expr = ...
 
     // transpile f to C
-    val code = transpiler.transpileReduce(expr)
-    val funcName = s"reduce_${Math.abs(code.hashCode())}"
+    val code = transpiler.transpile(expr)
+    val funcName = s"eval_${Math.abs(code.hashCode())}"
 
-    val newOutputs = List(CVector("out", CFunctionGeneration.VeScalarType.veNullableInt))
-    val newFunc = new CFunction2(
+    val outputs = List(CVector("out", CFunctionGeneration.VeScalarType.veNullableInt))
+    val func = new CFunction2(
       funcName,
       Seq(
-        PointerPointer(CVector("a_in", CFunctionGeneration.VeScalarType.veNullableInt)),
-        PointerPointer(newOutputs.head)
+        PointerPointer(CVector("a_in", CFunctionGeneration.VeScalarType.veNullableInt)), // TODO: More types
+        PointerPointer(outputs.head)
       ),
       code,
       DefaultHeaders
     )
 
-    println(s"Generated code:\n${newFunc.toCodeLinesWithHeaders.cCode}")
+    println(s"Generated code:\n${func.toCodeLinesWithHeaders.cCode}")
 
     // compile
-    val newCompiledPath = SparkCycloneDriverPlugin.currentCompiler.forCode(newFunc.toCodeLinesWithHeaders).toAbsolutePath.toString
-    println("compiled path:" + newCompiledPath)
+    val compiledPath = SparkCycloneDriverPlugin.currentCompiler.forCode(func.toCodeLinesWithHeaders)
+    println("compiled path:" + compiledPath)
 
-    val start1 = System.nanoTime()
+    // Call compiled
+    val results = prev.getVectorData().mapPartitions { inputIterator =>
 
-    val results = rdd.inputs.mapPartitions { inputIterator =>
-      //val start3 = System.nanoTime()
       import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
 
-      println("a")
-      val libRef = veProcess.loadLibrary(Paths.get(soPath))
+      val libRef = veProcess.loadLibrary(compiledPath)
       val batches = inputIterator.toList
       val iter = batches.map { batch =>
         evalFunction(func, libRef, batch.cols, outputs)
       }
-      println("b")
 
-      val newLibRef = veProcess.loadLibrary(Paths.get(newCompiledPath))
-
-      val iter2 = iter.map { batch =>
-        evalFunction(newFunc, newLibRef, batch.cols, newOutputs)
-      }
-      println("c")
-
-      //val end3 = System.nanoTime()
-      //println(s"reducing... took ${(end3 - start3) / 1000000000.0}s ")
-      iter2.toIterator
-    }
-
-    val end1 = System.nanoTime()
-
-    println(s"reduce evalFunction took ${(end1 - start1) / 1000000000.0}s")
-
-    results.mapPartitions { veColBatch =>
-      val start4 = System.nanoTime()
-
-      implicit val allocator: RootAllocator = new RootAllocator(Int.MaxValue)
-
-      val batches = veColBatch.toList
-      val r = batches.flatMap(_.cols).flatMap { veColVector =>
-        val intVec = veColVector.toArrowVector().asInstanceOf[IntVector]
-        val ids = (0 until intVec.getValueCount)
-        ids.map(intVec.get).toList
-      }
-      val end4 = System.nanoTime()
-      println(s"resultsing took ${(end4 - start4) / 1000000000.0}")
-      r.toIterator
-    }.collect().sum
-  }
-
-  override def reduce(f: (Int, Int) => Int): Int = {
-
-    val start1 = System.nanoTime()
-
-    val results = rdd.inputs.mapPartitions { inputIterator =>
-      //val start3 = System.nanoTime()
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
-
-      val libRef = veProcess.loadLibrary(Paths.get(soPath))
-      val batches = inputIterator.toList
-      val iter = batches.map { batch =>
-        evalFunction(func, libRef, batch.cols, outputs)
-      }
-      //val end3 = System.nanoTime()
-      //println(s"reducing... took ${(end3 - start3) / 1000000000.0}s ")
       iter.toIterator
     }
 
     val end1 = System.nanoTime()
 
-    println(s"evalFunction took ${(end1 - start1) / 1000000000.0}s")
+    println(s"MappedVeRDD.getVectorData took ${(end1 - start1) / 1000000000.0}s")
 
-    val start2 = System.nanoTime()
-
-    val out2 = results.mapPartitions { veColBatch =>
-      val start4 = System.nanoTime()
-
-      implicit val allocator: RootAllocator = new RootAllocator(Int.MaxValue)
-
-      val batches = veColBatch.toList
-      val r = batches.flatMap(_.cols).flatMap { veColVector =>
-        val intVec = veColVector.toArrowVector().asInstanceOf[IntVector]
-        val ids = (0 until intVec.getValueCount)
-        ids.map(intVec.get).toList
-      }
-      val end4 = System.nanoTime()
-      println(s"resultsing took ${(end4 - start4) / 1000000000.0}")
-      r.toIterator
-    }.reduce(f)
-
-    val end2 = System.nanoTime()
-
-    println(s"results.map took ${(end2 - start2) / 1000000000.0}s")
-
-    out2
+    results
   }
 }

--- a/src/main/scala/com/nec/ve/MappedVeRDD.scala
+++ b/src/main/scala/com/nec/ve/MappedVeRDD.scala
@@ -17,7 +17,6 @@ import scala.reflect.runtime.universe._
 //class MappedVeRDD(prev: VeRDD[Int], func: CFunction2, soPath: String, outputs: List[CVector]) extends VeRDD[Int](prev) {
 
 class MappedVeRDD[T: ClassTag](prev: VeRDD[T], expr: Expr[T => T]) extends VeRDD[T](prev) {
-  @transient val transpiler: CppTranspiler.type = CppTranspiler
 
   @Override
   def getVectorData(): RDD[VeColBatch] = {

--- a/src/main/scala/com/nec/ve/VeRDD.scala
+++ b/src/main/scala/com/nec/ve/VeRDD.scala
@@ -3,6 +3,7 @@ package com.nec.ve
 import com.nec.native.CppTranspiler
 import com.nec.spark.SparkCycloneDriverPlugin
 import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics.processMetrics
+import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
 import com.nec.spark.agile.CFunctionGeneration
 import com.nec.spark.agile.CFunctionGeneration.CVector
 import com.nec.spark.agile.core.CFunction2
@@ -10,6 +11,8 @@ import com.nec.spark.agile.core.CFunction2.CFunctionArgument.PointerPointer
 import com.nec.spark.agile.core.CFunction2.DefaultHeaders
 import com.nec.ve.VeProcess.{LibraryReference, OriginalCallingContext}
 import com.nec.ve.colvector.VeColVector
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.IntVector
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.{Partition, TaskContext}
@@ -21,17 +24,17 @@ import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
-class VeRDD[T: ClassTag](rdd: RDD[T]) extends RDD[T](rdd) {
-  @transient val transpiler: CppTranspiler.type = CppTranspiler
+class VectorizedRDD[T: ClassTag](prev: RDD[T]) extends VeRDD[T](prev) {
 
-  val inputs: RDD[VeColBatch] = rdd.mapPartitions { valsIter =>
+  val inputs: RDD[VeColBatch] = prev.mapPartitions { valsIter =>
     println("Reading inputs")
     val start = System.nanoTime()
     import com.nec.spark.SparkCycloneExecutorPlugin._
     import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
 
-    val vals = valsIter.toArray.asInstanceOf[Array[Int]]
+    val vals = valsIter.toArray.asInstanceOf[Array[T]]
     val len = vals.length
+
     val intVec = new IntPointer(len.asInstanceOf[Long])
     intVec.put(vals, 0, vals.length)
 
@@ -49,6 +52,29 @@ class VeRDD[T: ClassTag](rdd: RDD[T]) extends RDD[T](rdd) {
   }.persist(StorageLevel.MEMORY_ONLY)
   val inputCount: Long = inputs.count()
 
+  @Override
+  def getVectorData(): RDD[VeColBatch] = inputs
+
+}
+
+
+abstract class VeRDD[T: ClassTag](prev: VeRDD[T]) extends RDD[T](prev) {
+  @transient val transpiler: CppTranspiler.type = CppTranspiler
+
+
+  // subclasses need to implement this
+  // this (along with other operations) is where calculations on the VE are triggered
+  def getVectorData(): RDD[VeColBatch]
+
+
+  // first step of every vectorized
+  def vectorize() = new VectorizedRDD(this)
+
+  def vemap[U:ClassTag](expr: Expr[T => T]): MappedVeRDD[T] = {
+    new MappedVeRDD(this, expr)
+  }
+
+  /*
   def vemap[U:ClassTag](expr: Expr[T => T]): MappedVeRDD = {
     import scala.reflect.runtime.universe._
 
@@ -83,10 +109,15 @@ class VeRDD[T: ClassTag](rdd: RDD[T]) extends RDD[T](rdd) {
     new MappedVeRDD(this.asInstanceOf[RDD[Int]], func, compiledPath.toAbsolutePath.toString, outputs)
   }
 
+
+   */
+
+
+
   override def collect(): Array[T] = super.collect()
 
   override def compute(split: Partition, context: TaskContext): Iterator[T] = {
-    rdd.compute(split, context)
+    prev.compute(split, context)
   }
 
   case class VePartition(idx: Int) extends Partition {
@@ -95,7 +126,7 @@ class VeRDD[T: ClassTag](rdd: RDD[T]) extends RDD[T](rdd) {
 
   override protected def getPartitions: Array[Partition] = {
     //(0 until 8).map(i => VePartition(i)).toArray
-    rdd.partitions
+    prev.partitions
   }
 
   def withCompiled[U](cCode: String)(f: Path => U): U = {
@@ -105,15 +136,86 @@ class VeRDD[T: ClassTag](rdd: RDD[T]) extends RDD[T](rdd) {
     f(oPath)
   }
 
-
   def evalFunction(func: CFunction2, libRef: LibraryReference, inputs: List[VeColVector], outVectors: List[CVector])(implicit ctx: OriginalCallingContext): VeColBatch = {
     import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
 
     VeColBatch.fromList(veProcess.execute(libRef, func.name, inputs, outVectors))
   }
+
+  // Operations, trigger calculation
+  def vereduce[U:ClassTag](expr: Expr[(Int, Int) => Int]): Int = {
+
+    println("vereduce got expr: " + showRaw(expr.tree))
+
+    // transpile f to C
+    val code = transpiler.transpileReduce(expr)
+    val funcName = s"reduce_${Math.abs(code.hashCode())}"
+
+    val newOutputs = List(CVector("out", CFunctionGeneration.VeScalarType.veNullableInt))
+    val newFunc = new CFunction2(
+      funcName,
+      Seq(
+        PointerPointer(CVector("a_in", CFunctionGeneration.VeScalarType.veNullableInt)),
+        PointerPointer(newOutputs.head)
+      ),
+      code,
+      DefaultHeaders
+    )
+
+    println(s"Generated code:\n${newFunc.toCodeLinesWithHeaders.cCode}")
+
+    // compile
+    val newCompiledPath = SparkCycloneDriverPlugin.currentCompiler.forCode(newFunc.toCodeLinesWithHeaders).toAbsolutePath.toString
+    println("compiled path:" + newCompiledPath)
+
+    val start1 = System.nanoTime()
+
+    prev.getVectorData().mapPartitions { veColBatch =>
+      val start4 = System.nanoTime()
+
+      implicit val allocator: RootAllocator = new RootAllocator(Int.MaxValue)
+
+      val batches = veColBatch.toList
+      val r = batches.flatMap(_.cols).flatMap { veColVector =>
+        val intVec = veColVector.toArrowVector().asInstanceOf[IntVector]
+        val ids = (0 until intVec.getValueCount)
+        ids.map(intVec.get).toList
+      }
+      val end4 = System.nanoTime()
+      println(s"resultsing took ${(end4 - start4) / 1000000000.0}")
+      r.toIterator
+    }.collect().sum
+  }
+
+  override def reduce[T](f: (T, T) => T): T = {
+
+    val start2 = System.nanoTime()
+
+    val out2 = prev.getVectorData().mapPartitions { veColBatch =>
+      val start4 = System.nanoTime()
+
+      implicit val allocator: RootAllocator = new RootAllocator(Int.MaxValue)
+
+      val batches = veColBatch.toList
+      val r = batches.flatMap(_.cols).flatMap { veColVector =>
+        val intVec = veColVector.toArrowVector().asInstanceOf[IntVector]
+        val ids = (0 until intVec.getValueCount)
+        ids.map(intVec.get).toList
+      }
+      val end4 = System.nanoTime()
+      println(s"resultsing took ${(end4 - start4) / 1000000000.0}")
+      r.toIterator
+    }.reduce(f)
+
+    val end2 = System.nanoTime()
+
+    println(s"results.map took ${(end2 - start2) / 1000000000.0}s")
+
+    out2
+  }
 }
 
 // implicit conversion
 object VeRDD {
-  implicit def toVectorizedRDD[T: ClassTag](r: RDD[T]): VeRDD[T] = new VeRDD(r)
+  implicit def toVectorizedRDD[T: ClassTag](r: RDD[T]): VeRDD[T] = new VectorizedRDD[T](r)
 }

--- a/src/main/scala/com/nec/ve/colvector/VeColVector.scala
+++ b/src/main/scala/com/nec/ve/colvector/VeColVector.scala
@@ -12,7 +12,7 @@ import com.nec.ve.{VeProcess, VeProcessMetrics}
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector._
 import org.apache.spark.sql.vectorized.ColumnVector
-import org.bytedeco.javacpp.{BytePointer, IntPointer, LongPointer}
+import org.bytedeco.javacpp.{BytePointer, IntPointer, LongPointer, Pointer}
 import sun.misc.Unsafe
 
 import java.io.OutputStream
@@ -188,18 +188,19 @@ object VeColVector {
       .fromArrowVector(valueVector)
       .toVeColVector()
 
-  def fromPointer(pointer: IntPointer)(implicit
-    veProcess: VeProcess,
-    source: VeColVectorSource,
-    originalCallingContext: OriginalCallingContext,
-    cycloneMetrics: VeProcessMetrics
+
+  def fromPointer(pointer: Pointer)(implicit
+                                       veProcess: VeProcess,
+                                       source: VeColVectorSource,
+                                       originalCallingContext: OriginalCallingContext,
+                                       cycloneMetrics: VeProcessMetrics
   ): VeColVector = {
     val size = Math.ceil(pointer.limit() / 64).toLong
     val lp = new LongPointer(size.toLong)
     for (i <- 0 until size.toInt) {
       lp.put(i, -1)
     }
-    BytePointerColVector.fromIntPointer(pointer, lp)
+    BytePointerColVector.fromPointer(pointer, lp)
       .toVeColVector()
   }
 }


### PR DESCRIPTION
SparkCyclone/src/main/scala/com/nec/ve/VeRDD.scala:39:12: overloaded method value put with alternatives:
[error]   (x$1: Array[Int],x$2: Int,x$3: Int)org.bytedeco.javacpp.IntPointer <and>
[error]   (x$1: Int*)org.bytedeco.javacpp.IntPointer
[error]  cannot be applied to (Array[T], Int, Int)
[error]     intVec.put(vals, 0, vals.length)
[error]            ^
[error] /home/marko/customers/XpressAI/SparkCyclone/src/main/scala/com/nec/ve/VeRDD.scala:208:14: type mismatch;
[error]  found   : (T, T) => T
[error]  required: (Int, Int) => Int
[error]     }.reduce(f)
[error]              ^
