### PR TITLE
Very basic support for `RDD[Instant]`

### DIFF
--- a/src/main/scala/com/nec/util/DateTimeOps.scala
+++ b/src/main/scala/com/nec/util/DateTimeOps.scala
@@ -1,0 +1,22 @@
+package com.nec.util
+
+import scala.math.Ordered
+import java.time.Instant
+
+object DateTimeOps {
+  object ExtendedInstant {
+    def fromFrovedisDateTime(x: Long): Instant = {
+      Instant.ofEpochSecond((x / 1000000000).toLong, (x % 1000000000).toLong)
+    }
+  }
+
+  implicit class ExtendedInstant(val x: Instant) extends Ordered[ExtendedInstant] {
+    def toFrovedisDateTime: Long = {
+      x.getEpochSecond * 1000000000 + x.getNano.toLong
+    }
+
+    def compare(other: ExtendedInstant): Int = {
+      x.compareTo(other.x)
+    }
+  }
+}

--- a/src/main/scala/com/nec/ve/VeRDD.scala
+++ b/src/main/scala/com/nec/ve/VeRDD.scala
@@ -419,12 +419,13 @@ abstract class ChainedVeRDD[T](
       SparkExpressionToCExpression.sparkTypeToVeType(IntegerType)
     } else if (klass == classOf[Long]) {
       SparkExpressionToCExpression.sparkTypeToVeType(LongType)
+    } else if (klass == classOf[Instant]) {
+      SparkExpressionToCExpression.sparkTypeToVeType(LongType)
     } else if (klass == classOf[Float]) {
       SparkExpressionToCExpression.sparkTypeToVeType(FloatType)
     } else {
       SparkExpressionToCExpression.sparkTypeToVeType(DoubleType)
     }
-
 
     val outputs = List(CVector("out", dataType))
     val func = new CFunction2(


### PR DESCRIPTION
Summary:

- Add basic support to the transpiler for parsing `java.time.Instant`s and supporting `compareTo` between two `Instant`s.  This does NOT support transpilation of more advanced features such as calling on methods of `Instant` to extract the epoch milliseconds for example.
- Add support for converting `RDD[Instant]` to `VeRDD[Instant]`
- Update the existing transpiler unit tests to pass
- Add example benchmark query to test `RDD[Instant]`
- Clean up the existing benchmark code