### PR TITLE
[NS-10] Clean up `ByteArrayColVector` implementation

### DIFF
--- a/src/main/scala/com/nec/arrow/colvector/ArrayTConversions.scala
+++ b/src/main/scala/com/nec/arrow/colvector/ArrayTConversions.scala
@@ -57,7 +57,7 @@ object ArrayTConversions {
           container = None,
           buffers = List(
             Option(dataBuffer),
-            // Since T <: AnyVal, they are non-nullable
+            // Since T <: AnyVal, Array[T] is an array of non-nullable values
             Option(FixedBitSet.ones(input.size))
           ),
           variableSize = None

--- a/src/main/scala/com/nec/arrow/colvector/ByteArrayColBatch.scala
+++ b/src/main/scala/com/nec/arrow/colvector/ByteArrayColBatch.scala
@@ -4,7 +4,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 final case class ByteArrayColBatch(underlying: GenericColBatch[ByteArrayColVector]) {
   def toInternalColumnarBatch(): ColumnarBatch = {
-    val cb = new ColumnarBatch(underlying.cols.map(_.toInternalVector()).toArray)
+    val cb = new ColumnarBatch(underlying.cols.map(_.toSparkColumnVector).toArray)
     cb.setNumRows(underlying.numRows)
     cb
   }

--- a/src/main/scala/com/nec/arrow/colvector/ByteArrayColVector.scala
+++ b/src/main/scala/com/nec/arrow/colvector/ByteArrayColVector.scala
@@ -1,71 +1,120 @@
 package com.nec.arrow.colvector
 
 import com.nec.cache.VeColColumnarVector
-import com.nec.ve.VeProcess
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.spark.agile.core.VeType
 import com.nec.ve.colvector.VeColBatch.VeColVectorSource
 import org.apache.spark.sql.vectorized.ColumnVector
 import org.bytedeco.javacpp.BytePointer
+import com.nec.spark.agile.core.VeString
 
-/**
- * Storage of a col vector as serialized Arrow buffers
- * We use Option[] because the `container` has no location, only the buffers.
- */
-final case class ByteArrayColVector(underlying: GenericColVector[Option[Array[Byte]]]) {
+final case class ByteArrayColVector private[colvector] (
+  source: VeColVectorSource,
+  numItems: Int,
+  name: String,
+  veType: VeType,
+  buffers: Seq[Array[Byte]]
+) {
+  require(buffers.size > 0, s"${getClass.getName} should contain at least one Array[Byte] buffer")
+  require(buffers.filter(_.size <= 0).isEmpty, s"${getClass.getName} should not contain empty Array[Byte]'s")
 
-  import underlying._
-
-  def toInternalVector(): ColumnVector =
+  def toSparkColumnVector: ColumnVector = {
     new VeColColumnarVector(Right(this), veType.toSparkType)
+  }
 
-  def transferBuffersToVe()(implicit
-    veProcess: VeProcess,
-    source: VeColVectorSource,
-    originalCallingContext: OriginalCallingContext
-  ): GenericColVector[Option[Long]] =
-    underlying.copy(
-      buffers = buffers.map { maybeBa =>
-        maybeBa.map { ba =>
-          /** VE can only take direct byte buffers at the moment */
-          val bytePointer = new BytePointer(ba.length)
-          bytePointer.put(ba, 0, ba.length)
-          bytePointer.position(0)
-          veProcess.putPointer(bytePointer)
-        }
-      },
-      container = None,
-      source = source
-    )
-
-  def transferToBytePointers(): BytePointerColVector =
-    BytePointerColVector(underlying.map { baM =>
-      baM.map { ba =>
-        val bytePointer = new BytePointer(ba.length)
-        bytePointer.put(ba, 0, ba.length)
-        bytePointer.position(0)
-        bytePointer
-      }
-    })
-
-  /**
-   * Compress Array[Byte] list into an Array[Byte]
-   */
-  def serialize(): Array[Byte] = {
-    val totalSize = bufferSizes.sum
-
-    val extractedBuffers = underlying.buffers.flatten
-
-    val resultingArray = Array.ofDim[Byte](totalSize)
-    val bufferStarts = extractedBuffers.map(_.length).scanLeft(0)(_ + _)
-    bufferStarts.zip(extractedBuffers).foreach { case (start, buffer) =>
-      System.arraycopy(buffer, 0, resultingArray, start, buffer.length)
+  def toBytePointerColVector: BytePointerColVector = {
+    val pointers = buffers.map { buffer =>
+      // Copy the Array[Byte] to off-heap BytePointer
+      val ptr = new BytePointer(buffer.length)
+      ptr.put(buffer, 0, buffer.length)
+      ptr.position(0)
     }
 
-    assert(
-      resultingArray.length == totalSize,
-      "Resulting array should be same size as sum of all buffer sizes"
+    BytePointerColVector(
+      GenericColVector(
+        source,
+        numItems,
+        name,
+        // Populate variableSize for the VeString case
+        // The first Array[Byte] is where the data is stored
+        if (veType == VeString) Some(pointers.head.limit().toInt / 4) else None,
+        veType,
+        None,
+        pointers.map(Some(_)).toList
+      )
     )
+  }
 
-    resultingArray
+  def serialize: Array[Byte] = {
+    val lens = buffers.map(_.size)
+    val offsets = lens.scanLeft(0)(_ + _)
+    val output = Array.ofDim[Byte](lens.foldLeft(0)(_ + _))
+
+    buffers.zip(offsets).foreach { case (buffer, offset) =>
+      System.arraycopy(buffer, 0, output, offset, buffer.length)
+    }
+    output
   }
 }
+
+// /**
+//  * Storage of a col vector as serialized Arrow buffers
+//  * We use Option[] because the `container` has no location, only the buffers.
+//  */
+// final case class ByteArrayColVector(underlying: GenericColVector[Option[Array[Byte]]]) {
+
+//   import underlying._
+
+//   def toInternalVector(): ColumnVector =
+//     new VeColColumnarVector(Right(this), veType.toSparkType)
+
+//   def transferBuffersToVe()(implicit
+//     veProcess: VeProcess,
+//     source: VeColVectorSource,
+//     originalCallingContext: OriginalCallingContext
+//   ): GenericColVector[Option[Long]] =
+//     underlying.copy(
+//       buffers = buffers.map { maybeBa =>
+//         maybeBa.map { ba =>
+//           /** VE can only take direct byte buffers at the moment */
+//           val bytePointer = new BytePointer(ba.length)
+//           bytePointer.put(ba, 0, ba.length)
+//           bytePointer.position(0)
+//           veProcess.putPointer(bytePointer)
+//         }
+//       },
+//       container = None,
+//       source = source
+//     )
+
+//   def transferToBytePointers(): BytePointerColVector =
+//     BytePointerColVector(underlying.map { baM =>
+//       baM.map { ba =>
+//         val bytePointer = new BytePointer(ba.length)
+//         bytePointer.put(ba, 0, ba.length)
+//         bytePointer.position(0)
+//         bytePointer
+//       }
+//     })
+
+//   /**
+//    * Compress Array[Byte] list into an Array[Byte]
+//    */
+//   def serialize(): Array[Byte] = {
+//     val totalSize = bufferSizes.sum
+
+//     val extractedBuffers = underlying.buffers.flatten
+
+//     val resultingArray = Array.ofDim[Byte](totalSize)
+//     val bufferStarts = extractedBuffers.map(_.length).scanLeft(0)(_ + _)
+//     bufferStarts.zip(extractedBuffers).foreach { case (start, buffer) =>
+//       System.arraycopy(buffer, 0, resultingArray, start, buffer.length)
+//     }
+
+//     assert(
+//       resultingArray.length == totalSize,
+//       "Resulting array should be same size as sum of all buffer sizes"
+//     )
+
+//     resultingArray
+//   }
+// }

--- a/src/main/scala/com/nec/arrow/colvector/ByteArrayColVector.scala
+++ b/src/main/scala/com/nec/arrow/colvector/ByteArrayColVector.scala
@@ -14,8 +14,14 @@ final case class ByteArrayColVector private[colvector] (
   veType: VeType,
   buffers: Seq[Array[Byte]]
 ) {
-  require(buffers.size > 0, s"${getClass.getName} should contain at least one Array[Byte] buffer")
-  require(buffers.filter(_.size <= 0).isEmpty, s"${getClass.getName} should not contain empty Array[Byte]'s")
+  require(
+    buffers.size == (if (veType == VeString) 4 else 2),
+    s"${getClass.getName} Number of Array[Byte]'s does not match the requirement for ${veType}"
+  )
+  require(
+    buffers.filter(_.size <= 0).isEmpty,
+    s"${getClass.getName} should not contain empty Array[Byte]'s"
+  )
 
   def toSparkColumnVector: ColumnVector = {
     new VeColColumnarVector(Right(this), veType.toSparkType)
@@ -55,66 +61,3 @@ final case class ByteArrayColVector private[colvector] (
     output
   }
 }
-
-// /**
-//  * Storage of a col vector as serialized Arrow buffers
-//  * We use Option[] because the `container` has no location, only the buffers.
-//  */
-// final case class ByteArrayColVector(underlying: GenericColVector[Option[Array[Byte]]]) {
-
-//   import underlying._
-
-//   def toInternalVector(): ColumnVector =
-//     new VeColColumnarVector(Right(this), veType.toSparkType)
-
-//   def transferBuffersToVe()(implicit
-//     veProcess: VeProcess,
-//     source: VeColVectorSource,
-//     originalCallingContext: OriginalCallingContext
-//   ): GenericColVector[Option[Long]] =
-//     underlying.copy(
-//       buffers = buffers.map { maybeBa =>
-//         maybeBa.map { ba =>
-//           /** VE can only take direct byte buffers at the moment */
-//           val bytePointer = new BytePointer(ba.length)
-//           bytePointer.put(ba, 0, ba.length)
-//           bytePointer.position(0)
-//           veProcess.putPointer(bytePointer)
-//         }
-//       },
-//       container = None,
-//       source = source
-//     )
-
-//   def transferToBytePointers(): BytePointerColVector =
-//     BytePointerColVector(underlying.map { baM =>
-//       baM.map { ba =>
-//         val bytePointer = new BytePointer(ba.length)
-//         bytePointer.put(ba, 0, ba.length)
-//         bytePointer.position(0)
-//         bytePointer
-//       }
-//     })
-
-//   /**
-//    * Compress Array[Byte] list into an Array[Byte]
-//    */
-//   def serialize(): Array[Byte] = {
-//     val totalSize = bufferSizes.sum
-
-//     val extractedBuffers = underlying.buffers.flatten
-
-//     val resultingArray = Array.ofDim[Byte](totalSize)
-//     val bufferStarts = extractedBuffers.map(_.length).scanLeft(0)(_ + _)
-//     bufferStarts.zip(extractedBuffers).foreach { case (start, buffer) =>
-//       System.arraycopy(buffer, 0, resultingArray, start, buffer.length)
-//     }
-
-//     assert(
-//       resultingArray.length == totalSize,
-//       "Resulting array should be same size as sum of all buffer sizes"
-//     )
-
-//     resultingArray
-//   }
-// }

--- a/src/main/scala/com/nec/arrow/colvector/ByteArrayColVector.scala
+++ b/src/main/scala/com/nec/arrow/colvector/ByteArrayColVector.scala
@@ -18,8 +18,15 @@ final case class ByteArrayColVector private[colvector] (
     buffers.size == (if (veType == VeString) 4 else 2),
     s"${getClass.getName} Number of Array[Byte]'s does not match the requirement for ${veType}"
   )
+
   require(
-    buffers.filter(_.size <= 0).isEmpty,
+    if (numItems <= 0) {
+      // If there are no elements, then all buffers should be zero
+      (buffers.filter(_.size <= 0).size == buffers.size)
+    } else {
+      // Else there should be no empty buffer
+      buffers.filter(_.size <= 0).isEmpty
+    },
     s"${getClass.getName} should not contain empty Array[Byte]'s"
   )
 

--- a/src/main/scala/com/nec/arrow/colvector/BytePointerColVector.scala
+++ b/src/main/scala/com/nec/arrow/colvector/BytePointerColVector.scala
@@ -38,23 +38,45 @@ final case class BytePointerColVector(underlying: GenericColVector[Option[BytePo
     )(cycloneMetrics.registerTransferTime)
   }
 
-  def toByteArrayColVector(): ByteArrayColVector = {
+  def toByteArrayColVector: ByteArrayColVector = {
+    import underlying._
+
+    val buffers = underlying.buffers.flatten.map { ptr =>
+      try {
+        ptr.asBuffer.array
+
+      } catch {
+        case _: UnsupportedOperationException =>
+          val output = Array.fill[Byte](ptr.limit().toInt)(-1)
+          ptr.get(output)
+          output
+      }
+    }
+
     ByteArrayColVector(
-      underlying.copy(
-        container = None,
-        buffers = underlying
-          .map(_.map(bp => {
-            try bp.asBuffer.array()
-            catch {
-              case _: UnsupportedOperationException =>
-                val size = bp.limit()
-                val target: Array[Byte] = Array.fill(size.toInt)(-1)
-                bp.get(target)
-                target
-            }
-          }))
-          .buffers
-      )
+      source,
+      numItems,
+      name,
+      veType,
+      buffers
     )
+
+    // ByteArrayColVector(
+    //   underlying.copy(
+    //     container = None,
+    //     buffers = underlying
+    //       .map(_.map(bp => {
+    //         try bp.asBuffer.array()
+    //         catch {
+    //           case _: UnsupportedOperationException =>
+    //             val size = bp.limit()
+    //             val target: Array[Byte] = Array.fill(size.toInt)(-1)
+    //             bp.get(target)
+    //             target
+    //         }
+    //       }))
+    //       .buffers
+    //   )
+    // )
   }
 }

--- a/src/main/scala/com/nec/arrow/colvector/BytePointerColVector.scala
+++ b/src/main/scala/com/nec/arrow/colvector/BytePointerColVector.scala
@@ -60,23 +60,5 @@ final case class BytePointerColVector(underlying: GenericColVector[Option[BytePo
       veType,
       buffers
     )
-
-    // ByteArrayColVector(
-    //   underlying.copy(
-    //     container = None,
-    //     buffers = underlying
-    //       .map(_.map(bp => {
-    //         try bp.asBuffer.array()
-    //         catch {
-    //           case _: UnsupportedOperationException =>
-    //             val size = bp.limit()
-    //             val target: Array[Byte] = Array.fill(size.toInt)(-1)
-    //             bp.get(target)
-    //             target
-    //         }
-    //       }))
-    //       .buffers
-    //   )
-    // )
   }
 }

--- a/src/main/scala/com/nec/arrow/colvector/GenericColVector.scala
+++ b/src/main/scala/com/nec/arrow/colvector/GenericColVector.scala
@@ -36,13 +36,22 @@ final case class GenericColVector[Data](
    * Sizes of the underlying buffers --- use veType & combination with numItmes to decide them.
    */
   def bufferSizes: List[Int] = veType match {
-    case v: VeScalarType => List(numItems * v.cSize, Math.ceil(numItems / 64.0).toInt * 8)
+    case v: VeScalarType =>
+      List(
+        numItems * v.cSize,
+        Math.ceil(numItems / 64.0).toInt * 8
+      )
+
     case VeString =>
       val offsetBuffSize = numItems * 4
       val lenghtsSize = numItems * 4
       val validitySize = Math.ceil(numItems / 64.0).toInt * 8
 
-      variableSize.toList.map(_ * 4) ++ List(offsetBuffSize, lenghtsSize, validitySize)
+      variableSize.toList.map(_ * 4) ++ List(
+        offsetBuffSize,
+        lenghtsSize,
+        validitySize
+      )
   }
 
   def containerSize: Int = veType.containerSize

--- a/src/main/scala/com/nec/arrow/colvector/UnitColVector.scala
+++ b/src/main/scala/com/nec/arrow/colvector/UnitColVector.scala
@@ -40,7 +40,6 @@ final case class UnitColVector(underlying: GenericColVector[Unit]) {
                                    context: OriginalCallingContext,
                                    metrics: VeProcessMetrics): VeColVector = {
     metrics.measureRunningTime {
-
       val buffers = bufferSizes.scanLeft(0)(_ + _).zip(bufferSizes).map {
         case (bufferStart, bufferSize) =>
           ba.slice(bufferStart, bufferStart + bufferSize)
@@ -53,20 +52,6 @@ final case class UnitColVector(underlying: GenericColVector[Unit]) {
         veType,
         buffers
       ).toBytePointerColVector.toVeColVector
-
-      // VeColVector(
-      //   ByteArrayColVector(
-      //     underlying.copy(
-      //       container = None,
-      //       buffers = bufferSizes.scanLeft(0)(_ + _).zip(bufferSizes).map {
-      //         case (bufferStart, bufferSize) =>
-      //           Option(ba.slice(bufferStart, bufferStart + bufferSize))
-      //       }
-      //     )
-      //   ).transferBuffersToVe()
-      //     .map(_.getOrElse(-1))
-      // )
-        // .newContainer()
     }(metrics.registerDeserializationTime)
   }
 

--- a/src/main/scala/com/nec/cache/ColumnarBatchToVeColBatch.scala
+++ b/src/main/scala/com/nec/cache/ColumnarBatchToVeColBatch.scala
@@ -2,6 +2,7 @@ package com.nec.cache
 
 import com.nec.arrow.ArrowEncodingSettings
 import com.nec.arrow.colvector.BytePointerColVector
+import com.nec.arrow.colvector.ArrowVectorConversions._
 import com.nec.arrow.colvector.SparkSqlColumnVectorConversions._
 import com.nec.ve.VeProcess.OriginalCallingContext
 import com.nec.ve.colvector.VeColBatch.{VeColVector, VeColVectorSource}
@@ -31,7 +32,7 @@ object ColumnarBatchToVeColBatch {
             .map(i =>
               columnarBatch.column(i).getOptionalArrowValueVector match {
                 case Some(acv) =>
-                  VeColVector.fromArrowVector(acv)
+                  acv.toBytePointerColVector.toVeColVector
                 case None =>
                   val field = arrowSchema.getFields.get(i)
                   columnarBatch.column(i)

--- a/src/main/scala/com/nec/spark/planning/plans/VeFetchFromCachePlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VeFetchFromCachePlan.scala
@@ -47,9 +47,9 @@ case class VeFetchFromCachePlan(child: SparkPlan, requiresCleanup: Boolean)
         withInvocationMetrics(BATCH){
           val res = VeColBatch.fromList(unwrapBatch(cb).map {
             case Left(veColVector)         => veColVector
-            case Right(byteArrayColVector) =>
+            case Right(baColVector) =>
               import ImplicitMetrics._
-              byteArrayColVector.transferToBytePointers().toVeColVector()
+              baColVector.toBytePointerColVector.toVeColVector()
           })
           logger.debug(s"Finished mapping ColumnarBatch ${cb} to VE: ${res}")
           collectBatchMetrics(OUTPUT, res)

--- a/src/main/scala/com/nec/ve/colvector/VeColBatch.scala
+++ b/src/main/scala/com/nec/ve/colvector/VeColBatch.scala
@@ -280,7 +280,7 @@ object VeColBatch {
         numRows = columnarBatch.numRows(),
         cols = (0 until columnarBatch.numCols()).map { colNo =>
           val column = columnarBatch.column(colNo)
-          VeColVector.fromArrowVector(column.getArrowValueVector)
+          column.getArrowValueVector.toBytePointerColVector.toVeColVector
         }.toList
       )
     )

--- a/src/main/scala/com/nec/ve/colvector/VeColBatch.scala
+++ b/src/main/scala/com/nec/ve/colvector/VeColBatch.scala
@@ -226,6 +226,11 @@ object VeColBatch {
     VeColBatch(GenericColBatch(numRows = lv.head.underlying.numItems, lv))
   }
 
+  def from(vecs: VeColVector*): VeColBatch = {
+    assert(vecs.nonEmpty)
+    VeColBatch(GenericColBatch(numRows = vecs.head.underlying.numItems, vecs.toList))
+  }
+
   def empty: VeColBatch = {
     VeColBatch(GenericColBatch(0, List.empty))
   }

--- a/src/main/scala/com/nec/ve/colvector/VeColVector.scala
+++ b/src/main/scala/com/nec/ve/colvector/VeColVector.scala
@@ -154,13 +154,4 @@ object VeColVector {
       buffers = bufferLocations
     )
   )
-
-  def fromArrowVector(valueVector: ValueVector)(implicit
-    veProcess: VeProcess,
-    source: VeColVectorSource,
-    originalCallingContext: OriginalCallingContext,
-    cycloneMetrics: VeProcessMetrics
-  ): VeColVector = {
-    valueVector.toBytePointerColVector(source).toVeColVector
-  }
 }

--- a/src/main/scala/com/nec/ve/colvector/VeColVector.scala
+++ b/src/main/scala/com/nec/ve/colvector/VeColVector.scala
@@ -47,9 +47,7 @@ final case class VeColVector(underlying: GenericColVector[Long]) {
     val totalSize = bufferSizes.sum
 
     val resultingArray = cycloneMetrics.measureRunningTime(
-      toBytePointerVector()
-        .toByteArrayColVector()
-        .serialize()
+      toBytePointerVector.toByteArrayColVector.serialize
     )(cycloneMetrics.registerSerializationTime)
 
     assert(
@@ -60,7 +58,7 @@ final case class VeColVector(underlying: GenericColVector[Long]) {
     resultingArray
   }
 
-  def toBytePointerVector()(implicit veProcess: VeProcess): BytePointerColVector =
+  def toBytePointerVector(implicit veProcess: VeProcess): BytePointerColVector =
     BytePointerColVector(
       underlying.copy(
         container = None,

--- a/src/test/java/com/nec/cyclone/annotations/VectorEngineTest.java
+++ b/src/test/java/com/nec/cyclone/annotations/VectorEngineTest.java
@@ -1,0 +1,13 @@
+package com.nec.cyclone.annotations;
+
+import java.lang.annotation.*;
+import org.scalatest.TagAnnotation;
+
+/*
+  Define an annotation to decorate a test class:
+    https://www.scalatest.org/scaladoc/3.2.11/org/scalatest/Tag.html
+*/
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface VectorEngineTest {}

--- a/src/test/scala/com/nec/arrow/colvector/ByteArrayColVectorUnitSpec.scala
+++ b/src/test/scala/com/nec/arrow/colvector/ByteArrayColVectorUnitSpec.scala
@@ -100,6 +100,18 @@ class ByteArrayColVectorUnitSpec extends AnyWordSpec {
       }
     }
 
+    "be constructable from empty column vectors" in {
+      implicit val source = VeColVectorSource(s"${UUID.randomUUID}")
+      val name = s"${UUID.randomUUID}"
+
+      noException should be thrownBy { Seq.empty[Option[Int]].toBytePointerColVector(name).toByteArrayColVector }
+      noException should be thrownBy { Seq.empty[Option[Short]].toBytePointerColVector(name).toByteArrayColVector }
+      noException should be thrownBy { Seq.empty[Option[Long]].toBytePointerColVector(name).toByteArrayColVector }
+      noException should be thrownBy { Seq.empty[Option[Float]].toBytePointerColVector(name).toByteArrayColVector }
+      noException should be thrownBy { Seq.empty[Option[Double]].toBytePointerColVector(name).toByteArrayColVector }
+      noException should be thrownBy { Seq.empty[Option[String]].toBytePointerColVector(name).toByteArrayColVector }
+    }
+
     "correctly serialize to Array[Byte]" in {
       val buffers = Seq(
         Random.nextString(Random.nextInt(100) + 1).getBytes,

--- a/src/test/scala/com/nec/arrow/colvector/ByteArrayColVectorUnitSpec.scala
+++ b/src/test/scala/com/nec/arrow/colvector/ByteArrayColVectorUnitSpec.scala
@@ -1,0 +1,115 @@
+package com.nec.arrow.colvector
+
+import com.nec.ve.colvector.VeColBatch.VeColVectorSource
+import com.nec.arrow.colvector.SeqOptTConversions._
+import scala.reflect.ClassTag
+import scala.util.Random
+import java.util.UUID
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
+import com.nec.spark.agile.core.VeNullableInt
+import com.nec.spark.agile.core.VeString
+
+class ByteArrayColVectorUnitSpec extends AnyWordSpec {
+  def runConversionTest[T <: AnyVal : ClassTag](input: Seq[Option[T]]): Unit = {
+    implicit val source = VeColVectorSource(s"${UUID.randomUUID}")
+    val name = s"${UUID.randomUUID}"
+    val colvec = input.toBytePointerColVector(name).toByteArrayColVector
+
+    // Check fields
+    colvec.name should be (name)
+    colvec.source should be (source)
+    colvec.numItems should be (input.size)
+    colvec.veType.scalaType should be (implicitly[ClassTag[T]].runtimeClass)
+    colvec.buffers.size should be (2)
+    colvec.toBytePointerColVector.underlying.variableSize shouldBe empty
+
+    // Check conversion
+    colvec.toBytePointerColVector.toSeqOpt[T] should be (input)
+  }
+
+  "ByteArrayColVector" should {
+    "correctly convert from and to BytePointerColVector (Int)" in {
+      runConversionTest(0.until(Random.nextInt(100)).map(_ => if (Math.random < 0.5) Some(Random.nextInt(10000)) else None))
+    }
+
+    "correctly convert from and to BytePointerColVector (Short)" in {
+      runConversionTest(0.until(Random.nextInt(100)).map(_ => if (Math.random < 0.5) Some(Random.nextInt(10000).toShort) else None))
+    }
+
+    "correctly convert from and to BytePointerColVector (Long)" in {
+      runConversionTest(0.until(Random.nextInt(100)).map(_ => if (Math.random < 0.5) Some(Random.nextLong) else None))
+    }
+
+    "correctly convert from and to BytePointerColVector (Float)" in {
+      runConversionTest(0.until(Random.nextInt(100)).map(_ => if (Math.random < 0.5) Some(Random.nextFloat * 1000) else None))
+    }
+
+    "correctly convert from and to BytePointerColVector (Double)" in {
+      runConversionTest(0.until(Random.nextInt(100)).map(_ => if (Math.random < 0.5) Some(Random.nextDouble * 1000) else None))
+    }
+
+    "correctly convert from and to BytePointerColVector (String)" in {
+      val input = 0.until(Random.nextInt(100)).map(_ => if (Math.random < 0.5) Some(Random.nextString(Random.nextInt(30))) else None)
+
+      val source = VeColVectorSource(s"${UUID.randomUUID}")
+      val name = s"${UUID.randomUUID}"
+      val colvec = input.toBytePointerColVector(name)(source).toByteArrayColVector
+
+      // Check fields
+      colvec.name should be (name)
+      colvec.source should be (source)
+      colvec.numItems should be (input.size)
+      colvec.veType.scalaType should be (classOf[String])
+      colvec.buffers.size should be (4)
+      colvec.toBytePointerColVector.underlying.variableSize should be (Some(colvec.buffers.head.size / 4))
+
+      // Check conversion
+      colvec.toBytePointerColVector.toSeqOpt[String] should be (input)
+    }
+
+    "correctly enforce input requirements on construction" in {
+      val source = VeColVectorSource(s"${UUID.randomUUID}")
+      val name = s"${UUID.randomUUID}"
+
+      assertThrows[IllegalArgumentException] {
+        ByteArrayColVector(source, Random.nextInt(100), name, VeNullableInt, Seq.empty[Array[Byte]])
+      }
+
+      assertThrows[IllegalArgumentException] {
+        ByteArrayColVector(
+          source,
+          Random.nextInt(100),
+          name,
+          VeNullableInt,
+          Seq(Array.empty[Byte], Array.empty[Byte], Array.empty[Byte], Array.empty[Byte])
+        )
+      }
+
+      noException should be thrownBy {
+        ByteArrayColVector(
+          source,
+          Random.nextInt(100),
+          name,
+          VeNullableInt,
+          Seq(
+            Random.nextString(Random.nextInt(100) + 1).getBytes,
+            Random.nextString(Random.nextInt(100) + 1).getBytes
+          )
+        )
+      }
+    }
+
+    "correctly serialize to Array[Byte]" in {
+      val buffers = Seq(
+        Random.nextString(Random.nextInt(100) + 1).getBytes,
+        Random.nextString(Random.nextInt(100) + 1).getBytes,
+        Random.nextString(Random.nextInt(100) + 1).getBytes,
+        Random.nextString(Random.nextInt(100) + 1).getBytes
+      )
+      val colvec = ByteArrayColVector(VeColVectorSource(s"${UUID.randomUUID}"), Random.nextInt(100), s"${UUID.randomUUID}", VeString, buffers)
+
+      colvec.serialize.toSeq should be (buffers.foldLeft(Array.empty[Byte])(_ ++ _).toSeq)
+    }
+  }
+}

--- a/src/test/scala/com/nec/arrow/colvector/SeqOptTConversionsUnitSpec.scala
+++ b/src/test/scala/com/nec/arrow/colvector/SeqOptTConversionsUnitSpec.scala
@@ -67,7 +67,8 @@ class SeqOptTConversionsUnitSpec extends AnyWordSpec {
       // Check fields
       colvec.underlying.veType.scalaType should be (classOf[String])
       colvec.underlying.name should be (name)
-      colvec.underlying.source should be(source)
+      colvec.underlying.source should be (source)
+      colvec.underlying.numItems should be (input.size)
       colvec.underlying.buffers.size should be (4)
 
       // Data, starts, and lens buffer capacities should be correctly set

--- a/src/test/scala/com/nec/ve/ArrowTransferCheck.scala
+++ b/src/test/scala/com/nec/ve/ArrowTransferCheck.scala
@@ -14,317 +14,250 @@ import com.nec.ve.VeColBatch.{VeBatchOfBatches, VeColVector}
 import com.nec.ve.VeProcess.OriginalCallingContext
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.{FieldVector, Float8Vector, ValueVector, VarCharVector}
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 @VectorEngineTest
-final class ArrowTransferCheck extends AnyWordSpec with WithVeProcess with VeKernelInfra {
+final class ArrowTransferCheck extends AnyFreeSpec with WithVeProcess with VeKernelInfra {
   import OriginalCallingContext.Automatic._
-
-  "VeColVector" should {
-    "correctly transfer data from Host Off-Heap to VE and back (Int)" in {
-
+  "Execute our function" in {
+    compiledWithHeaders(DoublingFunction, "f") { path =>
+      val lib = veProcess.loadLibrary(path)
+      WithTestAllocator { implicit alloc =>
+        withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
+          val colVec = f8v.toBytePointerColVector.toVeColVector
+          val results = veProcess.execute(
+            libraryReference = lib,
+            functionName = "f",
+            cols = List(colVec),
+            results = List(VeNullableDouble.makeCVector("outd"))
+          )
+          expect(results.size == 1)
+          val vec = results.head.toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
+          val result = vec.toList
+          try expect(result == List[Double](2, 4, 6))
+          finally vec.close()
+        }
+      }
     }
   }
 
+  "Execute multi-function" in {
+    compiledWithHeaders(PartitioningFunction, "f") { path =>
+      val lib = veProcess.loadLibrary(path)
+      WithTestAllocator { implicit alloc =>
+        withArrowFloat8VectorI(List(95, 99, 105, 500, 501)) { f8v =>
+          val colVec = f8v.toBytePointerColVector.toVeColVector
+          val results = veProcess.executeMulti(
+            libraryReference = lib,
+            functionName = "f",
+            cols = List(colVec),
+            results = List(VeNullableDouble.makeCVector("outd"))
+          )
 
+          val plainResults: List[(Int, Option[Double])] = results.map { case (index, vecs) =>
+            val vec = vecs.head
+            index -> {
+              val av = vec.toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
+              val avl = av.toList
+              try if (avl.isEmpty) None else Some(avl.max)
+              finally av.close()
+            }
+          }
 
-  // "Identify check: data that we put into the VE can be retrieved back out" - {
-  //   "for Float8Vector" in {
-  //     WithTestAllocator { implicit alloc =>
-  //       withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
-  //         val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
-  //         val arrowVec = colVec.toBytePointerVector.toArrowVector
+          val expectedResult: List[(Int, Option[Double])] =
+            List((0, Some(99)), (1, Some(105)), (2, None), (3, None), (4, Some(501)))
 
-  //         try {
-  //           colVec.free()
-  //           expect(arrowVec.toString == f8v.toString)
-  //         } finally arrowVec.close()
-  //       }
-  //     }
-  //   }
+          expect(plainResults == expectedResult)
+        }
+      }
+    }
+  }
 
-  //   "for VarCharVector" in {
-  //     WithTestAllocator { implicit alloc =>
-  //       withArrowStringVector(List("Quick", "brown", "fox", "smth smth", "lazy dog")) { f8v =>
-  //         val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
-  //         val arrowVec = colVec.toBytePointerVector.toArrowVector
+  "Partition data by some means (simple Int partitioning in this case) (PIN)" in {
+    val groupingFn = GroupingFunction(
+      "f",
+      List(
+        GroupingFunction.DataDescription(VeNullableDouble, GroupingFunction.Key),
+        GroupingFunction.DataDescription(VeString, GroupingFunction.Key),
+        GroupingFunction.DataDescription(VeNullableDouble, GroupingFunction.Value)
+      ),
+      2
+    )
 
-  //         try {
-  //           colVec.free()
-  //           expect(arrowVec.toString == f8v.toString)
-  //         } finally arrowVec.close()
-  //       }
-  //     }
-  //   }
+    compiledWithHeaders(groupingFn.toCFunction) { path =>
+      val lib = veProcess.loadLibrary(path)
+      WithTestAllocator { implicit alloc =>
+        withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
+          withArrowFloat8VectorI(List(9, 8, 7)) { f8v2 =>
+            val lastString = "cccc"
+            withNullableArrowStringVector(List("a", "b", lastString).map(Some.apply)) { sv =>
+              val colVec = f8v.toBytePointerColVector.toVeColVector
+              val colVec2 = f8v2.toBytePointerColVector.toVeColVector
+              val colVecS = sv.toBytePointerColVector.toVeColVector
+              val results = veProcess.executeMulti(
+                libraryReference = lib,
+                functionName = groupingFn.name,
+                cols = List(colVec, colVecS, colVec2),
+                results = List(
+                  VeNullableDouble,
+                  VeString,
+                  VeNullableDouble
+                ).zipWithIndex.map { case (vt, i) => vt.makeCVector(s"out_${i}") }
+              )
 
-  //   "for BigInt" in {
-  //     WithTestAllocator { implicit alloc =>
-  //       withDirectBigIntVector(List(1, -1, 1238)) { biv =>
-  //         val colVec: VeColVector = VeColVector.fromArrowVector(biv)
-  //         val arrowVec = colVec.toBytePointerVector.toArrowVector
+              val plainResultsD: List[(Int, List[(Double, String, Double)])] = results.map {
+                case (index, vecs) =>
+                  val vecFloat = vecs(0).toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
+                  val vecStr = vecs(1).toBytePointerVector.toArrowVector.asInstanceOf[VarCharVector]
+                  val vecFl2 = vecs(2).toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
+                  try {
+                    index -> vecFloat.toList.zip(vecFl2.toList).zip(vecStr.toList).map {
+                      case ((a, b), c) => (a, c, b)
+                    }
+                  } finally {
+                    vecStr.close()
+                    vecFloat.close()
+                    vecFl2.close()
+                  }
+              }
 
-  //         try {
-  //           colVec.free()
-  //           expect(arrowVec.toString == biv.toString)
-  //         } finally arrowVec.close()
-  //       }
-  //     }
-  //   }
+              val allSets = plainResultsD.flatMap(_._2).toSet
 
-  //   "for Int" in {
-  //     WithTestAllocator { implicit alloc =>
-  //       withDirectIntVector(List(1, 2, 3, -5)) { dirInt =>
-  //         val colVec: VeColVector = VeColVector.fromArrowVector(dirInt)
-  //         val arrowVec = colVec.toBytePointerVector.toArrowVector
+              val expectedGroups: Set[(Double, String, Double)] =
+                Set((1, "a", 9), (2, "b", 8), (3, lastString, 7))
 
-  //         try {
-  //           colVec.free()
-  //           expect(arrowVec.toString == dirInt.toString)
-  //         } finally arrowVec.close()
-  //       }
-  //     }
-  //   }
-  // }
+              assert(
+                plainResultsD.map(_._2.size).toSet == Set(1, 2),
+                "We expect the groups to have exactly size 2 and 1 each because of the split"
+              )
+              assert(allSets == expectedGroups, "we verify that we get back the data we had put in")
+            }
+          }
+        }
+      }
+    }
+  }
 
-  // "Execute our function" in {
-  //   compiledWithHeaders(DoublingFunction, "f") { path =>
-  //     val lib = veProcess.loadLibrary(path)
-  //     WithTestAllocator { implicit alloc =>
-  //       withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
-  //         val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
-  //         val results = veProcess.execute(
-  //           libraryReference = lib,
-  //           functionName = "f",
-  //           cols = List(colVec),
-  //           results = List(VeNullableDouble.makeCVector("outd"))
-  //         )
-  //         expect(results.size == 1)
-  //         val vec = results.head.toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
-  //         val result = vec.toList
-  //         try expect(result == List[Double](2, 4, 6))
-  //         finally vec.close()
-  //       }
-  //     }
-  //   }
-  // }
+  "We can serialize/deserialize VeColVector" - {
 
-  // "Execute multi-function" in {
-  //   compiledWithHeaders(PartitioningFunction, "f") { path =>
-  //     val lib = veProcess.loadLibrary(path)
-  //     WithTestAllocator { implicit alloc =>
-  //       withArrowFloat8VectorI(List(95, 99, 105, 500, 501)) { f8v =>
-  //         val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
-  //         val results = veProcess.executeMulti(
-  //           libraryReference = lib,
-  //           functionName = "f",
-  //           cols = List(colVec),
-  //           results = List(VeNullableDouble.makeCVector("outd"))
-  //         )
+    def checkVector(
+      valueVector: ValueVector
+    )(implicit veProcess: VeProcess, bufferAllocator: BufferAllocator): Unit = {
+      val colVec = valueVector.toBytePointerColVector.toVeColVector
+      val serialized = colVec.serialize()
+      val serList = serialized.toList
+      val newColVec = colVec.underlying.toUnit.deserialize(serialized)
+      expect(
+        newColVec.containerLocation != colVec.containerLocation,
+        newColVec.bufferLocations != colVec.bufferLocations
+      )
+      val newSerialized = newColVec.serialize().toList
+      val newSerList = newSerialized.toList
+      assert(newSerList == serList, "Serializing a deserialized one should yield the same result")
+      val newColVecArrow = newColVec.toBytePointerVector.toArrowVector
+      try {
+        colVec.free()
+        newColVec.free()
+        expect(newColVecArrow.toString == valueVector.toString)
+      } finally newColVecArrow.close()
 
-  //         val plainResults: List[(Int, Option[Double])] = results.map { case (index, vecs) =>
-  //           val vec = vecs.head
-  //           index -> {
-  //             val av = vec.toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
-  //             val avl = av.toList
-  //             try if (avl.isEmpty) None else Some(avl.max)
-  //             finally av.close()
-  //           }
-  //         }
+    }
 
-  //         val expectedResult: List[(Int, Option[Double])] =
-  //           List((0, Some(99)), (1, Some(105)), (2, None), (3, None), (4, Some(501)))
+    "for Float8Vector" in {
+      WithTestAllocator { implicit alloc =>
+        withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
+          checkVector(f8v)
+        }
+      }
+    }
+    "for IntVector" in {
+      WithTestAllocator { implicit alloc =>
+        withDirectIntVector(List(1, 2, 3)) { f8v =>
+          checkVector(f8v)
+        }
+      }
+    }
+    "for BigIntVector" in {
+      WithTestAllocator { implicit alloc =>
+        withDirectBigIntVector(List(1, 2, 3)) { f8v =>
+          checkVector(f8v)
+        }
+      }
+    }
+    "for VarCharVector" in {
+      WithTestAllocator { implicit alloc =>
+        withArrowStringVector(List("1", "2", "3x")) { sv =>
+          checkVector(sv)
+        }
+      }
+    }
+    "for empty VarCharVector" in {
+      WithTestAllocator { implicit alloc =>
+        withArrowStringVector(List.empty) { sv =>
+          checkVector(sv)
+        }
+      }
+    }
+    "for an empty Float8Vector" in {
+      WithTestAllocator { implicit alloc =>
+        withArrowFloat8VectorI(List.empty) { f8v =>
+          checkVector(f8v)
+        }
+      }
+    }
+  }
 
-  //         expect(plainResults == expectedResult)
-  //       }
-  //     }
-  //   }
-  // }
+  /**
+   * Let's first take the data, as it is,
+   * perform partial aggregation,
+   * then bucket it,
+   * then exchange it,
+   * re-merge according to buckets
+   * then finalize
+   */
 
-  // "Partition data by some means (simple Int partitioning in this case) (PIN)" in {
-  //   val groupingFn = GroupingFunction(
-  //     "f",
-  //     List(
-  //       GroupingFunction.DataDescription(VeNullableDouble, GroupingFunction.Key),
-  //       GroupingFunction.DataDescription(VeString, GroupingFunction.Key),
-  //       GroupingFunction.DataDescription(VeNullableDouble, GroupingFunction.Value)
-  //     ),
-  //     2
-  //   )
+  "We can merge multiple VeColBatches" in {
+    val mergeFn = MergeFunction("merger", List(VeNullableDouble, VeString))
 
-  //   compiledWithHeaders(groupingFn.toCFunction) { path =>
-  //     val lib = veProcess.loadLibrary(path)
-  //     WithTestAllocator { implicit alloc =>
-  //       withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
-  //         withArrowFloat8VectorI(List(9, 8, 7)) { f8v2 =>
-  //           val lastString = "cccc"
-  //           withNullableArrowStringVector(List("a", "b", lastString).map(Some.apply)) { sv =>
-  //             val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
-  //             val colVec2: VeColVector = VeColVector.fromArrowVector(f8v2)
-  //             val colVecS: VeColVector = VeColVector.fromArrowVector(sv)
-  //             val results = veProcess.executeMulti(
-  //               libraryReference = lib,
-  //               functionName = groupingFn.name,
-  //               cols = List(colVec, colVecS, colVec2),
-  //               results = List(
-  //                 VeNullableDouble,
-  //                 VeString,
-  //                 VeNullableDouble
-  //               ).zipWithIndex.map { case (vt, i) => vt.makeCVector(s"out_${i}") }
-  //             )
+    compiledWithHeaders(mergeFn.toCFunction) {
+      path =>
+        val lib = veProcess.loadLibrary(path)
+        WithTestAllocator { implicit alloc =>
+          withArrowFloat8VectorI(List(1, 2, 3, -1)) { f8v =>
+            withArrowStringVector(Seq("a", "b", "c", "x")) { sv =>
+              withArrowStringVector(Seq("d", "e", "f")) { sv2 =>
+                withArrowFloat8VectorI(List(2, 3, 4)) { f8v2 =>
+                  val colVec = f8v.toBytePointerColVector.toVeColVector
+                  val colVec2 = f8v2.toBytePointerColVector.toVeColVector
+                  val sVec = sv.toBytePointerColVector.toVeColVector
+                  val sVec2 = sv2.toBytePointerColVector.toVeColVector
+                  val colBatch1: VeColBatch = VeColBatch(colVec.numItems, List(colVec, sVec))
+                  val colBatch2: VeColBatch = VeColBatch(colVec2.numItems, List(colVec2, sVec2))
+                  val bg = VeBatchOfBatches.fromVeColBatches(List(colBatch1, colBatch2))
+                  val r: List[VeColVector] = veProcess.executeMultiIn(
+                    libraryReference = lib,
+                    functionName = mergeFn.name,
+                    batches = bg,
+                    results = colBatch1.cols.zipWithIndex.map { case (vcv, idx) =>
+                      vcv.veType.makeCVector(s"o_${idx}")
+                    }
+                  )
 
-  //             val plainResultsD: List[(Int, List[(Double, String, Double)])] = results.map {
-  //               case (index, vecs) =>
-  //                 val vecFloat = vecs(0).toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
-  //                 val vecStr = vecs(1).toBytePointerVector.toArrowVector.asInstanceOf[VarCharVector]
-  //                 val vecFl2 = vecs(2).toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
-  //                 try {
-  //                   index -> vecFloat.toList.zip(vecFl2.toList).zip(vecStr.toList).map {
-  //                     case ((a, b), c) => (a, c, b)
-  //                   }
-  //                 } finally {
-  //                   vecStr.close()
-  //                   vecFloat.close()
-  //                   vecFl2.close()
-  //                 }
-  //             }
+                  val resultVecs: List[FieldVector] = r.map(_.toBytePointerVector.toArrowVector)
 
-  //             val allSets = plainResultsD.flatMap(_._2).toSet
+                  try {
+                    val nums = resultVecs(0).asInstanceOf[Float8Vector].toListSafe
+                    val strs = resultVecs(1).asInstanceOf[VarCharVector].toList
 
-  //             val expectedGroups: Set[(Double, String, Double)] =
-  //               Set((1, "a", 9), (2, "b", 8), (3, lastString, 7))
-
-  //             assert(
-  //               plainResultsD.map(_._2.size).toSet == Set(1, 2),
-  //               "We expect the groups to have exactly size 2 and 1 each because of the split"
-  //             )
-  //             assert(allSets == expectedGroups, "we verify that we get back the data we had put in")
-  //           }
-  //         }
-  //       }
-  //     }
-  //   }
-  // }
-
-  // "We can serialize/deserialize VeColVector" - {
-
-  //   def checkVector(
-  //     valueVector: ValueVector
-  //   )(implicit veProcess: VeProcess, bufferAllocator: BufferAllocator): Unit = {
-  //     val colVec: VeColVector = VeColVector.fromArrowVector(valueVector)
-  //     val serialized = colVec.serialize()
-  //     val serList = serialized.toList
-  //     val newColVec = colVec.underlying.toUnit.deserialize(serialized)
-  //     expect(
-  //       newColVec.containerLocation != colVec.containerLocation,
-  //       newColVec.bufferLocations != colVec.bufferLocations
-  //     )
-  //     val newSerialized = newColVec.serialize().toList
-  //     val newSerList = newSerialized.toList
-  //     assert(newSerList == serList, "Serializing a deserialized one should yield the same result")
-  //     val newColVecArrow = newColVec.toBytePointerVector.toArrowVector
-  //     try {
-  //       colVec.free()
-  //       newColVec.free()
-  //       expect(newColVecArrow.toString == valueVector.toString)
-  //     } finally newColVecArrow.close()
-
-  //   }
-
-  //   "for Float8Vector" in {
-  //     WithTestAllocator { implicit alloc =>
-  //       withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
-  //         checkVector(f8v)
-  //       }
-  //     }
-  //   }
-  //   "for IntVector" in {
-  //     WithTestAllocator { implicit alloc =>
-  //       withDirectIntVector(List(1, 2, 3)) { f8v =>
-  //         checkVector(f8v)
-  //       }
-  //     }
-  //   }
-  //   "for BigIntVector" in {
-  //     WithTestAllocator { implicit alloc =>
-  //       withDirectBigIntVector(List(1, 2, 3)) { f8v =>
-  //         checkVector(f8v)
-  //       }
-  //     }
-  //   }
-  //   "for VarCharVector" in {
-  //     WithTestAllocator { implicit alloc =>
-  //       withArrowStringVector(List("1", "2", "3x")) { sv =>
-  //         checkVector(sv)
-  //       }
-  //     }
-  //   }
-  //   "for empty VarCharVector" in {
-  //     WithTestAllocator { implicit alloc =>
-  //       withArrowStringVector(List.empty) { sv =>
-  //         checkVector(sv)
-  //       }
-  //     }
-  //   }
-  //   "for an empty Float8Vector" in {
-  //     WithTestAllocator { implicit alloc =>
-  //       withArrowFloat8VectorI(List.empty) { f8v =>
-  //         checkVector(f8v)
-  //       }
-  //     }
-  //   }
-  // }
-
-  // /**
-  //  * Let's first take the data, as it is,
-  //  * perform partial aggregation,
-  //  * then bucket it,
-  //  * then exchange it,
-  //  * re-merge according to buckets
-  //  * then finalize
-  //  */
-
-  // "We can merge multiple VeColBatches" in {
-  //   val mergeFn = MergeFunction("merger", List(VeNullableDouble, VeString))
-
-  //   compiledWithHeaders(mergeFn.toCFunction) {
-  //     path =>
-  //       val lib = veProcess.loadLibrary(path)
-  //       WithTestAllocator { implicit alloc =>
-  //         withArrowFloat8VectorI(List(1, 2, 3, -1)) { f8v =>
-  //           withArrowStringVector(Seq("a", "b", "c", "x")) { sv =>
-  //             withArrowStringVector(Seq("d", "e", "f")) { sv2 =>
-  //               withArrowFloat8VectorI(List(2, 3, 4)) { f8v2 =>
-  //                 val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
-  //                 val colVec2: VeColVector = VeColVector.fromArrowVector(f8v2)
-  //                 val sVec: VeColVector = VeColVector.fromArrowVector(sv)
-  //                 val sVec2: VeColVector = VeColVector.fromArrowVector(sv2)
-  //                 val colBatch1: VeColBatch = VeColBatch(colVec.numItems, List(colVec, sVec))
-  //                 val colBatch2: VeColBatch = VeColBatch(colVec2.numItems, List(colVec2, sVec2))
-  //                 val bg = VeBatchOfBatches.fromVeColBatches(List(colBatch1, colBatch2))
-  //                 val r: List[VeColVector] = veProcess.executeMultiIn(
-  //                   libraryReference = lib,
-  //                   functionName = mergeFn.name,
-  //                   batches = bg,
-  //                   results = colBatch1.cols.zipWithIndex.map { case (vcv, idx) =>
-  //                     vcv.veType.makeCVector(s"o_${idx}")
-  //                   }
-  //                 )
-
-  //                 val resultVecs: List[FieldVector] = r.map(_.toBytePointerVector.toArrowVector)
-
-  //                 try {
-  //                   val nums = resultVecs(0).asInstanceOf[Float8Vector].toListSafe
-  //                   val strs = resultVecs(1).asInstanceOf[VarCharVector].toList
-
-  //                   val expected = List(1, 2, 3, -1, 2, 3, 4).map(v => Option(v))
-  //                   val expectedStrs = Seq("a", "b", "c", "x", "d", "e", "f")
-  //                   expect(nums == expected, strs == expectedStrs)
-  //                 } finally resultVecs.foreach(_.close())
-  //               }
-  //             }
-  //           }
-  //         }
-  //       }
-  //   }
-  // }
+                    val expected = List(1, 2, 3, -1, 2, 3, 4).map(v => Option(v))
+                    val expectedStrs = Seq("a", "b", "c", "x", "d", "e", "f")
+                    expect(nums == expected, strs == expectedStrs)
+                  } finally resultVecs.foreach(_.close())
+                }
+              }
+            }
+          }
+        }
+    }
+  }
 }

--- a/src/test/scala/com/nec/ve/ArrowTransferCheck.scala
+++ b/src/test/scala/com/nec/ve/ArrowTransferCheck.scala
@@ -4,6 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import com.nec.arrow.ArrowVectorBuilders._
 import com.nec.arrow.WithTestAllocator
 import com.nec.arrow.colvector.ArrowVectorConversions._
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.agile.core.{VeNullableDouble, VeScalarType, VeString}
 import com.nec.spark.agile.exchange.GroupingFunction
 import com.nec.spark.agile.merge.MergeFunction
@@ -15,6 +16,7 @@ import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.{FieldVector, Float8Vector, ValueVector, VarCharVector}
 import org.scalatest.wordspec.AnyWordSpec
 
+@VectorEngineTest
 final class ArrowTransferCheck extends AnyWordSpec with WithVeProcess with VeKernelInfra {
   import OriginalCallingContext.Automatic._
 

--- a/src/test/scala/com/nec/ve/ArrowTransferCheck.scala
+++ b/src/test/scala/com/nec/ve/ArrowTransferCheck.scala
@@ -13,308 +13,316 @@ import com.nec.ve.VeColBatch.{VeBatchOfBatches, VeColVector}
 import com.nec.ve.VeProcess.OriginalCallingContext
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.{FieldVector, Float8Vector, ValueVector, VarCharVector}
-import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-final class ArrowTransferCheck extends AnyFreeSpec with WithVeProcess with VeKernelInfra {
+final class ArrowTransferCheck extends AnyWordSpec with WithVeProcess with VeKernelInfra {
   import OriginalCallingContext.Automatic._
 
-  "Identify check: data that we put into the VE can be retrieved back out" - {
-    "for Float8Vector" in {
-      WithTestAllocator { implicit alloc =>
-        withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
-          val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
-          val arrowVec = colVec.toBytePointerVector.toArrowVector
+  "VeColVector" should {
+    "correctly transfer data from Host Off-Heap to VE and back (Int)" in {
 
-          try {
-            colVec.free()
-            expect(arrowVec.toString == f8v.toString)
-          } finally arrowVec.close()
-        }
-      }
-    }
-
-    "for VarCharVector" in {
-      WithTestAllocator { implicit alloc =>
-        withArrowStringVector(List("Quick", "brown", "fox", "smth smth", "lazy dog")) { f8v =>
-          val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
-          val arrowVec = colVec.toBytePointerVector.toArrowVector
-
-          try {
-            colVec.free()
-            expect(arrowVec.toString == f8v.toString)
-          } finally arrowVec.close()
-        }
-      }
-    }
-
-    "for BigInt" in {
-      WithTestAllocator { implicit alloc =>
-        withDirectBigIntVector(List(1, -1, 1238)) { biv =>
-          val colVec: VeColVector = VeColVector.fromArrowVector(biv)
-          val arrowVec = colVec.toBytePointerVector.toArrowVector
-
-          try {
-            colVec.free()
-            expect(arrowVec.toString == biv.toString)
-          } finally arrowVec.close()
-        }
-      }
-    }
-
-    "for Int" in {
-      WithTestAllocator { implicit alloc =>
-        withDirectIntVector(List(1, 2, 3, -5)) { dirInt =>
-          val colVec: VeColVector = VeColVector.fromArrowVector(dirInt)
-          val arrowVec = colVec.toBytePointerVector.toArrowVector
-
-          try {
-            colVec.free()
-            expect(arrowVec.toString == dirInt.toString)
-          } finally arrowVec.close()
-        }
-      }
     }
   }
 
-  "Execute our function" in {
-    compiledWithHeaders(DoublingFunction, "f") { path =>
-      val lib = veProcess.loadLibrary(path)
-      WithTestAllocator { implicit alloc =>
-        withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
-          val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
-          val results = veProcess.execute(
-            libraryReference = lib,
-            functionName = "f",
-            cols = List(colVec),
-            results = List(VeNullableDouble.makeCVector("outd"))
-          )
-          expect(results.size == 1)
-          val vec = results.head.toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
-          val result = vec.toList
-          try expect(result == List[Double](2, 4, 6))
-          finally vec.close()
-        }
-      }
-    }
-  }
 
-  "Execute multi-function" in {
-    compiledWithHeaders(PartitioningFunction, "f") { path =>
-      val lib = veProcess.loadLibrary(path)
-      WithTestAllocator { implicit alloc =>
-        withArrowFloat8VectorI(List(95, 99, 105, 500, 501)) { f8v =>
-          val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
-          val results = veProcess.executeMulti(
-            libraryReference = lib,
-            functionName = "f",
-            cols = List(colVec),
-            results = List(VeNullableDouble.makeCVector("outd"))
-          )
 
-          val plainResults: List[(Int, Option[Double])] = results.map { case (index, vecs) =>
-            val vec = vecs.head
-            index -> {
-              val av = vec.toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
-              val avl = av.toList
-              try if (avl.isEmpty) None else Some(avl.max)
-              finally av.close()
-            }
-          }
+  // "Identify check: data that we put into the VE can be retrieved back out" - {
+  //   "for Float8Vector" in {
+  //     WithTestAllocator { implicit alloc =>
+  //       withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
+  //         val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
+  //         val arrowVec = colVec.toBytePointerVector.toArrowVector
 
-          val expectedResult: List[(Int, Option[Double])] =
-            List((0, Some(99)), (1, Some(105)), (2, None), (3, None), (4, Some(501)))
+  //         try {
+  //           colVec.free()
+  //           expect(arrowVec.toString == f8v.toString)
+  //         } finally arrowVec.close()
+  //       }
+  //     }
+  //   }
 
-          expect(plainResults == expectedResult)
-        }
-      }
-    }
-  }
+  //   "for VarCharVector" in {
+  //     WithTestAllocator { implicit alloc =>
+  //       withArrowStringVector(List("Quick", "brown", "fox", "smth smth", "lazy dog")) { f8v =>
+  //         val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
+  //         val arrowVec = colVec.toBytePointerVector.toArrowVector
 
-  "Partition data by some means (simple Int partitioning in this case) (PIN)" in {
-    val groupingFn = GroupingFunction(
-      "f",
-      List(
-        GroupingFunction.DataDescription(VeNullableDouble, GroupingFunction.Key),
-        GroupingFunction.DataDescription(VeString, GroupingFunction.Key),
-        GroupingFunction.DataDescription(VeNullableDouble, GroupingFunction.Value)
-      ),
-      2
-    )
+  //         try {
+  //           colVec.free()
+  //           expect(arrowVec.toString == f8v.toString)
+  //         } finally arrowVec.close()
+  //       }
+  //     }
+  //   }
 
-    compiledWithHeaders(groupingFn.toCFunction) { path =>
-      val lib = veProcess.loadLibrary(path)
-      WithTestAllocator { implicit alloc =>
-        withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
-          withArrowFloat8VectorI(List(9, 8, 7)) { f8v2 =>
-            val lastString = "cccc"
-            withNullableArrowStringVector(List("a", "b", lastString).map(Some.apply)) { sv =>
-              val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
-              val colVec2: VeColVector = VeColVector.fromArrowVector(f8v2)
-              val colVecS: VeColVector = VeColVector.fromArrowVector(sv)
-              val results = veProcess.executeMulti(
-                libraryReference = lib,
-                functionName = groupingFn.name,
-                cols = List(colVec, colVecS, colVec2),
-                results = List(
-                  VeNullableDouble,
-                  VeString,
-                  VeNullableDouble
-                ).zipWithIndex.map { case (vt, i) => vt.makeCVector(s"out_${i}") }
-              )
+  //   "for BigInt" in {
+  //     WithTestAllocator { implicit alloc =>
+  //       withDirectBigIntVector(List(1, -1, 1238)) { biv =>
+  //         val colVec: VeColVector = VeColVector.fromArrowVector(biv)
+  //         val arrowVec = colVec.toBytePointerVector.toArrowVector
 
-              val plainResultsD: List[(Int, List[(Double, String, Double)])] = results.map {
-                case (index, vecs) =>
-                  val vecFloat = vecs(0).toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
-                  val vecStr = vecs(1).toBytePointerVector.toArrowVector.asInstanceOf[VarCharVector]
-                  val vecFl2 = vecs(2).toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
-                  try {
-                    index -> vecFloat.toList.zip(vecFl2.toList).zip(vecStr.toList).map {
-                      case ((a, b), c) => (a, c, b)
-                    }
-                  } finally {
-                    vecStr.close()
-                    vecFloat.close()
-                    vecFl2.close()
-                  }
-              }
+  //         try {
+  //           colVec.free()
+  //           expect(arrowVec.toString == biv.toString)
+  //         } finally arrowVec.close()
+  //       }
+  //     }
+  //   }
 
-              val allSets = plainResultsD.flatMap(_._2).toSet
+  //   "for Int" in {
+  //     WithTestAllocator { implicit alloc =>
+  //       withDirectIntVector(List(1, 2, 3, -5)) { dirInt =>
+  //         val colVec: VeColVector = VeColVector.fromArrowVector(dirInt)
+  //         val arrowVec = colVec.toBytePointerVector.toArrowVector
 
-              val expectedGroups: Set[(Double, String, Double)] =
-                Set((1, "a", 9), (2, "b", 8), (3, lastString, 7))
+  //         try {
+  //           colVec.free()
+  //           expect(arrowVec.toString == dirInt.toString)
+  //         } finally arrowVec.close()
+  //       }
+  //     }
+  //   }
+  // }
 
-              assert(
-                plainResultsD.map(_._2.size).toSet == Set(1, 2),
-                "We expect the groups to have exactly size 2 and 1 each because of the split"
-              )
-              assert(allSets == expectedGroups, "we verify that we get back the data we had put in")
-            }
-          }
-        }
-      }
-    }
-  }
+  // "Execute our function" in {
+  //   compiledWithHeaders(DoublingFunction, "f") { path =>
+  //     val lib = veProcess.loadLibrary(path)
+  //     WithTestAllocator { implicit alloc =>
+  //       withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
+  //         val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
+  //         val results = veProcess.execute(
+  //           libraryReference = lib,
+  //           functionName = "f",
+  //           cols = List(colVec),
+  //           results = List(VeNullableDouble.makeCVector("outd"))
+  //         )
+  //         expect(results.size == 1)
+  //         val vec = results.head.toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
+  //         val result = vec.toList
+  //         try expect(result == List[Double](2, 4, 6))
+  //         finally vec.close()
+  //       }
+  //     }
+  //   }
+  // }
 
-  "We can serialize/deserialize VeColVector" - {
+  // "Execute multi-function" in {
+  //   compiledWithHeaders(PartitioningFunction, "f") { path =>
+  //     val lib = veProcess.loadLibrary(path)
+  //     WithTestAllocator { implicit alloc =>
+  //       withArrowFloat8VectorI(List(95, 99, 105, 500, 501)) { f8v =>
+  //         val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
+  //         val results = veProcess.executeMulti(
+  //           libraryReference = lib,
+  //           functionName = "f",
+  //           cols = List(colVec),
+  //           results = List(VeNullableDouble.makeCVector("outd"))
+  //         )
 
-    def checkVector(
-      valueVector: ValueVector
-    )(implicit veProcess: VeProcess, bufferAllocator: BufferAllocator): Unit = {
-      val colVec: VeColVector = VeColVector.fromArrowVector(valueVector)
-      val serialized = colVec.serialize()
-      val serList = serialized.toList
-      val newColVec = colVec.underlying.toUnit.deserialize(serialized)
-      expect(
-        newColVec.containerLocation != colVec.containerLocation,
-        newColVec.bufferLocations != colVec.bufferLocations
-      )
-      val newSerialized = newColVec.serialize().toList
-      val newSerList = newSerialized.toList
-      assert(newSerList == serList, "Serializing a deserialized one should yield the same result")
-      val newColVecArrow = newColVec.toBytePointerVector.toArrowVector
-      try {
-        colVec.free()
-        newColVec.free()
-        expect(newColVecArrow.toString == valueVector.toString)
-      } finally newColVecArrow.close()
+  //         val plainResults: List[(Int, Option[Double])] = results.map { case (index, vecs) =>
+  //           val vec = vecs.head
+  //           index -> {
+  //             val av = vec.toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
+  //             val avl = av.toList
+  //             try if (avl.isEmpty) None else Some(avl.max)
+  //             finally av.close()
+  //           }
+  //         }
 
-    }
+  //         val expectedResult: List[(Int, Option[Double])] =
+  //           List((0, Some(99)), (1, Some(105)), (2, None), (3, None), (4, Some(501)))
 
-    "for Float8Vector" in {
-      WithTestAllocator { implicit alloc =>
-        withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
-          checkVector(f8v)
-        }
-      }
-    }
-    "for IntVector" in {
-      WithTestAllocator { implicit alloc =>
-        withDirectIntVector(List(1, 2, 3)) { f8v =>
-          checkVector(f8v)
-        }
-      }
-    }
-    "for BigIntVector" in {
-      WithTestAllocator { implicit alloc =>
-        withDirectBigIntVector(List(1, 2, 3)) { f8v =>
-          checkVector(f8v)
-        }
-      }
-    }
-    "for VarCharVector" in {
-      WithTestAllocator { implicit alloc =>
-        withArrowStringVector(List("1", "2", "3x")) { sv =>
-          checkVector(sv)
-        }
-      }
-    }
-    "for empty VarCharVector" in {
-      WithTestAllocator { implicit alloc =>
-        withArrowStringVector(List.empty) { sv =>
-          checkVector(sv)
-        }
-      }
-    }
-    "for an empty Float8Vector" in {
-      WithTestAllocator { implicit alloc =>
-        withArrowFloat8VectorI(List.empty) { f8v =>
-          checkVector(f8v)
-        }
-      }
-    }
-  }
+  //         expect(plainResults == expectedResult)
+  //       }
+  //     }
+  //   }
+  // }
 
-  /**
-   * Let's first take the data, as it is,
-   * perform partial aggregation,
-   * then bucket it,
-   * then exchange it,
-   * re-merge according to buckets
-   * then finalize
-   */
+  // "Partition data by some means (simple Int partitioning in this case) (PIN)" in {
+  //   val groupingFn = GroupingFunction(
+  //     "f",
+  //     List(
+  //       GroupingFunction.DataDescription(VeNullableDouble, GroupingFunction.Key),
+  //       GroupingFunction.DataDescription(VeString, GroupingFunction.Key),
+  //       GroupingFunction.DataDescription(VeNullableDouble, GroupingFunction.Value)
+  //     ),
+  //     2
+  //   )
 
-  "We can merge multiple VeColBatches" in {
-    val mergeFn = MergeFunction("merger", List(VeNullableDouble, VeString))
+  //   compiledWithHeaders(groupingFn.toCFunction) { path =>
+  //     val lib = veProcess.loadLibrary(path)
+  //     WithTestAllocator { implicit alloc =>
+  //       withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
+  //         withArrowFloat8VectorI(List(9, 8, 7)) { f8v2 =>
+  //           val lastString = "cccc"
+  //           withNullableArrowStringVector(List("a", "b", lastString).map(Some.apply)) { sv =>
+  //             val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
+  //             val colVec2: VeColVector = VeColVector.fromArrowVector(f8v2)
+  //             val colVecS: VeColVector = VeColVector.fromArrowVector(sv)
+  //             val results = veProcess.executeMulti(
+  //               libraryReference = lib,
+  //               functionName = groupingFn.name,
+  //               cols = List(colVec, colVecS, colVec2),
+  //               results = List(
+  //                 VeNullableDouble,
+  //                 VeString,
+  //                 VeNullableDouble
+  //               ).zipWithIndex.map { case (vt, i) => vt.makeCVector(s"out_${i}") }
+  //             )
 
-    compiledWithHeaders(mergeFn.toCFunction) {
-      path =>
-        val lib = veProcess.loadLibrary(path)
-        WithTestAllocator { implicit alloc =>
-          withArrowFloat8VectorI(List(1, 2, 3, -1)) { f8v =>
-            withArrowStringVector(Seq("a", "b", "c", "x")) { sv =>
-              withArrowStringVector(Seq("d", "e", "f")) { sv2 =>
-                withArrowFloat8VectorI(List(2, 3, 4)) { f8v2 =>
-                  val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
-                  val colVec2: VeColVector = VeColVector.fromArrowVector(f8v2)
-                  val sVec: VeColVector = VeColVector.fromArrowVector(sv)
-                  val sVec2: VeColVector = VeColVector.fromArrowVector(sv2)
-                  val colBatch1: VeColBatch = VeColBatch(colVec.numItems, List(colVec, sVec))
-                  val colBatch2: VeColBatch = VeColBatch(colVec2.numItems, List(colVec2, sVec2))
-                  val bg = VeBatchOfBatches.fromVeColBatches(List(colBatch1, colBatch2))
-                  val r: List[VeColVector] = veProcess.executeMultiIn(
-                    libraryReference = lib,
-                    functionName = mergeFn.name,
-                    batches = bg,
-                    results = colBatch1.cols.zipWithIndex.map { case (vcv, idx) =>
-                      vcv.veType.makeCVector(s"o_${idx}")
-                    }
-                  )
+  //             val plainResultsD: List[(Int, List[(Double, String, Double)])] = results.map {
+  //               case (index, vecs) =>
+  //                 val vecFloat = vecs(0).toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
+  //                 val vecStr = vecs(1).toBytePointerVector.toArrowVector.asInstanceOf[VarCharVector]
+  //                 val vecFl2 = vecs(2).toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector]
+  //                 try {
+  //                   index -> vecFloat.toList.zip(vecFl2.toList).zip(vecStr.toList).map {
+  //                     case ((a, b), c) => (a, c, b)
+  //                   }
+  //                 } finally {
+  //                   vecStr.close()
+  //                   vecFloat.close()
+  //                   vecFl2.close()
+  //                 }
+  //             }
 
-                  val resultVecs: List[FieldVector] = r.map(_.toBytePointerVector.toArrowVector)
+  //             val allSets = plainResultsD.flatMap(_._2).toSet
 
-                  try {
-                    val nums = resultVecs(0).asInstanceOf[Float8Vector].toListSafe
-                    val strs = resultVecs(1).asInstanceOf[VarCharVector].toList
+  //             val expectedGroups: Set[(Double, String, Double)] =
+  //               Set((1, "a", 9), (2, "b", 8), (3, lastString, 7))
 
-                    val expected = List(1, 2, 3, -1, 2, 3, 4).map(v => Option(v))
-                    val expectedStrs = Seq("a", "b", "c", "x", "d", "e", "f")
-                    expect(nums == expected, strs == expectedStrs)
-                  } finally resultVecs.foreach(_.close())
-                }
-              }
-            }
-          }
-        }
-    }
-  }
+  //             assert(
+  //               plainResultsD.map(_._2.size).toSet == Set(1, 2),
+  //               "We expect the groups to have exactly size 2 and 1 each because of the split"
+  //             )
+  //             assert(allSets == expectedGroups, "we verify that we get back the data we had put in")
+  //           }
+  //         }
+  //       }
+  //     }
+  //   }
+  // }
+
+  // "We can serialize/deserialize VeColVector" - {
+
+  //   def checkVector(
+  //     valueVector: ValueVector
+  //   )(implicit veProcess: VeProcess, bufferAllocator: BufferAllocator): Unit = {
+  //     val colVec: VeColVector = VeColVector.fromArrowVector(valueVector)
+  //     val serialized = colVec.serialize()
+  //     val serList = serialized.toList
+  //     val newColVec = colVec.underlying.toUnit.deserialize(serialized)
+  //     expect(
+  //       newColVec.containerLocation != colVec.containerLocation,
+  //       newColVec.bufferLocations != colVec.bufferLocations
+  //     )
+  //     val newSerialized = newColVec.serialize().toList
+  //     val newSerList = newSerialized.toList
+  //     assert(newSerList == serList, "Serializing a deserialized one should yield the same result")
+  //     val newColVecArrow = newColVec.toBytePointerVector.toArrowVector
+  //     try {
+  //       colVec.free()
+  //       newColVec.free()
+  //       expect(newColVecArrow.toString == valueVector.toString)
+  //     } finally newColVecArrow.close()
+
+  //   }
+
+  //   "for Float8Vector" in {
+  //     WithTestAllocator { implicit alloc =>
+  //       withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
+  //         checkVector(f8v)
+  //       }
+  //     }
+  //   }
+  //   "for IntVector" in {
+  //     WithTestAllocator { implicit alloc =>
+  //       withDirectIntVector(List(1, 2, 3)) { f8v =>
+  //         checkVector(f8v)
+  //       }
+  //     }
+  //   }
+  //   "for BigIntVector" in {
+  //     WithTestAllocator { implicit alloc =>
+  //       withDirectBigIntVector(List(1, 2, 3)) { f8v =>
+  //         checkVector(f8v)
+  //       }
+  //     }
+  //   }
+  //   "for VarCharVector" in {
+  //     WithTestAllocator { implicit alloc =>
+  //       withArrowStringVector(List("1", "2", "3x")) { sv =>
+  //         checkVector(sv)
+  //       }
+  //     }
+  //   }
+  //   "for empty VarCharVector" in {
+  //     WithTestAllocator { implicit alloc =>
+  //       withArrowStringVector(List.empty) { sv =>
+  //         checkVector(sv)
+  //       }
+  //     }
+  //   }
+  //   "for an empty Float8Vector" in {
+  //     WithTestAllocator { implicit alloc =>
+  //       withArrowFloat8VectorI(List.empty) { f8v =>
+  //         checkVector(f8v)
+  //       }
+  //     }
+  //   }
+  // }
+
+  // /**
+  //  * Let's first take the data, as it is,
+  //  * perform partial aggregation,
+  //  * then bucket it,
+  //  * then exchange it,
+  //  * re-merge according to buckets
+  //  * then finalize
+  //  */
+
+  // "We can merge multiple VeColBatches" in {
+  //   val mergeFn = MergeFunction("merger", List(VeNullableDouble, VeString))
+
+  //   compiledWithHeaders(mergeFn.toCFunction) {
+  //     path =>
+  //       val lib = veProcess.loadLibrary(path)
+  //       WithTestAllocator { implicit alloc =>
+  //         withArrowFloat8VectorI(List(1, 2, 3, -1)) { f8v =>
+  //           withArrowStringVector(Seq("a", "b", "c", "x")) { sv =>
+  //             withArrowStringVector(Seq("d", "e", "f")) { sv2 =>
+  //               withArrowFloat8VectorI(List(2, 3, 4)) { f8v2 =>
+  //                 val colVec: VeColVector = VeColVector.fromArrowVector(f8v)
+  //                 val colVec2: VeColVector = VeColVector.fromArrowVector(f8v2)
+  //                 val sVec: VeColVector = VeColVector.fromArrowVector(sv)
+  //                 val sVec2: VeColVector = VeColVector.fromArrowVector(sv2)
+  //                 val colBatch1: VeColBatch = VeColBatch(colVec.numItems, List(colVec, sVec))
+  //                 val colBatch2: VeColBatch = VeColBatch(colVec2.numItems, List(colVec2, sVec2))
+  //                 val bg = VeBatchOfBatches.fromVeColBatches(List(colBatch1, colBatch2))
+  //                 val r: List[VeColVector] = veProcess.executeMultiIn(
+  //                   libraryReference = lib,
+  //                   functionName = mergeFn.name,
+  //                   batches = bg,
+  //                   results = colBatch1.cols.zipWithIndex.map { case (vcv, idx) =>
+  //                     vcv.veType.makeCVector(s"o_${idx}")
+  //                   }
+  //                 )
+
+  //                 val resultVecs: List[FieldVector] = r.map(_.toBytePointerVector.toArrowVector)
+
+  //                 try {
+  //                   val nums = resultVecs(0).asInstanceOf[Float8Vector].toListSafe
+  //                   val strs = resultVecs(1).asInstanceOf[VarCharVector].toList
+
+  //                   val expected = List(1, 2, 3, -1, 2, 3, 4).map(v => Option(v))
+  //                   val expectedStrs = Seq("a", "b", "c", "x", "d", "e", "f")
+  //                   expect(nums == expected, strs == expectedStrs)
+  //                 } finally resultVecs.foreach(_.close())
+  //               }
+  //             }
+  //           }
+  //         }
+  //       }
+  //   }
+  // }
 }

--- a/src/test/scala/com/nec/ve/CachingSpec.scala
+++ b/src/test/scala/com/nec/ve/CachingSpec.scala
@@ -1,5 +1,6 @@
 package com.nec.ve
 
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.SparkAdditions
 import com.nec.tpc.TPCHVESqlSpec
 import com.nec.ve.CachingSpec.SampleStructure
@@ -14,6 +15,8 @@ object CachingSpec {
     SampleStructure(str = "cd", num = 5)
   )
 }
+
+@VectorEngineTest
 final class CachingSpec extends AnyFreeSpec with SparkAdditions with VeKernelInfra {
   "We can retrieve cached items back out" ignore withSparkSession2(
     TPCHVESqlSpec.VeConfiguration(failFast = true)

--- a/src/test/scala/com/nec/ve/CheckCompiledLibrarySpec.scala
+++ b/src/test/scala/com/nec/ve/CheckCompiledLibrarySpec.scala
@@ -1,9 +1,11 @@
 package com.nec.ve
 
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.agile.CppResource.CppResources
 import com.nec.ve.VeKernelCompiler.PlatformLibrarySoName
 import org.scalatest.freespec.AnyFreeSpec
 
+@VectorEngineTest
 final class CheckCompiledLibrarySpec extends AnyFreeSpec {
   "We can get the resource file" in {
     val names = CppResources.AllVe.all.map(_.name)

--- a/src/test/scala/com/nec/ve/ColumnarBatchToVeColBatchTest.scala
+++ b/src/test/scala/com/nec/ve/ColumnarBatchToVeColBatchTest.scala
@@ -3,6 +3,7 @@ package com.nec.ve
 import com.nec.arrow.{ArrowEncodingSettings, WithTestAllocator}
 import com.nec.arrow.colvector.ArrowVectorConversions._
 import com.nec.cache.ColumnarBatchToVeColBatch
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.SparkAdditions
 import com.nec.ve.VeProcess.OriginalCallingContext
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
@@ -40,6 +41,7 @@ object ColumnarBatchToVeColBatchTest {
 
 }
 
+@VectorEngineTest
 final class ColumnarBatchToVeColBatchTest
   extends AnyFreeSpec
   with SparkAdditions

--- a/src/test/scala/com/nec/ve/DetectVectorEngineSpec.scala
+++ b/src/test/scala/com/nec/ve/DetectVectorEngineSpec.scala
@@ -20,6 +20,7 @@
 package com.nec.ve
 
 import com.eed3si9n.expecty.Expecty._
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.{AuroraSqlPlugin, SparkAdditions}
 import com.nec.ve.DetectVectorEngineSpec.{ExpectedClassPathItems, ExtraClassPath, VeClusterConfig}
 import org.apache.log4j.Level
@@ -68,6 +69,7 @@ object DetectVectorEngineSpec {
   final case class SampleClass(a: Int, b: Double)
 }
 
+@VectorEngineTest
 final class DetectVectorEngineSpec extends AnyFreeSpec with BeforeAndAfter with SparkAdditions {
   "It works" in {
     import scala.collection.JavaConverters._

--- a/src/test/scala/com/nec/ve/DualModeVESpec.scala
+++ b/src/test/scala/com/nec/ve/DualModeVESpec.scala
@@ -4,6 +4,7 @@ import com.nec.arrow.ArrowEncodingSettings
 import com.nec.arrow.colvector.SparkSqlColumnVectorConversions._
 import com.nec.cache.CycloneCacheBase
 import com.nec.cache.DualMode.unwrapPossiblyDualToVeColBatches
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.{SparkAdditions, SparkCycloneExecutorPlugin}
 import com.nec.ve.VeColBatch.VeColVectorSource
 import com.nec.ve.VeProcess.{DeferredVeProcess, OriginalCallingContext, WrappingVeo}
@@ -21,6 +22,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import scala.collection.JavaConverters.asScalaIteratorConverter
 
 @org.scalatest.Ignore()
+@VectorEngineTest
 final class DualModeVESpec
   extends AnyFreeSpec
   with SparkAdditions

--- a/src/test/scala/com/nec/ve/DynamicBenchmarkVeCheck.scala
+++ b/src/test/scala/com/nec/ve/DynamicBenchmarkVeCheck.scala
@@ -19,6 +19,7 @@
  */
 package com.nec.ve
 
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.BenchTestingPossibilities
 import org.scalatest.freespec.AnyFreeSpec
 import com.nec.spark.SparkCycloneExecutorPlugin
@@ -29,6 +30,7 @@ import org.apache.log4j.Level
 import org.apache.log4j.Logger
 import org.bytedeco.veoffload.global.veo
 
+@VectorEngineTest
 final class DynamicBenchmarkVeCheck
   extends AnyFreeSpec
   with BeforeAndAfterAll

--- a/src/test/scala/com/nec/ve/DynamicVeSqlExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/ve/DynamicVeSqlExpressionEvaluationSpec.scala
@@ -20,6 +20,7 @@
 package com.nec.ve
 
 import com.nec.cmake.DynamicCSqlExpressionEvaluationSpec
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.SparkCycloneExecutorPlugin
 import com.nec.tpc.TPCHVESqlSpec
 import org.apache.spark.sql.SparkSession
@@ -32,6 +33,7 @@ object DynamicVeSqlExpressionEvaluationSpec {
     TPCHVESqlSpec.VeConfiguration(failFast = true)
 }
 
+@VectorEngineTest
 final class DynamicVeSqlExpressionEvaluationSpec extends DynamicCSqlExpressionEvaluationSpec {
 
   override def configuration: SparkSession.Builder => SparkSession.Builder =

--- a/src/test/scala/com/nec/ve/ExchangeOnClusterSpec.scala
+++ b/src/test/scala/com/nec/ve/ExchangeOnClusterSpec.scala
@@ -1,6 +1,7 @@
 package com.nec.ve
 
 import com.eed3si9n.expecty.Expecty.expect
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.SparkAdditions
 import com.nec.ve.DetectVectorEngineSpec.VeClusterConfig
 import com.nec.ve.PureVeFunctions.PartitioningFunction
@@ -8,6 +9,7 @@ import com.nec.ve.VERDDSpec.{MultiFunctionName, exchangeBatches}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 
+@VectorEngineTest
 final class ExchangeOnClusterSpec
   extends AnyFreeSpec
   with SparkAdditions

--- a/src/test/scala/com/nec/ve/ExchangeOnLocalSpec.scala
+++ b/src/test/scala/com/nec/ve/ExchangeOnLocalSpec.scala
@@ -1,12 +1,14 @@
 package com.nec.ve
 
 import com.eed3si9n.expecty.Expecty.expect
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.SparkAdditions
 import com.nec.ve.PureVeFunctions.PartitioningFunction
-import com.nec.ve.VERDDSpec.{exchangeBatches, MultiFunctionName}
+import com.nec.ve.VERDDSpec.{MultiFunctionName, exchangeBatches}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 
+@VectorEngineTest
 final class ExchangeOnLocalSpec
   extends AnyFreeSpec
   with SparkAdditions

--- a/src/test/scala/com/nec/ve/JoinRDDSpec.scala
+++ b/src/test/scala/com/nec/ve/JoinRDDSpec.scala
@@ -1,12 +1,10 @@
 package com.nec.ve
 
-import com.nec.arrow.ArrowVectorBuilders.withDirectFloat8Vector
-import com.nec.arrow.WithTestAllocator
+import com.nec.arrow.colvector.ArrayTConversions._
 import com.nec.arrow.colvector.ArrowVectorConversions._
 import com.nec.spark.{SparkAdditions, SparkCycloneExecutorPlugin}
 import com.nec.util.RichVectors.RichFloat8
 import com.nec.ve.DetectVectorEngineSpec.VeClusterConfig
-import com.nec.ve.JoinRDDSpec.testJoin
 import com.nec.ve.VeColBatch.{VeColVector, VeColVectorSource}
 import com.nec.ve.VeProcess.OriginalCallingContext
 import org.apache.arrow.vector.Float8Vector
@@ -14,6 +12,36 @@ import org.apache.spark.sql.SparkSession
 import org.scalatest.freespec.AnyFreeSpec
 
 final class JoinRDDSpec extends AnyFreeSpec with SparkAdditions with VeKernelInfra {
+  def testJoin(sparkSession: SparkSession): Seq[(Seq[Double], Seq[Double])] = {
+    val partsL: Seq[(Int, Seq[Double])] =
+      Seq(1 -> Seq(3, 4, 5), 2 -> Seq(5, 6, 7))
+    val partsR: Seq[(Int, Seq[Double])] =
+      Seq(1 -> Seq(5, 6, 7), 2 -> Seq(8, 8, 7), 3 -> Seq(9, 6, 7))
+
+    import SparkCycloneExecutorPlugin._
+    import SparkCycloneExecutorPlugin.ImplicitMetrics._
+
+    VeRDDOps
+      .joinExchange(
+        sparkSession.sparkContext.makeRDD(partsL).map { case (i, l) =>
+          import OriginalCallingContext.Automatic._
+          i -> VeColBatch.fromList(List(l.toArray.toBytePointerColVector("left").toVeColVector))
+        },
+        sparkSession.sparkContext.makeRDD(partsR).map { case (i, l) =>
+          import OriginalCallingContext.Automatic._
+          i -> VeColBatch.fromList(List(l.toArray.toBytePointerColVector("right").toVeColVector))
+        },
+        cleanUpInput = true
+      )
+      .map { case (la, lb) =>
+        ???
+        // TODO: fix up test cases
+        //(la.cols.flatMap(_.toSeq), lb.cols.flatMap(_.toSeq))
+      }
+      .collect()
+      .toSeq
+  }
+
 
   "Join data across partitioned data (Local mode)" ignore {
     val result =
@@ -21,14 +49,15 @@ final class JoinRDDSpec extends AnyFreeSpec with SparkAdditions with VeKernelInf
         testJoin(sparkSession)
       }.sortBy(_._1.head)
 
-    val expected: List[(List[Double], List[Double])] =
-      List(
-        List[Double](3, 4, 5) -> List[Double](5, 6, 7),
-        List[Double](5, 6, 7) -> List[Double](8, 8, 7)
+    val expected: Seq[(Seq[Double], Seq[Double])] =
+      Seq(
+        Seq[Double](3, 4, 5) -> Seq[Double](5, 6, 7),
+        Seq[Double](5, 6, 7) -> Seq[Double](8, 8, 7)
       )
 
     assert(result == expected)
   }
+
   "Join data across partitioned data (Cluster mode)" ignore {
     val result =
       withSparkSession2(
@@ -38,86 +67,12 @@ final class JoinRDDSpec extends AnyFreeSpec with SparkAdditions with VeKernelInf
         testJoin(sparkSession)
       }.sortBy(_._1.head)
 
-    val expected: List[(List[Double], List[Double])] =
-      List(
-        List[Double](3, 4, 5) -> List[Double](5, 6, 7),
-        List[Double](5, 6, 7) -> List[Double](8, 8, 7)
+    val expected: Seq[(Seq[Double], Seq[Double])] =
+      Seq(
+        Seq[Double](3, 4, 5) -> Seq[Double](5, 6, 7),
+        Seq[Double](5, 6, 7) -> Seq[Double](8, 8, 7)
       )
 
     assert(result == expected)
   }
-
-}
-
-object JoinRDDSpec {
-
-  def testJoin(sparkSession: SparkSession): List[(List[Double], List[Double])] = {
-
-    val partsL: List[(Int, List[Double])] =
-      List(1 -> List(3, 4, 5), 2 -> List(5, 6, 7))
-    val partsR: List[(Int, List[Double])] =
-      List(1 -> List(5, 6, 7), 2 -> List(8, 8, 7), 3 -> List(9, 6, 7))
-    import SparkCycloneExecutorPlugin._
-    VeRDDOps
-      .joinExchange(
-        sparkSession.sparkContext.makeRDD(partsL).map { case (i, l) =>
-          import OriginalCallingContext.Automatic._
-          i -> VeColBatch.fromList(List(l.toVeColVector()))
-        },
-        sparkSession.sparkContext.makeRDD(partsR).map { case (i, l) =>
-          import OriginalCallingContext.Automatic._
-          i -> VeColBatch.fromList(List(l.toVeColVector()))
-        },
-        cleanUpInput = true
-      )
-      .map { case (la, lb) =>
-        ???
-        // TODO: fix up test cases
-        //(la.cols.flatMap(_.toList), lb.cols.flatMap(_.toList))
-      }
-      .collect()
-      .toList
-  }
-
-  implicit class RichDoubleList(l: List[Double]) {
-    def toVeColVector()(implicit
-      veProcess: VeProcess,
-      source: VeColVectorSource,
-      originalCallingContext: OriginalCallingContext
-    ): VeColVector = {
-      WithTestAllocator { implicit alloc =>
-        withDirectFloat8Vector(l) { vec =>
-          import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics._
-          VeColVector.fromArrowVector(vec)
-        }
-      }
-    }
-  }
-
-  trait ColVectorDecoder[T] {
-    def decode(
-      veColVector: VeColVector
-    )(implicit veProcess: VeProcess, source: VeColVectorSource): List[T]
-  }
-  object ColVectorDecoder {
-    implicit val decodeDouble: ColVectorDecoder[Double] = new ColVectorDecoder[Double] {
-      override def decode(
-        veColVector: VeColVector
-      )(implicit veProcess: VeProcess, source: VeColVectorSource): List[Double] = {
-        WithTestAllocator { implicit alloc =>
-          veColVector.toBytePointerVector.toArrowVector.asInstanceOf[Float8Vector].toList
-        }
-      }
-    }
-  }
-  implicit class RichVeColVector(veColVector: VeColVector) {
-    def toList[T: ColVectorDecoder](implicit
-      veProcess: VeProcess,
-      source: VeColVectorSource
-    ): List[T] =
-      implicitly[ColVectorDecoder[T]].decode(veColVector)
-  }
-
-  val MultiFunctionName = "f_multi"
-
 }

--- a/src/test/scala/com/nec/ve/JoinRDDSpec.scala
+++ b/src/test/scala/com/nec/ve/JoinRDDSpec.scala
@@ -2,6 +2,7 @@ package com.nec.ve
 
 import com.nec.arrow.colvector.ArrayTConversions._
 import com.nec.arrow.colvector.ArrowVectorConversions._
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.{SparkAdditions, SparkCycloneExecutorPlugin}
 import com.nec.util.RichVectors.RichFloat8
 import com.nec.ve.DetectVectorEngineSpec.VeClusterConfig
@@ -11,6 +12,7 @@ import org.apache.arrow.vector.Float8Vector
 import org.apache.spark.sql.SparkSession
 import org.scalatest.freespec.AnyFreeSpec
 
+@VectorEngineTest
 final class JoinRDDSpec extends AnyFreeSpec with SparkAdditions with VeKernelInfra {
   def testJoin(sparkSession: SparkSession): Seq[(Seq[Double], Seq[Double])] = {
     val partsL: Seq[(Int, Seq[Double])] =

--- a/src/test/scala/com/nec/ve/VERDDSpec.scala
+++ b/src/test/scala/com/nec/ve/VERDDSpec.scala
@@ -3,6 +3,7 @@ package com.nec.ve
 import com.eed3si9n.expecty.Expecty.expect
 import com.nec.arrow.WithTestAllocator
 import com.nec.arrow.colvector.ArrowVectorConversions._
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.agile.core.VeNullableDouble
 import com.nec.spark.{SparkAdditions, SparkCycloneExecutorPlugin}
 import com.nec.util.RichVectors.RichFloat8
@@ -20,6 +21,7 @@ import org.apache.spark.sql.util.ArrowUtilsExposed
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 
+@VectorEngineTest
 final class VERDDSpec
   extends AnyFreeSpec
   with SparkAdditions

--- a/src/test/scala/com/nec/ve/VERDDSpec.scala
+++ b/src/test/scala/com/nec/ve/VERDDSpec.scala
@@ -48,7 +48,7 @@ final class VERDDSpec
           .map(_.toDouble)
       }.map { arrowVec =>
         import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics._
-        VeColVector.fromArrowVector(arrowVec)
+        arrowVec.toBytePointerColVector.toVeColVector
       }.map(ve => veProcess.execute(ref, "f", List(ve), DoublingFunction.outputs))
         .map(vectors => {
           WithTestAllocator { implicit alloc =>
@@ -87,7 +87,7 @@ object VERDDSpec {
             .map(arrowVec => {
               import SparkCycloneExecutorPlugin.source
               import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics._
-              try VeColVector.fromArrowVector(arrowVec)
+              try arrowVec.toBytePointerColVector.toVeColVector
               finally arrowVec.close()
             })
             .flatMap(veColVector => {

--- a/src/test/scala/com/nec/ve/VeColVectorUnitSpec.scala
+++ b/src/test/scala/com/nec/ve/VeColVectorUnitSpec.scala
@@ -1,5 +1,6 @@
 package com.nec.ve
 
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.arrow.colvector.SeqOptTConversions._
 import com.nec.ve.colvector.VeColBatch.VeColVectorSource
 import com.nec.ve.VeProcess.OriginalCallingContext
@@ -9,6 +10,7 @@ import java.util.UUID
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers._
 
+@VectorEngineTest
 final class VeColVectorUnitSpec extends AnyWordSpec with WithVeProcess {
   import OriginalCallingContext.Automatic._
 

--- a/src/test/scala/com/nec/ve/VeColVectorUnitSpec.scala
+++ b/src/test/scala/com/nec/ve/VeColVectorUnitSpec.scala
@@ -1,0 +1,71 @@
+package com.nec.ve
+
+import com.nec.arrow.colvector.SeqOptTConversions._
+import com.nec.ve.colvector.VeColBatch.VeColVectorSource
+import com.nec.ve.VeProcess.OriginalCallingContext
+import scala.reflect.ClassTag
+import scala.util.Random
+import java.util.UUID
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers._
+
+final class VeColVectorUnitSpec extends AnyWordSpec with WithVeProcess {
+  import OriginalCallingContext.Automatic._
+
+  def runConversionTest[T <: AnyVal : ClassTag](input: Seq[Option[T]]): Unit = {
+    implicit val source = VeColVectorSource(s"${UUID.randomUUID}")
+    val name = s"${UUID.randomUUID}"
+    val colvec = input.toBytePointerColVector(name).toVeColVector
+
+    // Check fields
+    colvec.underlying.veType.scalaType should be (implicitly[ClassTag[T]].runtimeClass)
+    colvec.underlying.name should be (name)
+    colvec.underlying.source should be (source)
+    colvec.underlying.numItems should be (input.size)
+    colvec.underlying.buffers.size should be (2)
+
+    // Check conversion
+    colvec.toBytePointerVector.toSeqOpt[T] should be (input)
+  }
+
+  "VeColVector" should {
+    "correctly transfer data from Host Off-Heap to VE and back (Int)" in {
+      runConversionTest(0.until(Random.nextInt(100)).map(_ => if (Math.random < 0.5) Some(Random.nextInt(10000)) else None))
+    }
+
+    "correctly transfer data from Host Off-Heap to VE and back (Short)" in {
+      runConversionTest(0.until(Random.nextInt(100)).map(_ => if (Math.random < 0.5) Some(Random.nextInt(10000).toShort) else None))
+    }
+
+    "correctly transfer data from Host Off-Heap to VE and back (Long)" in {
+      runConversionTest(0.until(Random.nextInt(100)).map(_ => if (Math.random < 0.5) Some(Random.nextLong) else None))
+    }
+
+    "correctly transfer data from Host Off-Heap to VE and back (Float)" in {
+      runConversionTest(0.until(Random.nextInt(100)).map(_ => if (Math.random < 0.5) Some(Random.nextFloat * 1000) else None))
+    }
+
+    "correctly transfer data from Host Off-Heap to VE and back (Double)" in {
+      runConversionTest(0.until(Random.nextInt(100)).map(_ => if (Math.random < 0.5) Some(Random.nextDouble * 1000) else None))
+    }
+
+    "correctly transfer data from Host Off-Heap to VE and back (String)" in {
+      val input = 0.until(Random.nextInt(100)).map(_ => if (Math.random < 0.5) Some(Random.nextString(Random.nextInt(30))) else None)
+
+      implicit val source = VeColVectorSource(s"${UUID.randomUUID}")
+      val name = s"${UUID.randomUUID}"
+      val colvec = input.toBytePointerColVector(name).toVeColVector
+
+      // Check fields
+      colvec.underlying.veType.scalaType should be (classOf[String])
+      colvec.underlying.name should be (name)
+      colvec.underlying.source should be (source)
+      colvec.underlying.numItems should be (input.size)
+      colvec.underlying.buffers.size should be (4)
+
+
+      // Check conversion
+      colvec.toBytePointerVector.toSeqOpt[String] should be (input)
+    }
+  }
+}

--- a/src/test/scala/com/nec/ve/WithVeProcess.scala
+++ b/src/test/scala/com/nec/ve/WithVeProcess.scala
@@ -5,7 +5,6 @@ import org.bytedeco.veoffload.global.veo
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
 trait WithVeProcess extends BeforeAndAfterAll { this: Suite =>
-
   implicit def noOpMetrics = VeProcessMetrics.noOp
   implicit def source: VeColVectorSource = VeColVectorSource(s"VE Tests")
   implicit def veProcess: VeProcess = VeProcess.WrappingVeo(proc, source, VeProcessMetrics.noOp)

--- a/src/test/scala/com/nec/ve/eval/AggregateExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/ve/eval/AggregateExpressionEvaluationSpec.scala
@@ -19,10 +19,8 @@
  */
 package com.nec.ve.eval
 
-import com.nec.spark.agile.CFunctionGeneration.GroupByExpression.{
-  GroupByAggregation,
-  GroupByProjection
-}
+import com.nec.cyclone.annotations.VectorEngineTest
+import com.nec.spark.agile.CFunctionGeneration.GroupByExpression.{GroupByAggregation, GroupByProjection}
 import com.nec.spark.agile.join.JoinUtils.JoinExpression.JoinProjection
 import com.nec.spark.agile.core.VeNullableDouble
 import com.nec.spark.agile.CFunctionGeneration._
@@ -37,6 +35,7 @@ import org.scalatest.Ignore
 import org.scalatest.freespec.AnyFreeSpec
 
 @Ignore
+@VectorEngineTest
 final class AggregateExpressionEvaluationSpec
   extends AnyFreeSpec
   with WithVeProcess

--- a/src/test/scala/com/nec/ve/eval/DateCastStringHoleEvaluationSpec.scala
+++ b/src/test/scala/com/nec/ve/eval/DateCastStringHoleEvaluationSpec.scala
@@ -1,6 +1,7 @@
 package com.nec.ve.eval
 
 import com.nec.cmake.CMakeBuilder
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.agile.core._
 import com.nec.spark.agile.CFunctionGeneration.CFunction
 import com.nec.spark.agile.StringHole.StringHoleEvaluation
@@ -14,6 +15,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 @Ignore
+@VectorEngineTest
 final class DateCastStringHoleEvaluationSpec extends AnyFlatSpec {
   "It" should "correctly map string to date" in {
     val list = List("1970-01-01", "2000-01-01", "1960-01-01", "2022-12-31")

--- a/src/test/scala/com/nec/ve/eval/FilterExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/ve/eval/FilterExpressionEvaluationSpec.scala
@@ -20,6 +20,7 @@
 package com.nec.ve.eval
 
 import com.eed3si9n.expecty.Expecty.expect
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.agile.CFunctionGeneration._
 import com.nec.ve._
 import org.scalatest.Ignore
@@ -29,6 +30,7 @@ import org.scalatest.freespec.AnyFreeSpec
  * This test suite evaluates expressions and Ve logical plans to verify correctness of the key bits.
  */
 @Ignore
+@VectorEngineTest
 final class FilterExpressionEvaluationSpec
   extends AnyFreeSpec
   with WithVeProcess

--- a/src/test/scala/com/nec/ve/eval/InStringHoleEvaluationSpec.scala
+++ b/src/test/scala/com/nec/ve/eval/InStringHoleEvaluationSpec.scala
@@ -1,6 +1,7 @@
 package com.nec.ve.eval
 
 import com.nec.cmake.CMakeBuilder
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.agile.core.{CodeLines, VeNullableInt}
 import com.nec.spark.agile.CFunctionGeneration.CFunction
 import com.nec.spark.agile.core.{CVector, VeScalarType}
@@ -13,6 +14,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import scala.util.Random
 
 @Ignore
+@VectorEngineTest
 final class InStringHoleEvaluationSpec extends AnyWordSpec {
   implicit class EvalOps(evaluation: InStringHoleEvaluation) {
     def execute(input: List[String]): List[Int] = {

--- a/src/test/scala/com/nec/ve/eval/JoinExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/ve/eval/JoinExpressionEvaluationSpec.scala
@@ -19,6 +19,7 @@
  */
 package com.nec.ve.eval
 
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.agile.join.JoinUtils.JoinExpression.JoinProjection
 import com.nec.spark.agile.join.JoinUtils.TypedJoinExpression
 import com.nec.spark.agile.CFunctionGeneration._
@@ -29,6 +30,7 @@ import org.scalatest.Ignore
 import org.scalatest.freespec.AnyFreeSpec
 
 @Ignore
+@VectorEngineTest
 final class JoinExpressionEvaluationSpec extends AnyFreeSpec with WithVeProcess with VeKernelInfra {
 
   import RealExpressionEvaluationUtils._

--- a/src/test/scala/com/nec/ve/eval/ProjectExpressionEvalSpec.scala
+++ b/src/test/scala/com/nec/ve/eval/ProjectExpressionEvalSpec.scala
@@ -20,6 +20,7 @@
 package com.nec.ve.eval
 
 import com.eed3si9n.expecty.Expecty.expect
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.agile.CFunctionGeneration._
 import com.nec.spark.agile.SparkExpressionToCExpression.EvalFallback
 import com.nec.ve._
@@ -28,6 +29,7 @@ import org.scalatest.freespec.AnyFreeSpec
 /**
  * This test suite evaluates expressions and Ve logical plans to verify correctness of the key bits.
  */
+@VectorEngineTest
 final class ProjectExpressionEvalSpec extends AnyFreeSpec with WithVeProcess with VeKernelInfra {
 
   import RealExpressionEvaluationUtils._

--- a/src/test/scala/com/nec/ve/eval/SortExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/ve/eval/SortExpressionEvaluationSpec.scala
@@ -20,6 +20,7 @@
 package com.nec.ve.eval
 
 import com.eed3si9n.expecty.Expecty.expect
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.agile.CFunctionGeneration._
 import com.nec.spark.agile.core._
 import com.nec.spark.agile.SparkExpressionToCExpression.EvalFallback
@@ -31,6 +32,7 @@ import org.scalatest.freespec.AnyFreeSpec
 /**
  * This test suite evaluates expressions and Ve logical plans to verify correctness of the key bits.
  */
+@VectorEngineTest
 final class SortExpressionEvaluationSpec extends AnyFreeSpec with WithVeProcess with VeKernelInfra {
 
   import RealExpressionEvaluationUtils._

--- a/src/test/scala/com/nec/ve/eval/StaticTypingTestAdditions.scala
+++ b/src/test/scala/com/nec/ve/eval/StaticTypingTestAdditions.scala
@@ -66,7 +66,7 @@ object StaticTypingTestAdditions {
       ): VeColBatch =
         WithTestAllocator { implicit a =>
           withArrowFloat8VectorI(data) { f8v =>
-            VeColBatch.fromList(List(VeColVector.fromArrowVector(f8v)))
+            VeColBatch.fromList(List(f8v.toBytePointerColVector.toVeColVector))
           }
         }
 
@@ -81,7 +81,7 @@ object StaticTypingTestAdditions {
       ): VeColBatch =
         WithTestAllocator { implicit a =>
           withArrowStringVector(data) { vcv =>
-            VeColBatch.fromList(List(VeColVector.fromArrowVector(vcv)))
+            VeColBatch.fromList(List(vcv.toBytePointerColVector.toVeColVector))
           }
         }
       override def veTypes: List[VeType] = List(VeString)
@@ -97,7 +97,10 @@ object StaticTypingTestAdditions {
           withArrowStringVector(data.map(_._1)) { vcv =>
             withArrowFloat8VectorI(data.map(_._2)) { f8v =>
               VeColBatch.fromList(
-                List(VeColVector.fromArrowVector(vcv), VeColVector.fromArrowVector(f8v))
+                List(
+                  vcv.toBytePointerColVector.toVeColVector,
+                  f8v.toBytePointerColVector.toVeColVector
+                )
               )
             }
           }
@@ -116,7 +119,10 @@ object StaticTypingTestAdditions {
           withArrowFloat8VectorI(data.map(_._1)) { vcv =>
             withArrowFloat8VectorI(data.map(_._2)) { f8v =>
               VeColBatch.fromList(
-                List(VeColVector.fromArrowVector(vcv), VeColVector.fromArrowVector(f8v))
+                List(
+                  vcv.toBytePointerColVector.toVeColVector,
+                  f8v.toBytePointerColVector.toVeColVector
+                )
               )
             }
           }
@@ -137,9 +143,9 @@ object StaticTypingTestAdditions {
               withArrowFloat8VectorI(data.map(_._3)) { c =>
                 VeColBatch.fromList(
                   List(
-                    VeColVector.fromArrowVector(a),
-                    VeColVector.fromArrowVector(b),
-                    VeColVector.fromArrowVector(c)
+                    a.toBytePointerColVector.toVeColVector,
+                    b.toBytePointerColVector.toVeColVector,
+                    c.toBytePointerColVector.toVeColVector
                   )
                 )
               }
@@ -165,10 +171,10 @@ object StaticTypingTestAdditions {
                 withArrowFloat8VectorI(data.map(_._3)) { d =>
                   VeColBatch.fromList(
                     List(
-                      VeColVector.fromArrowVector(a),
-                      VeColVector.fromArrowVector(b),
-                      VeColVector.fromArrowVector(c),
-                      VeColVector.fromArrowVector(d)
+                      a.toBytePointerColVector.toVeColVector,
+                      b.toBytePointerColVector.toVeColVector,
+                      c.toBytePointerColVector.toVeColVector,
+                      d.toBytePointerColVector.toVeColVector
                     )
                   )
                 }
@@ -189,7 +195,7 @@ object StaticTypingTestAdditions {
       ): VeColBatch =
         WithTestAllocator { implicit a =>
           withNullableDoubleVector(data) { f8v =>
-            VeColBatch.fromList(List(VeColVector.fromArrowVector(f8v)))
+            VeColBatch.fromList(List(f8v.toBytePointerColVector.toVeColVector))
           }
         }
 
@@ -209,9 +215,9 @@ object StaticTypingTestAdditions {
               withArrowFloat8VectorI(data.map(_._2)) { c =>
                 VeColBatch.fromList(
                   List(
-                    VeColVector.fromArrowVector(a),
-                    VeColVector.fromArrowVector(b),
-                    VeColVector.fromArrowVector(c)
+                    a.toBytePointerColVector.toVeColVector,
+                    b.toBytePointerColVector.toVeColVector,
+                    c.toBytePointerColVector.toVeColVector
                   )
                 )
               }

--- a/src/test/scala/com/nec/ve/eval/StringOpsStringHoleEvaluationSpec.scala
+++ b/src/test/scala/com/nec/ve/eval/StringOpsStringHoleEvaluationSpec.scala
@@ -2,6 +2,7 @@ package com.nec.ve.eval
 
 import com.eed3si9n.expecty.Expecty.expect
 import com.nec.arrow.WithTestAllocator
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.agile.core._
 import com.nec.spark.agile.CFunctionGeneration.CFunction
 import com.nec.spark.agile.StringHole
@@ -16,6 +17,7 @@ import org.scalatest.Ignore
 import org.scalatest.freespec.AnyFreeSpec
 
 @Ignore
+@VectorEngineTest
 final class StringOpsStringHoleEvaluationSpec
   extends AnyFreeSpec
   with WithVeProcess

--- a/src/test/scala/com/nec/ve/serializer/VeSerializerSpec.scala
+++ b/src/test/scala/com/nec/ve/serializer/VeSerializerSpec.scala
@@ -4,6 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import com.nec.arrow.ArrowVectorBuilders.withArrowFloat8VectorI
 import com.nec.arrow.colvector.ArrowVectorConversions._
 import com.nec.arrow.WithTestAllocator
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.ve.colvector.VeColBatch.VeColVector
 import com.nec.ve.serializer.DualBatchOrBytes.ColBatchWrapper
 import com.nec.ve.{VeColBatch, VeKernelInfra, WithVeProcess}
@@ -11,6 +12,7 @@ import org.scalatest.freespec.AnyFreeSpec
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, DataOutputStream}
 
+@VectorEngineTest
 final class VeSerializerSpec extends AnyFreeSpec with WithVeProcess with VeKernelInfra {
   import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
 

--- a/src/test/scala/com/nec/ve/serializer/VeSerializerSpec.scala
+++ b/src/test/scala/com/nec/ve/serializer/VeSerializerSpec.scala
@@ -19,7 +19,7 @@ final class VeSerializerSpec extends AnyFreeSpec with WithVeProcess with VeKerne
       withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
         withArrowFloat8VectorI(List(-1, -2, -3)) { f8v2 =>
           val colVec: VeColBatch = VeColBatch.fromList(
-            List(VeColVector.fromArrowVector(f8v), VeColVector.fromArrowVector(f8v2))
+            List(f8v.toBytePointerColVector.toVeColVector, f8v2.toBytePointerColVector.toVeColVector)
           )
           val theBatch = VeColBatch.deserialize(colVec.serialize())
           val gotVecStr = theBatch.cols.head.toBytePointerVector.toArrowVector.toString
@@ -38,7 +38,7 @@ final class VeSerializerSpec extends AnyFreeSpec with WithVeProcess with VeKerne
       withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
         withArrowFloat8VectorI(List(-1, -2, -3)) { f8v2 =>
           val veColBatch: VeColBatch = VeColBatch.fromList(
-            List(VeColVector.fromArrowVector(f8v), VeColVector.fromArrowVector(f8v2))
+            List(f8v.toBytePointerColVector.toVeColVector, f8v2.toBytePointerColVector.toVeColVector)
           )
           val byteArrayOutputStream = new ByteArrayOutputStream()
           val dataOutputStream = new DataOutputStream(byteArrayOutputStream)
@@ -67,7 +67,7 @@ final class VeSerializerSpec extends AnyFreeSpec with WithVeProcess with VeKerne
       withArrowFloat8VectorI(List(1, 2, 3)) { f8v =>
         withArrowFloat8VectorI(List(-1, -2, -3)) { f8v2 =>
           val veColBatch: VeColBatch = VeColBatch.fromList(
-            List(VeColVector.fromArrowVector(f8v), VeColVector.fromArrowVector(f8v2))
+            List(f8v.toBytePointerColVector.toVeColVector, f8v2.toBytePointerColVector.toVeColVector)
           )
 
           val byteArrayOutputStream = new ByteArrayOutputStream()


### PR DESCRIPTION
Summary:

- [NS-9] Rewrite `ByteArrayColVector` as its own type instead of as a handle of `GenericColVector[Option[Array[Byte]]` to simplify its implementation
- [NS-10] Add unit tests to check conversions from `BytePointerColVector` to `ByteArrayColVector`
- [NS-10] Update `ByteArrayColVector` constraints to allow for construction from empty `BytePointerColVector`
- [NS-16] Rather than denoting VE tests by their package namespaces, use ScalaTest tags and annotations to mark VE tests with `@VectorEngineTest` annotation and have `sbt` filter tests based on annotations.  This allows VE tests to be defined in different packages as well as allow for running different (but overlapping) subsets of tests based on their annotations.
- [NS-16] Mark all existing VE tests with `@VectorEngineTest` annotation
- [NS-16] Update `build.sbt` to filter for VE tests based on the `@VectorEngineTest` annotation
- Uncomment `ArrowTransferCheck` tests
- Move over some unit tests in `ArrowTransferCheck` to `VeColVectorUnitSpec`
- Remove deprecated and unused code in `JoinRDDSpec`


[NS-9]: https://xpressai.atlassian.net/browse/NS-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NS-10]: https://xpressai.atlassian.net/browse/NS-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NS-10]: https://xpressai.atlassian.net/browse/NS-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NS-16]: https://xpressai.atlassian.net/browse/NS-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NS-16]: https://xpressai.atlassian.net/browse/NS-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NS-16]: https://xpressai.atlassian.net/browse/NS-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ