### PR TITLE
Add support for VeColBatch to Tuple conversion

### DIFF
--- a/rddbench/src/main/scala/RDDBench.scala
+++ b/rddbench/src/main/scala/RDDBench.scala
@@ -10,16 +10,16 @@ object RDDBench {
 
   def checkRuns(sc: SparkContext): Unit = {
     println("Making VeRDD[Long]")
-    val numbers = (1L to (5 * 1000000))
+    val numbers = (1L to (1 * 1000))
 
     val start2 = System.nanoTime()
     val verdd = sc.veParallelize(numbers)
     benchmark("checkRuns - VE ") {
       verdd
-        .vemap(reify {(a: Long) => (3 * a)})
-        .vegroupBy(reify {(a: Long) => a % 8})
+        .vemap(reify {(a: Long) => (3 * a, a * 2)})
         .toRDD
-        .count()
+        .collect()
+        .mkString(", ")
     }
     val verddCount = verdd.count()
     val end2 = System.nanoTime()

--- a/src/main/scala/com/nec/ve/FilteredVeRDD.scala
+++ b/src/main/scala/com/nec/ve/FilteredVeRDD.scala
@@ -4,9 +4,9 @@ import com.nec.native.CompiledVeFunction
 
 import scala.language.experimental.macros
 import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
 
-class FilteredVeRDD[T: ClassTag](
+class FilteredVeRDD[T: ClassTag: TypeTag](
   rdd: VeRDD[T],
   func: CompiledVeFunction) extends ChainedVeRDD[T](rdd, func) {
 }
-

--- a/src/main/scala/com/nec/ve/MappedVeRDD.scala
+++ b/src/main/scala/com/nec/ve/MappedVeRDD.scala
@@ -3,9 +3,9 @@ package com.nec.ve
 import com.nec.native.CompiledVeFunction
 
 import scala.language.experimental.macros
-import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
 
-class MappedVeRDD[U: ClassTag, T: ClassTag](
+class MappedVeRDD[U: TypeTag, T: TypeTag](
   rdd: VeRDD[T],
   func: CompiledVeFunction,
 ) extends ChainedVeRDD[U](rdd, func) {}

--- a/src/main/scala/com/nec/ve/VeConcatGroups.scala
+++ b/src/main/scala/com/nec/ve/VeConcatGroups.scala
@@ -1,37 +1,31 @@
 package com.nec.ve
 
 import com.nec.native.CompiledVeFunction
-import com.nec.spark.agile.SparkExpressionToCExpression
 import com.nec.spark.agile.merge.MergeFunction
-import com.nec.util.DateTimeOps.ExtendedInstant
 import com.nec.ve.colvector.VeColBatch.{VeBatchOfBatches, VeColVector}
-import org.apache.arrow.memory.RootAllocator
 import org.apache.spark.rdd.{RDD, ShuffledRDD}
-import org.apache.spark.sql.types.{DoubleType, FloatType, IntegerType, LongType}
 import org.apache.spark.{Partition, TaskContext}
 
-import java.time.Instant
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe
 
-class VeConcatGroups[K: ClassTag, T: ClassTag](
+class VeConcatGroups[K: universe.TypeTag, T: universe.TypeTag](
   shuffled: ShuffledRDD[K, VeColBatch, VeColBatch]
-)(implicit val tag: ClassTag[(K, Iterable[T])]) extends RDD[(K, Iterable[T])](shuffled) with VeRDD[(K, Iterable[T])] {
+)(implicit val typeTag: universe.TypeTag[(K, Iterable[T])]) extends RDD[(K, Iterable[T])](shuffled)(ClassTag(typeTag.mirror.runtimeClass(typeTag.tpe))) with VeRDD[(K, Iterable[T])] {
   override val inputs: RDD[VeColBatch] = null
   val concatInputs: RDD[(K, VeColBatch)] = computeMergeVe()
 
   override def compute(split: Partition, context: TaskContext): Iterator[(K, Iterable[T])] = {
     val batches = concatInputs.iterator(split, context)
     batches.map { case (key, veColBatch) =>
-      val array = veColBatch.toArray[T](0)
-      (key, array.toSeq)
+      (key, veColBatch.toCPUSeq[T]())
     }
   }
 
   override protected def getPartitions: Array[Partition] = concatInputs.partitions
 
   def computeMergeVe(): RDD[(K, VeColBatch)] = {
-    val dataType = veType(implicitly[ClassTag[T]])
+    val dataType = veType(ClassTag(typeTag.mirror.runtimeClass(typeTag.tpe)))
 
     val funcName = s"merge_${dataType.toString}_2"
     val code = MergeFunction(funcName, List(dataType))
@@ -55,13 +49,13 @@ class VeConcatGroups[K: ClassTag, T: ClassTag](
   def toRDD: RDD[(K, Iterable[T])] = {
     concatInputs.mapPartitions { batches =>
       batches.map { case (key, veColBatch) =>
-        val array = veColBatch.toArray[T](0)
-        (key, array.toSeq)
+        val array = veColBatch.toCPUSeq[T]()
+        (key, array)
       }
     }
   }
 
-  override def vemap[U: ClassTag](expr: universe.Expr[((K, Iterable[T])) => U]): VeRDD[U] = ???
+  override def vemap[U: universe.TypeTag](expr: universe.Expr[((K, Iterable[T])) => U]): VeRDD[U] = ???
 
   //override def veflatMap[U: ClassTag](expr: universe.Expr[((K, Iterable[T])) => TraversableOnce[U]]): VeRDD[U] = ???
 
@@ -69,7 +63,7 @@ class VeConcatGroups[K: ClassTag, T: ClassTag](
 
   override def vereduce(expr: universe.Expr[((K, Iterable[T]), (K, Iterable[T])) => (K, Iterable[T])]): (K, Iterable[T]) = ???
 
-  override def vegroupBy[G](expr: universe.Expr[((K, Iterable[T])) => G]): VeRDD[(G, Iterable[(K, Iterable[T])])] = ???
+  override def vegroupBy[G: universe.TypeTag](expr: universe.Expr[((K, Iterable[T])) => G]): VeRDD[(G, Iterable[(K, Iterable[T])])] = ???
 
   override def vesortBy[G](expr: universe.Expr[((K, Iterable[T])) => G], ascending: Boolean, numPartitions: Int): VeRDD[(K, Iterable[T])] = ???
 }

--- a/src/main/scala/com/nec/ve/VeConcatRDD.scala
+++ b/src/main/scala/com/nec/ve/VeConcatRDD.scala
@@ -5,9 +5,9 @@ import com.nec.ve.colvector.VeColBatch.VeBatchOfBatches
 import org.apache.spark.rdd.RDD
 
 import scala.language.experimental.macros
-import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
 
-class VeConcatRDD[U: ClassTag, T: ClassTag](
+class VeConcatRDD[U: TypeTag, T: TypeTag](
   rdd: VeRDD[T],
   func: CompiledVeFunction,
 ) extends MappedVeRDD[U, T](rdd, func) {

--- a/src/main/scala/com/nec/ve/VeGroupByRDD.scala
+++ b/src/main/scala/com/nec/ve/VeGroupByRDD.scala
@@ -11,8 +11,8 @@ import scala.reflect.runtime.universe
 class VeGroupByRDD[G, T](
   verdd: VeRDD[T],
   func: CompiledVeFunction
-)(override implicit val tag: ClassTag[(G, VeColBatch)])
-  extends RDD[(G, VeColBatch)](verdd)
+)(override implicit val typeTag: universe.TypeTag[(G, VeColBatch)])
+  extends RDD[(G, VeColBatch)](verdd)(ClassTag(typeTag.mirror.runtimeClass(typeTag.tpe)))
     with VeRDD[(G, VeColBatch)] {
 
   override val inputs: RDD[VeColBatch] = null
@@ -38,7 +38,7 @@ class VeGroupByRDD[G, T](
     }
   }
 
-  override def vemap[U: ClassTag](expr: universe.Expr[((G, VeColBatch)) => U]): VeRDD[U] = ???
+  override def vemap[U: universe.TypeTag](expr: universe.Expr[((G, VeColBatch)) => U]): VeRDD[U] = ???
 
   override def vefilter(expr: universe.Expr[((G, VeColBatch)) => Boolean]): VeRDD[(G, VeColBatch)] = ???
 
@@ -46,7 +46,7 @@ class VeGroupByRDD[G, T](
 
   override def toRDD: RDD[(G, VeColBatch)] = keyedInputs
 
-  override def vegroupBy[K](expr: universe.Expr[((G, VeColBatch)) => K]): VeRDD[(K, Iterable[(G, VeColBatch)])] = ???
+  override def vegroupBy[K: universe.TypeTag](expr: universe.Expr[((G, VeColBatch)) => K]): VeRDD[(K, Iterable[(G, VeColBatch)])] = ???
 
   override def vesortBy[K](expr: universe.Expr[((G, VeColBatch)) => K], ascending: Boolean, numPartitions: Int): VeRDD[(G, VeColBatch)] = ???
 }

--- a/src/main/scala/com/nec/ve/colvector/VeColBatch.scala
+++ b/src/main/scala/com/nec/ve/colvector/VeColBatch.scala
@@ -1,25 +1,64 @@
 package com.nec.ve.colvector
 
-import com.nec.arrow.colvector.{GenericColBatch, UnitColBatch, UnitColVector}
 import com.nec.arrow.colvector.ArrowVectorConversions._
 import com.nec.arrow.colvector.SparkSqlColumnVectorConversions._
+import com.nec.arrow.colvector.{GenericColBatch, UnitColBatch, UnitColVector}
 import com.nec.spark.agile.core.VeType
-import com.nec.util.DateTimeOps
 import com.nec.util.DateTimeOps.ExtendedInstant
 import com.nec.ve
-import com.nec.ve.{VeProcess, VeProcessMetrics}
 import com.nec.ve.VeProcess.OriginalCallingContext
 import com.nec.ve.colvector.VeColBatch.VeColVectorSource
+import com.nec.ve.{VeProcess, VeProcessMetrics}
 import org.apache.arrow.memory.{BufferAllocator, RootAllocator}
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
 
 import java.io._
 import java.time.Instant
 import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
 import scala.util.Try
 
 //noinspection AccessorLikeMethodIsEmptyParen
 final case class VeColBatch(underlying: GenericColBatch[VeColVector]) {
+  def toCPUSeq[T: TypeTag](): Seq[T] = {
+    val tag = implicitly[TypeTag[T]]
+    tag.tpe.asInstanceOf[TypeRef].args match {
+      case Nil => toArray[T](0)(ClassTag(tag.mirror.runtimeClass(tag.tpe))).toSeq
+      case args => args.zipWithIndex.map { case (t, idx) =>
+          toArray(idx)(ClassTag(tag.mirror.runtimeClass(t))).toSeq
+        }.transpose.map { r =>
+          val size = r.size
+          if(r.isEmpty || size > 22){
+            throw new IllegalArgumentException(s"Can not create tuple with size ${size}")
+          }
+          size match {
+            case 1 => Tuple1(r.head)
+            case 2 => (r(0), r(1))
+            case 3 => (r(0), r(1), r(2))
+            case 4 => (r(0), r(1), r(2), r(3))
+            case 5 => (r(0), r(1), r(2), r(3), r(4))
+            case 6 => (r(0), r(1), r(2), r(3), r(4), r(5))
+            case 7 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6))
+            case 8 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7))
+            case 9 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8))
+            case 10 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8), r(9))
+            case 11 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8), r(9), r(10))
+            case 12 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8), r(9), r(10), r(11))
+            case 13 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8), r(9), r(10), r(11), r(12))
+            case 14 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8), r(9), r(10), r(11), r(12), r(13))
+            case 15 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8), r(9), r(10), r(11), r(12), r(13), r(14))
+            case 16 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8), r(9), r(10), r(11), r(12), r(13), r(14), r(15))
+            case 17 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8), r(9), r(10), r(11), r(12), r(13), r(14), r(15), r(16))
+            case 18 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8), r(9), r(10), r(11), r(12), r(13), r(14), r(15), r(16), r(17))
+            case 19 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8), r(9), r(10), r(11), r(12), r(13), r(14), r(15), r(16), r(17), r(18))
+            case 20 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8), r(9), r(10), r(11), r(12), r(13), r(14), r(15), r(16), r(17), r(18), r(19))
+            case 21 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8), r(9), r(10), r(11), r(12), r(13), r(14), r(15), r(16), r(17), r(18), r(19), r(20))
+            case 22 => (r(0), r(1), r(2), r(3), r(4), r(5), r(6), r(7), r(8), r(9), r(10), r(11), r(12), r(13), r(14), r(15), r(16), r(17), r(18), r(19), r(20), r(21))
+          }
+        }.asInstanceOf[Seq[T]]
+    }
+  }
+
   def toArray[T: ClassTag](colIdx: Int): Array[T] = {
     import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
     implicit val allocator: RootAllocator = new RootAllocator(Int.MaxValue)


### PR DESCRIPTION
At the interface level we pretend to work on tuples. This in turn means that we need to turn the column vectors back into tuples when we go from VeRDD to regular RDD based execution.

Unfortunately, ClassTag doesn't appear to hold the necessary information for us to know exactly what types are necessary for the tuple conversion. For this reason we move to using TypeTag instead of ClassTag where ever possible.