### PR TITLE
Prime Compiler ToolBox on Creation

### DIFF
--- a/src/main/scala/com/nec/native/CompilerToolBox.scala
+++ b/src/main/scala/com/nec/native/CompilerToolBox.scala
@@ -1,0 +1,21 @@
+package com.nec.native
+
+import scala.reflect.runtime.universe.reify
+import scala.reflect.runtime.{universe, currentMirror => cm}
+import scala.tools.reflect.ToolBox
+
+/**
+ * The toolbox is somewhat stateful. Depending on the very first expression it
+ * typechecks, some fundamental types (e.g. Int, Long, etc.) will either be
+ * comparable with =:= or not.
+ *
+ * For this reason we make one single primed toolbox available for use
+ * everywhere.
+ */
+object CompilerToolBox {
+  private val toolbox = cm.mkToolBox()
+  toolbox.typecheck(reify{a: Long => a}.tree)
+
+  def get: ToolBox[universe.type] = toolbox
+
+}

--- a/src/main/scala/com/nec/native/CppTranspiler.scala
+++ b/src/main/scala/com/nec/native/CppTranspiler.scala
@@ -1,20 +1,19 @@
 package com.nec.native
 
+import com.nec.native.SyntaxTreeOps._
 import com.nec.spark.agile.SparkExpressionToCExpression
 import com.nec.spark.agile.core.CFunction2.CFunctionArgument.{PointerPointer, Raw}
 import com.nec.spark.agile.core.CFunction2.DefaultHeaders
 import com.nec.spark.agile.core.{CFunction2, CVector, CodeLines, VeType}
 import com.nec.util.DateTimeOps._
-import com.nec.native.SyntaxTreeOps._
 import org.apache.spark.sql.types.{DoubleType, FloatType, IntegerType, LongType}
 
 import java.time.Instant
+import scala.reflect.runtime.universe
 import scala.reflect.runtime.universe._
-import scala.reflect.runtime.{universe, currentMirror => cm}
-import scala.tools.reflect.ToolBox
 
 object CppTranspiler {
-  private val toolbox = cm.mkToolBox()
+  private val toolbox = CompilerToolBox.get
 
   def transpileGroupBy[T, K](expr: universe.Expr[T => K]): CompiledVeFunction = {
     val resultType = expr.staticType.typeArgs.last
@@ -549,4 +548,3 @@ object CppTranspiler {
     }
   }
 }
-

--- a/src/main/scala/com/nec/native/FunctionReformatter.scala
+++ b/src/main/scala/com/nec/native/FunctionReformatter.scala
@@ -1,8 +1,8 @@
 package com.nec.native
 
 import com.nec.native.SyntaxTreeOps._
+
 import scala.reflect.runtime.universe._
-import scala.tools.reflect.ToolBox
 
 object FunctionReformatter {
   def flattenParams(func: Function): List[ValDef] = {
@@ -47,7 +47,7 @@ object FunctionReformatter {
   }
 
   def reformatFunction[T, U](expr: Expr[T => U]): Function = {
-    val toolbox = expr.mirror.mkToolBox()
+    val toolbox = CompilerToolBox.get
 
     toolbox.typecheck(expr.tree) match {
       // NOTE: For now, this is always the case bc the method is type-constrained with T and U

--- a/src/main/scala/com/nec/native/FunctionTyping.scala
+++ b/src/main/scala/com/nec/native/FunctionTyping.scala
@@ -12,7 +12,7 @@ case class FunctionTyping[I, O](input: TypeContainer[I], output: TypeContainer[O
 
 object FunctionTyping {
   def fromExpression[I, O](expr: Expr[_]): FunctionTyping[I, O] = {
-    val toolbox = expr.mirror.mkToolBox()
+    val toolbox = CompilerToolBox.get
     toolbox.typecheck(expr.tree) match {
       case f: Function => {
         val input = extractTypes[I](f.vparams.head.tpt.tpe, toolbox)

--- a/src/main/scala/com/nec/ve/VeRDD.scala
+++ b/src/main/scala/com/nec/ve/VeRDD.scala
@@ -1,6 +1,6 @@
 package com.nec.ve
 
-import com.nec.native.{CompiledVeFunction, CppTranspiler}
+import com.nec.native.{CompiledVeFunction, CompilerToolBox, CppTranspiler}
 import com.nec.spark.agile.merge.MergeFunction
 import com.nec.util.DateTimeOps._
 import com.nec.ve.serializer.VeSerializer
@@ -15,8 +15,8 @@ import scala.language.experimental.macros
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.reflect.macros.whitebox
+import scala.reflect.runtime.universe
 import scala.reflect.runtime.universe._
-import scala.reflect.runtime.{currentMirror, universe}
 import scala.tools.reflect.ToolBox
 
 object VeRDD {
@@ -73,7 +73,7 @@ object VeRDD {
 trait VeRDD[T] extends RDD[T] {
   import VeRDD._
 
-  @transient protected val toolbox: ToolBox[universe.type] = currentMirror.mkToolBox()
+  @transient protected val toolbox: ToolBox[universe.type] = CompilerToolBox.get
 
   implicit val tag: ClassTag[T]
 


### PR DESCRIPTION
The toolbox is somewhat stateful. Depending on the very first expression it
typechecks, some fundamental types (e.g. Int, Long, etc.) will either be
comparable with =:= or not.

For this reason we make one single primed toolbox available for use
everywhere.

This fixes weird issues like reported in https://github.com/XpressAI/SparkCyclone/pull/548#issuecomment-1086913663

or like this:
```
java.lang.AssertionError: assertion failed: ofEpochSecond value ofEpochSecond <none>
[info]   at scala.reflect.internal.SymbolTable.throwAssertionError(SymbolTable.scala:184)
[info]   at scala.reflect.internal.Importers$StandardImporter.$anonfun$importSymbol$6(Importers.scala:208)
[info]   at scala.reflect.internal.Importers$StandardImporter.recreateOrRelink$1(Importers.scala:205)
[info]   at scala.reflect.internal.Importers$StandardImporter.importSymbol(Importers.scala:222)
[info]   at scala.reflect.internal.Importers$StandardImporter.recreatedTreeCompleter(Importers.scala:310)
[info]   at scala.reflect.internal.Importers$StandardImporter.$anonfun$importTree$1(Importers.scala:429)
[info]   at scala.reflect.internal.Importers$StandardImporter.tryFixup(Importers.scala:61)
[info]   at scala.reflect.internal.Importers$StandardImporter.importTree(Importers.scala:430)
[info]   at scala.reflect.internal.Importers$StandardImporter.recreateTree(Importers.scala:386)
[info]   at scala.reflect.internal.Importers$StandardImporter.importTree(Importers.scala:427)
```