### PR TITLE
Use asynchronous memory access

### DIFF
--- a/src/main/scala/com/nec/cache/ColumnarBatchToVeColBatch.scala
+++ b/src/main/scala/com/nec/cache/ColumnarBatchToVeColBatch.scala
@@ -35,9 +35,9 @@ object ColumnarBatchToVeColBatch {
                   .toBytePointerColVector(field.getName, columnarBatch.numRows)
                   .asyncToVeColVector
             }
-          ).map(_.apply())
+          )
     }.map{ it =>
-      VeColBatch(it.map(_.get()).toList)
+      VeColBatch(it.map(_.apply()).map(_.get()).toList)
     }.toList.iterator
   }
 

--- a/src/main/scala/com/nec/cache/DualColumnarBatchContainer.scala
+++ b/src/main/scala/com/nec/cache/DualColumnarBatchContainer.scala
@@ -1,10 +1,8 @@
 package com.nec.cache
 
 import com.nec.colvector.ArrowVectorConversions._
-import com.nec.colvector.{ByteArrayColBatch, ByteArrayColVector, VeColVector}
+import com.nec.colvector._
 import com.nec.ve.VeProcess.OriginalCallingContext
-import com.nec.colvector.VeColVectorSource
-import com.nec.colvector.VeColBatch
 import com.nec.ve.{VeProcess, VeProcessMetrics}
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
@@ -50,7 +48,7 @@ final case class DualColumnarBatchContainer(vecs: List[Either[VeColVector, ByteA
       case Some(vecs) => VeColBatch(vecs)
       case None =>
         val byteArrayColVectors = vecs.flatMap(_.right.toSeq)
-        VeColBatch(byteArrayColVectors.map(_.toVeColVector))
+        VeColBatch(byteArrayColVectors.map(_.asyncToVeColVector).map(_.apply()).map(_.get()))
     }
   }
 

--- a/src/main/scala/com/nec/colvector/UnitColBatch.scala
+++ b/src/main/scala/com/nec/colvector/UnitColBatch.scala
@@ -1,13 +1,13 @@
 package com.nec.colvector
 
-import com.nec.ve.{VeProcess, VeProcessMetrics}
 import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.ve.{VeProcess, VeProcessMetrics}
 
 final case class UnitColBatch(columns: Seq[UnitColVector]) {
   def withData(arrays: Seq[Array[Byte]])(implicit source: VeColVectorSource,
                                          process: VeProcess,
                                          context: OriginalCallingContext,
                                          metrics: VeProcessMetrics): VeColBatch = {
-    VeColBatch(columns.zip(arrays).map { case (colvec, bytes) => colvec.withData(bytes) })
+    VeColBatch(columns.zip(arrays).map { case (colvec, bytes) => colvec.withData(bytes) }.map(_.apply()).map(_.get()))
   }
 }

--- a/src/main/scala/com/nec/colvector/UnitColVector.scala
+++ b/src/main/scala/com/nec/colvector/UnitColVector.scala
@@ -49,7 +49,7 @@ final case class UnitColVector private[colvector] (
   def withData(array: Array[Byte])(implicit source: VeColVectorSource,
                                    process: VeProcess,
                                    context: OriginalCallingContext,
-                                   metrics: VeProcessMetrics): VeColVector = {
+                                   metrics: VeProcessMetrics): () => VeAsyncResult[VeColVector] = {
     metrics.measureRunningTime {
       val buffers = bufferSizes.scanLeft(0)(_ + _).zip(bufferSizes).map {
         case (start, size) => array.slice(start, start + size)
@@ -61,7 +61,7 @@ final case class UnitColVector private[colvector] (
         veType,
         numItems,
         buffers
-      ).toVeColVector
+      ).asyncToVeColVector
     }(metrics.registerDeserializationTime)
   }
 

--- a/src/main/scala/com/nec/colvector/VeColBatch.scala
+++ b/src/main/scala/com/nec/colvector/VeColBatch.scala
@@ -9,6 +9,7 @@ import org.apache.arrow.memory.BufferAllocator
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
 
 import java.io._
+import java.nio.channels.Channels
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 import scala.util.Try
@@ -68,9 +69,12 @@ final case class VeColBatch(columns: Seq[VeColVector]) {
 
   def toStream(stream: DataOutputStream)(implicit process: VeProcess,
                                          metrics: VeProcessMetrics): Unit = {
+    val hostBuffersAsync = columns.map(_.toBytePointersAsync())
+    val channel = Channels.newChannel(stream)
+
     stream.writeInt(VeColBatch.ColLengthsId)
     stream.writeInt(columns.size)
-    columns.foreach { vec =>
+    columns.zip(hostBuffersAsync).foreach { case (vec, buffers) =>
       stream.writeInt(VeColBatch.DescLengthId)
       stream.writeInt(-1)
       stream.writeInt(VeColBatch.DescDataId)
@@ -79,7 +83,10 @@ final case class VeColBatch(columns: Seq[VeColVector]) {
       // no bytes length as it's a stream here
       stream.writeInt(-1)
       stream.writeInt(VeColBatch.PayloadBytesId)
-      vec.toStream(stream)
+      buffers.map(_.get()).foreach{ bytePointer =>
+        val numWritten = channel.write(bytePointer.asBuffer())
+        require(numWritten == bytePointer.limit(), s"Written ${numWritten}, expected ${bytePointer.limit()}")
+      }
     }
   }
 
@@ -174,7 +181,7 @@ object VeColBatch {
             e
           )
       }
-    }
+    }.map(_.apply()).map(_.get())
 
     VeColBatch(columns)
   }

--- a/src/main/scala/com/nec/colvector/VeColBatch.scala
+++ b/src/main/scala/com/nec/colvector/VeColBatch.scala
@@ -1,13 +1,13 @@
 package com.nec.colvector
 
-import com.nec.colvector.ArrowVectorConversions._
 import com.nec.colvector.ArrayTConversions._
+import com.nec.colvector.ArrowVectorConversions._
 import com.nec.colvector.SparkSqlColumnVectorConversions._
-import com.nec.spark.agile.core.VeType
 import com.nec.ve.VeProcess.OriginalCallingContext
 import com.nec.ve.{VeProcess, VeProcessMetrics}
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
+
 import java.io._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
@@ -199,8 +199,11 @@ object VeColBatch {
                                                    metrics: VeProcessMetrics): VeColBatch = {
     VeColBatch(
       (0 until batch.numCols).map { i =>
-        batch.column(i).getArrowValueVector.toBytePointerColVector.toVeColVector
-      }
+        batch.column(i)
+          .getArrowValueVector
+          .toBytePointerColVector
+          .asyncToVeColVector
+      }.map(_.apply()).map(_.get())
     )
   }
 

--- a/src/main/scala/com/nec/colvector/VeColVector.scala
+++ b/src/main/scala/com/nec/colvector/VeColVector.scala
@@ -1,15 +1,13 @@
 package com.nec.colvector
 
 import com.nec.cache.VeColColumnarVector
-import com.nec.spark.agile.core.{VeScalarType, VeString, VeType}
+import com.nec.spark.agile.core.VeType
 import com.nec.ve.VeProcess.OriginalCallingContext
-import com.nec.ve.{VeProcess, VeProcessMetrics}
+import com.nec.ve.{VeAsyncResult, VeProcess, VeProcessMetrics}
 import org.apache.spark.sql.vectorized.ColumnVector
 import org.bytedeco.javacpp.BytePointer
 import org.bytedeco.veoffload.global.veo
 import org.slf4j.LoggerFactory
-
-import java.io.OutputStream
 
 final case class VeColVector private[colvector] (
   source: VeColVectorSource,
@@ -42,9 +40,12 @@ final case class VeColVector private[colvector] (
     bytes
   }
 
-  def toStream(stream: OutputStream)(implicit process: VeProcess): Unit = {
-    buffers.zip(bufferSizes).foreach { case (start, size) =>
-      process.writeToStream(stream, start, size)
+  def toBytePointersAsync()(implicit process: VeProcess): Seq[VeAsyncResult[BytePointer]] = {
+    import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+    buffers.zip(bufferSizes).map { case (start, size) =>
+      val bp = new BytePointer(size)
+      val handle = process.getAsync(bp, start, size)
+      VeAsyncResult(handle){() => bp}
     }
   }
 
@@ -91,52 +92,6 @@ final case class VeColVector private[colvector] (
       require(dsource == source, s"Intended to `free` in ${source}, but got ${dsource} context.")
       allocations.foreach(process.free)
       memoryFreed = true
-    }
-  }
-}
-
-object VeColVector {
-  def buildContainer(veType: VeType,
-                     count: Int,
-                     buffers: Seq[Long],
-                     dataSizeO: Option[Int])
-                    (implicit source: VeColVectorSource,
-                     process: VeProcess,
-                     context: OriginalCallingContext): Long = {
-    veType match {
-      case stype: VeScalarType =>
-        require(buffers.size == 2, s"Exactly 2 VE buffer pointers are required to construct container for ${stype}")
-
-        // Declare the struct in host memory
-        // The layout of `nullable_T_vector` is the same for all T = primitive
-        val ptr = new BytePointer(stype.containerSize.toLong)
-
-        // Assign the data, validity, and count values
-        ptr.putLong(0, buffers(0))
-        ptr.putLong(8, buffers(1))
-        ptr.putInt(16, count.abs)
-
-        // Copy the struct to VE and return the VE pointer
-        process.putPointer(ptr)
-
-      case VeString =>
-        require(buffers.size == 4, s"Exactly 4 VE buffer pointers are required to construct container for ${VeString}")
-        require(dataSizeO.nonEmpty, s"dataSize is required to construct container for ${VeString}")
-        val Some(dataSize) = dataSizeO
-
-        // Declare the struct in host memory
-        val ptr = new BytePointer(VeString.containerSize.toLong)
-
-        // Assign the data, validity, and count values
-        ptr.putLong(0,  buffers(0))
-        ptr.putLong(8,  buffers(1))
-        ptr.putLong(16, buffers(2))
-        ptr.putLong(24, buffers(3))
-        ptr.putInt(32,  dataSize.abs)
-        ptr.putInt(36,  count.abs)
-
-        // Copy the struct to VE and return the VE pointer
-        process.putPointer(ptr)
     }
   }
 }

--- a/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
+++ b/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
@@ -57,7 +57,7 @@ object SparkCycloneExecutorPlugin extends LazyLogging {
 
   implicit def veProcess: VeProcess =
     VeProcess.DeferredVeProcess(() =>
-      VeProcess.WrappingVeo(_veo_proc, _veo_thr_ctxt, source, ImplicitMetrics.processMetrics)
+      VeProcess.WrappingVeo(_veo_proc, _veo_thr_ctxt, source, VeProcessMetrics.noOp)
     )
 
   implicit def source: VeColVectorSource = VeColVectorSource(

--- a/src/main/scala/com/nec/ve/VeAsyncResult.scala
+++ b/src/main/scala/com/nec/ve/VeAsyncResult.scala
@@ -44,4 +44,6 @@ object VeAsyncResult {
   def apply[T](handles: Seq[Long])(fn: () => T)(implicit process: VeProcess, originalCallingContext: OriginalCallingContext): VeAsyncResult[T] = {
     new VeAsyncResult[T](process, handles, fn)
   }
+
+  def empty()(implicit process: VeProcess, originalCallingContext: OriginalCallingContext): VeAsyncResult[Unit] = VeAsyncResult(Nil){ () =>}
 }

--- a/src/main/scala/com/nec/ve/VeAsyncResult.scala
+++ b/src/main/scala/com/nec/ve/VeAsyncResult.scala
@@ -37,6 +37,10 @@ class VeAsyncResult[T](
 }
 
 object VeAsyncResult {
+  def apply[T](handle: Long)(fn: () => T)(implicit process: VeProcess, originalCallingContext: OriginalCallingContext): VeAsyncResult[T] = {
+    new VeAsyncResult[T](process, Seq(handle), fn)
+  }
+
   def apply[T](handles: Seq[Long])(fn: () => T)(implicit process: VeProcess, originalCallingContext: OriginalCallingContext): VeAsyncResult[T] = {
     new VeAsyncResult[T](process, handles, fn)
   }

--- a/src/main/scala/com/nec/ve/VeAsyncResult.scala
+++ b/src/main/scala/com/nec/ve/VeAsyncResult.scala
@@ -1,0 +1,43 @@
+package com.nec.ve
+
+import com.nec.ve.VeProcess.OriginalCallingContext
+import org.bytedeco.veoffload.global.veo
+
+class VeAsyncResult[T](
+  val process: VeProcess,
+  val handles: Seq[Long],
+  val fn: () => T)(
+  implicit val originalCallingContext: OriginalCallingContext
+) {
+  lazy private val result: T = {
+    handles.foreach{ handle =>
+      require(process.waitResult(handle)._1 == veo.VEO_COMMAND_OK)
+    }
+
+    fn()
+  }
+
+  def get(): T = result
+
+  def map[U](g: T => U): VeAsyncResult[U] = {
+    new VeAsyncResult[U](
+      process,
+      handles,
+      () => {g(fn())}
+    )
+  }
+
+  def flatMap[U](g: T => VeAsyncResult[U]): VeAsyncResult[U] = {
+    new VeAsyncResult[U](
+      process,
+      handles,
+      () => {g(fn()).get()}
+    )
+  }
+}
+
+object VeAsyncResult {
+  def apply[T](handles: Seq[Long])(fn: () => T)(implicit process: VeProcess, originalCallingContext: OriginalCallingContext): VeAsyncResult[T] = {
+    new VeAsyncResult[T](process, handles, fn)
+  }
+}

--- a/src/main/scala/com/nec/ve/VeProcess.scala
+++ b/src/main/scala/com/nec/ve/VeProcess.scala
@@ -1,9 +1,8 @@
 package com.nec.ve
 
+import com.nec.colvector.{VeBatchOfBatches, VeColBatch, VeColVector, VeColVectorSource}
 import com.nec.spark.SparkCycloneExecutorPlugin
 import com.nec.spark.agile.core.{CScalarVector, CVarChar, CVector, VeString}
-import com.nec.colvector.VeBatchOfBatches
-import com.nec.colvector.{VeColVector, VeColBatch, VeColVectorSource}
 import com.nec.ve.VeProcess.Requires.requireOk
 import com.nec.ve.VeProcess.{LibraryReference, OriginalCallingContext}
 import com.typesafe.scalalogging.LazyLogging
@@ -201,15 +200,26 @@ object VeProcess {
     override def putPointer(
       bytePointer: BytePointer
     )(implicit context: OriginalCallingContext): Long = {
+      val start = System.nanoTime()
       val memoryLocation = allocate(bytePointer.limit())
       requireOk(
         veo.veo_write_mem(veo_proc_handle, memoryLocation, bytePointer, bytePointer.limit())
       )
+      val stop = System.nanoTime()
+      val duration = (stop - start).asInstanceOf[Double] / 1000000
+      val throughput = (bytePointer.limit() / 1024) / (duration / 1000)
+      println(s"Putting pointer ${bytePointer.address()}; size ${bytePointer.limit()}; duration $duration ms; speed $throughput kb/s (Start: $start; Stop: $stop)")
       memoryLocation
     }
 
-    override def get(from: Long, to: BytePointer, size: Long): Unit =
+    override def get(from: Long, to: BytePointer, size: Long): Unit = {
+      val start = System.nanoTime()
       veo.veo_read_mem(veo_proc_handle, to, from, size)
+      val stop = System.nanoTime()
+      val duration = (stop - start).asInstanceOf[Double] / 1000000
+      val throughput = (size.asInstanceOf[Double] / 1024) / (duration / 1000)
+      println(s"Reading pointer ${from}; size ${size}; duration $duration ms; speed $throughput kb/s (Start: $start; Stop: $stop)")
+    }
 
     override def free(memoryLocation: Long)(implicit context: OriginalCallingContext): Unit = {
       veProcessMetrics.deregisterAllocation(memoryLocation)

--- a/src/main/scala/com/nec/ve/VeProcess.scala
+++ b/src/main/scala/com/nec/ve/VeProcess.scala
@@ -2,7 +2,6 @@ package com.nec.ve
 
 import com.nec.colvector.{VeBatchOfBatches, VeColBatch, VeColVector, VeColVectorSource}
 import com.nec.spark.SparkCycloneExecutorPlugin
-import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
 import com.nec.spark.agile.core.{CScalarVector, CVarChar, CVector, VeString}
 import com.nec.ve.VeProcess.Requires.requireOk
 import com.nec.ve.VeProcess.{LibraryReference, OriginalCallingContext}
@@ -692,7 +691,7 @@ object VeProcess {
             }
             bytePointer.close()
             veColVector
-          }
+          }(this, context)
       }
     }
 

--- a/src/main/scala/org/apache/spark/metrics/source/ProcessExecutorMetrics.scala
+++ b/src/main/scala/org/apache/spark/metrics/source/ProcessExecutorMetrics.scala
@@ -91,9 +91,13 @@ final class ProcessExecutorMetrics(val allocationTracker: AllocationTracker, reg
       case Some(hist) => hist.update(timeTaken)
       case None => {
         val hist = new Histogram(new UniformReservoir())
-        metricRegistry.register(MetricRegistry.name("ve", s"veCallTimeHist_${functionName}"), hist)
-        perFunctionHistograms.put(functionName, hist)
-        hist.update(timeTaken)
+        try {
+          metricRegistry.register(MetricRegistry.name("ve", s"veCallTimeHist_${functionName}"), hist)
+          perFunctionHistograms.put(functionName, hist)
+          hist.update(timeTaken)
+        }catch{
+          case e: Exception => // NoOP
+        }
       }
     }
   }

--- a/src/test/scala/com/nec/colvector/UnitColVectorUnitSpec.scala
+++ b/src/test/scala/com/nec/colvector/UnitColVectorUnitSpec.scala
@@ -4,11 +4,12 @@ import com.nec.colvector.SeqOptTConversions._
 import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.agile.core.{VeNullableInt, VeString}
 import com.nec.ve.WithVeProcess
-import scala.util.Random
-import java.io._
-import java.util.UUID
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.io._
+import java.util.UUID
+import scala.util.Random
 
 @VectorEngineTest
 final class UnitColVectorUnitSpec extends AnyWordSpec with WithVeProcess {
@@ -38,7 +39,7 @@ final class UnitColVectorUnitSpec extends AnyWordSpec with WithVeProcess {
     s"correctly construct ${classOf[VeColVector].getSimpleName} from Array[Byte] (Int)" in {
       val input = InputSamples.seqOpt[Int]
       val colvec1 = input.toBytePointerColVector("_").toVeColVector
-      val colvec2 = colvec1.toUnitColVector.withData(colvec1.toBytes)
+      val colvec2 = colvec1.toUnitColVector.withData(colvec1.toBytes).apply().get()
 
       colvec2.toBytePointerColVector.toSeqOpt[Int] should be (input)
     }
@@ -46,7 +47,7 @@ final class UnitColVectorUnitSpec extends AnyWordSpec with WithVeProcess {
     s"correctly construct ${classOf[VeColVector].getSimpleName} from Array[Byte] (String)" in {
       val input = InputSamples.seqOpt[String]
       val colvec1 = input.toBytePointerColVector("_").toVeColVector
-      val colvec2 = colvec1.toUnitColVector.withData(colvec1.toBytes)
+      val colvec2 = colvec1.toUnitColVector.withData(colvec1.toBytes).apply().get()
 
       colvec2.toBytePointerColVector.toSeqOpt[String] should be (input)
     }

--- a/src/test/scala/com/nec/colvector/VeColVectorUnitSpec.scala
+++ b/src/test/scala/com/nec/colvector/VeColVectorUnitSpec.scala
@@ -2,11 +2,11 @@ package com.nec.colvector
 
 import com.nec.colvector.SeqOptTConversions._
 import com.nec.cyclone.annotations.VectorEngineTest
-import com.nec.ve.{VeKernelInfra, WithVeProcess}
-import scala.util.Random
-import java.io._
+import com.nec.ve.WithVeProcess
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Random
 
 @VectorEngineTest
 final class VeColVectorUnitSpec extends AnyWordSpec with WithVeProcess {
@@ -15,7 +15,7 @@ final class VeColVectorUnitSpec extends AnyWordSpec with WithVeProcess {
   def runByteArraySerializationTest(input: BytePointerColVector): BytePointerColVector = {
     val colvec1 = input.toVeColVector
     val bytes = colvec1.toBytes
-    val colvec2 = colvec1.toUnitColVector.withData(bytes)
+    val colvec2 = colvec1.toUnitColVector.withData(bytes).apply().get()
 
     colvec1.container should not be (colvec2.container)
     colvec1.buffers should not be (colvec2.buffers)

--- a/src/test/scala/com/nec/colvector/VeColVectorUnitSpec.scala
+++ b/src/test/scala/com/nec/colvector/VeColVectorUnitSpec.scala
@@ -24,24 +24,6 @@ final class VeColVectorUnitSpec extends AnyWordSpec with WithVeProcess {
     colvec2.toBytePointerColVector
   }
 
-  def runDataStreamSerializationTest(input: BytePointerColVector): BytePointerColVector = {
-    val colvec1 = input.toVeColVector
-
-    val bostream = new ByteArrayOutputStream
-    val ostream = new DataOutputStream(bostream)
-    colvec1.toStream(ostream)
-
-    val bistream = new ByteArrayInputStream(bostream.toByteArray)
-    val istream = new DataInputStream(bistream)
-    val colvec2 = colvec1.toUnitColVector.withData(istream)
-
-    colvec1.container should not be (colvec2.container)
-    colvec1.buffers should not be (colvec2.buffers)
-    colvec2.toBytes.toSeq should be (colvec1.toBytes.toSeq)
-
-    colvec2.toBytePointerColVector
-  }
-
   "VeColVector" should {
     "correctly serialize to and deserialize from Array[Byte] (Int)" in {
       val input = InputSamples.seqOpt[Int]
@@ -71,36 +53,6 @@ final class VeColVectorUnitSpec extends AnyWordSpec with WithVeProcess {
     "correctly serialize to and deserialize from Array[Byte] (String)" in {
       val input = InputSamples.seqOpt[String]
       runByteArraySerializationTest(input.toBytePointerColVector("_")).toSeqOpt[String] should be (input)
-    }
-
-    "correctly serialize to java.io.OutputStream and deserialize from java.io.InputStream (Int)" in {
-      val input = InputSamples.seqOpt[Int]
-      runDataStreamSerializationTest(input.toBytePointerColVector("_")).toSeqOpt[Int] should be (input)
-    }
-
-    "correctly serialize to java.io.OutputStream and deserialize from java.io.InputStream (Short)" in {
-      val input = InputSamples.seqOpt[Short]
-      runDataStreamSerializationTest(input.toBytePointerColVector("_")).toSeqOpt[Short] should be (input)
-    }
-
-    "correctly serialize to java.io.OutputStream and deserialize from java.io.InputStream (Long)" in {
-      val input = InputSamples.seqOpt[Long]
-      runDataStreamSerializationTest(input.toBytePointerColVector("_")).toSeqOpt[Long] should be (input)
-    }
-
-    "correctly serialize to java.io.OutputStream and deserialize from java.io.InputStream (Float)" in {
-      val input = InputSamples.seqOpt[Float]
-      runDataStreamSerializationTest(input.toBytePointerColVector("_")).toSeqOpt[Float] should be (input)
-    }
-
-    "correctly serialize to java.io.OutputStream and deserialize from java.io.InputStream (Double)" in {
-      val input = InputSamples.seqOpt[Double]
-      runDataStreamSerializationTest(input.toBytePointerColVector("_")).toSeqOpt[Double] should be (input)
-    }
-
-    "correctly serialize to java.io.OutputStream and deserialize from java.io.InputStream (String)" in {
-      val input = InputSamples.seqOpt[String]
-      runDataStreamSerializationTest(input.toBytePointerColVector("_")).toSeqOpt[String] should be (input)
     }
 
     "NOT crash if a double-free were called" in {

--- a/src/test/scala/com/nec/ve/DualModeVESpec.scala
+++ b/src/test/scala/com/nec/ve/DualModeVESpec.scala
@@ -1,11 +1,11 @@
 package com.nec.ve
 
-import com.nec.colvector.SparkSqlColumnVectorConversions._
-import com.nec.cache.{ArrowEncodingSettings, CycloneCacheBase}
 import com.nec.cache.DualMode.unwrapPossiblyDualToVeColBatches
+import com.nec.cache.{ArrowEncodingSettings, CycloneCacheBase}
+import com.nec.colvector.SparkSqlColumnVectorConversions._
+import com.nec.colvector.{VeColBatch, VeColVectorSource}
 import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.{SparkAdditions, SparkCycloneExecutorPlugin}
-import com.nec.colvector.{VeColBatch, VeColVectorSource}
 import com.nec.ve.VeProcess.{DeferredVeProcess, OriginalCallingContext, WrappingVeo}
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.IntVector
@@ -39,7 +39,7 @@ final class DualModeVESpec
 
     implicit val veProc: VeProcess =
       DeferredVeProcess(() =>
-        WrappingVeo(SparkCycloneExecutorPlugin._veo_proc, source, VeProcessMetrics.noOp)
+        WrappingVeo(SparkCycloneExecutorPlugin._veo_proc, SparkCycloneExecutorPlugin._veo_thr_ctxt, source, VeProcessMetrics.noOp)
       )
 
     def makeColumnarBatch1() = {

--- a/src/test/scala/com/nec/ve/DynamicBenchmarkVeCheck.scala
+++ b/src/test/scala/com/nec/ve/DynamicBenchmarkVeCheck.scala
@@ -20,15 +20,12 @@
 package com.nec.ve
 
 import com.nec.cyclone.annotations.VectorEngineTest
-import com.nec.spark.BenchTestingPossibilities
-import org.scalatest.freespec.AnyFreeSpec
-import com.nec.spark.SparkCycloneExecutorPlugin
 import com.nec.spark.BenchTestingPossibilities.BenchTestAdditions
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.ConfigMap
-import org.apache.log4j.Level
-import org.apache.log4j.Logger
+import com.nec.spark.{BenchTestingPossibilities, SparkCycloneExecutorPlugin}
+import org.apache.log4j.{Level, Logger}
 import org.bytedeco.veoffload.global.veo
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.freespec.AnyFreeSpec
 
 @VectorEngineTest
 final class DynamicBenchmarkVeCheck
@@ -40,6 +37,7 @@ final class DynamicBenchmarkVeCheck
     val rootLogger = Logger.getRootLogger
     rootLogger.setLevel(Level.INFO)
     SparkCycloneExecutorPlugin._veo_proc = veo.veo_proc_create(-1)
+    SparkCycloneExecutorPlugin._veo_thr_ctxt = veo.veo_context_open(SparkCycloneExecutorPlugin._veo_proc)
     super.beforeAll()
   }
 

--- a/src/test/scala/com/nec/ve/DynamicVeSqlExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/ve/DynamicVeSqlExpressionEvaluationSpec.scala
@@ -44,6 +44,7 @@ final class DynamicVeSqlExpressionEvaluationSpec extends DynamicCSqlExpressionEv
 
   override protected def beforeAll(): Unit = {
     SparkCycloneExecutorPlugin._veo_proc = veo.veo_proc_create(-1)
+    SparkCycloneExecutorPlugin._veo_thr_ctxt = veo.veo_context_open(SparkCycloneExecutorPlugin._veo_proc)
     super.beforeAll()
   }
 

--- a/src/test/scala/com/nec/ve/WithVeProcess.scala
+++ b/src/test/scala/com/nec/ve/WithVeProcess.scala
@@ -7,23 +7,33 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 trait WithVeProcess extends BeforeAndAfterAll { this: Suite =>
   implicit def metrics = VeProcessMetrics.noOp
   implicit def source = VeColVectorSource(getClass.getName)
-  implicit def veProcess: VeProcess = VeProcess.WrappingVeo(proc, thr_ctxt, source, VeProcessMetrics.noOp)
+  implicit def veProcess: VeProcess = VeProcess.WrappingVeo(proc_and_ctxt._1, proc_and_ctxt._2, source, VeProcessMetrics.noOp)
 
   private var initialized = false
 
-  private lazy val proc = {
+  private lazy val proc_and_ctxt = {
     initialized = true
-    veo.veo_proc_create(0)
-  }
+    val selectedVeNodeId = 0
+    val proc = veo.veo_proc_create(selectedVeNodeId)
+    val ctxt = veo.veo_context_open(proc)
 
-  private lazy val thr_ctxt = {
-    veo.veo_context_open(proc)
+    require(
+      proc != null,
+      s"Proc could not be allocated for node ${selectedVeNodeId}, got null"
+    )
+    require(
+      ctxt != null,
+      s"Async Context could not be allocated for node ${selectedVeNodeId}, got null"
+    )
+
+    (proc, ctxt)
   }
 
   override protected def afterAll(): Unit = {
     super.afterAll()
     if (initialized) {
-      veo.veo_context_close(thr_ctxt);
+      val (proc, thr_ctxt) = proc_and_ctxt
+      veo.veo_context_close(thr_ctxt)
       veo.veo_proc_destroy(proc)
     }
   }

--- a/src/test/scala/com/nec/ve/WithVeProcess.scala
+++ b/src/test/scala/com/nec/ve/WithVeProcess.scala
@@ -7,7 +7,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 trait WithVeProcess extends BeforeAndAfterAll { this: Suite =>
   implicit def metrics = VeProcessMetrics.noOp
   implicit def source = VeColVectorSource(getClass.getName)
-  implicit def veProcess: VeProcess = VeProcess.WrappingVeo(proc, source, VeProcessMetrics.noOp)
+  implicit def veProcess: VeProcess = VeProcess.WrappingVeo(proc, thr_ctxt, source, VeProcessMetrics.noOp)
 
   private var initialized = false
 
@@ -16,9 +16,14 @@ trait WithVeProcess extends BeforeAndAfterAll { this: Suite =>
     veo.veo_proc_create(0)
   }
 
+  private lazy val thr_ctxt = {
+    veo.veo_context_open(proc)
+  }
+
   override protected def afterAll(): Unit = {
     super.afterAll()
     if (initialized) {
+      veo.veo_context_close(thr_ctxt);
       veo.veo_proc_destroy(proc)
     }
   }


### PR DESCRIPTION
With `VEO_LOG_DEBUG=1`, we can see that we have many small reads and writes to/from the VE. This can introduce a lot of latency.

This PR changes the communication patterns in such a way, that asynchronous reads/writes are used wherever possible. By waiting for the responses only after all requests have been sent, we can hide a lot of that latency.

There is one pattern that may look a bit weird in this PR `.map(_.apply()).map(_.get())`. It exists for one very specific purpose:
In order to make it possible to transfer entire partitions to the VE in an asynchronous fashion, we need to be able to do that in a staged manner.

First the memory for all the transfers gets allocated - this is async below the covers, but that isn't exposed in aveo to us. As far as I can tell, this will only finish after all initiated transfers are done. As we don't want to introduce this implicit sync, we need to ensure all allocations can be done first. 

Second, we need to initiate all transfers.

Third, we wait for the transfers to finish, and get the now usable `VeColVector` instances.

Additionally, we want to keep the logic for creating a `VeColVector` all in one place. 

In order to solve that problem, we're allocating the memory as usual, but then we return a `() => VeAsyncResult[VeColVector]`. This function allows us to trigger the transfers and the resulting `VeAsyncResult` allows us to wait until the async execution has finished. 

By calling `.map(_.apply()).map(_.get())`, we therefore first trigger all pending transfers, and then we effectively wait until they are all done. 

According to the debug logs the intended purpose is being achieved, as we can see results coming in before we are done triggering all transfers. In some cases we can even see that all results are available by the time we start waiting for the last result.