### PR TITLE
Bugfix: Memcpy on shortcircuit

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
@@ -391,8 +391,10 @@ template <typename T>
 void NullableScalarVec<T>::group_indexes_on_subset(size_t* iter_order_arr, size_t* group_pos, size_t group_pos_size, size_t* idx_arr, size_t* out_group_pos, size_t &out_group_pos_size) const {
   // Shortcut for case when every element would end up in its own group anyway
   if(group_pos_size > count){
-    idx_arr = iter_order_arr;
-    out_group_pos = group_pos;
+    auto start = group_pos[0];
+    auto count = group_pos[group_pos_size - 1] - start;
+    memcpy(&idx_arr[start], &iter_order_arr[start], sizeof(size_t) * count);
+    memcpy(out_group_pos, group_pos, sizeof(size_t) * group_pos_size);
     out_group_pos_size = group_pos_size;
     return;
   }

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -587,8 +587,10 @@ nullable_varchar_vector * nullable_varchar_vector::from_binary_choice(const size
 void nullable_varchar_vector::group_indexes_on_subset(size_t* iter_order_arr, size_t* group_pos, size_t group_pos_size, size_t* idx_arr, size_t* out_group_pos, size_t &out_group_pos_size) const {
   // Shortcut for case when every element would end up in its own group anyway
   if(group_pos_size > count){
-    idx_arr = iter_order_arr;
-    out_group_pos = group_pos;
+    auto start = group_pos[0];
+    auto count = group_pos[group_pos_size - 1] - start;
+    memcpy(&idx_arr[start], &iter_order_arr[start], sizeof(size_t) * count);
+    memcpy(out_group_pos, group_pos, sizeof(size_t) * group_pos_size);
     out_group_pos_size = group_pos_size;
     return;
   }

--- a/src/main/resources/com/nec/cyclone/cpp/tests/nullable_scalar_vector_spec.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/nullable_scalar_vector_spec.cc
@@ -383,4 +383,36 @@ namespace cyclone::tests {
 
     CHECK(result == expected);
   }
+
+  TEST_CASE("group_indexes_on_subset short-circuit works"){
+    std::vector<long> grouping_1 = { 1, 2, 3, 4, 5 };
+    auto *input1 = new NullableScalarVec(grouping_1);
+
+    size_t count = grouping_1.size();
+    size_t start_arr[5] = {0, 1, 2, 3, 4};
+    size_t start_group_pos[6] = {0, 1, 2, 3, 4, 5};
+
+    size_t* a_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
+    size_t* a_pos_idxs = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
+    size_t a_pos_idxs_size;
+
+    input1->group_indexes_on_subset(start_arr, start_group_pos, 6, a_arr, a_pos_idxs, a_pos_idxs_size);
+
+    CHECK(a_pos_idxs_size == 6);
+    CHECK(a_arr[0] == start_arr[0]);
+    CHECK(a_arr[1] == start_arr[1]);
+    CHECK(a_arr[2] == start_arr[2]);
+    CHECK(a_arr[3] == start_arr[3]);
+    CHECK(a_arr[4] == start_arr[4]);
+
+    CHECK(a_pos_idxs[0] == start_group_pos[0]);
+    CHECK(a_pos_idxs[1] == start_group_pos[1]);
+    CHECK(a_pos_idxs[2] == start_group_pos[2]);
+    CHECK(a_pos_idxs[3] == start_group_pos[3]);
+    CHECK(a_pos_idxs[4] == start_group_pos[4]);
+    CHECK(a_pos_idxs[5] == start_group_pos[5]);
+
+    free(a_arr);
+    free(a_pos_idxs);
+  }
 }

--- a/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/nullable_varchar_vector_spec.cc
@@ -363,5 +363,35 @@ namespace cyclone::tests {
     
       CHECK(result == expected);
     }
+    TEST_CASE("group_indexes_on_subset short-circuit works"){
+      auto *input1 = new nullable_varchar_vector(std::vector<std::string> {"A", "B", "C", "D", "E"});
+
+      size_t count = 5;
+      size_t start_arr[5] = {0, 1, 2, 3, 4};
+      size_t start_group_pos[6] = {0, 1, 2, 3, 4, 5};
+
+      size_t* a_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
+      size_t* a_pos_idxs = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
+      size_t a_pos_idxs_size;
+
+      input1->group_indexes_on_subset(start_arr, start_group_pos, 6, a_arr, a_pos_idxs, a_pos_idxs_size);
+
+      CHECK(a_pos_idxs_size == 6);
+      CHECK(a_arr[0] == start_arr[0]);
+      CHECK(a_arr[1] == start_arr[1]);
+      CHECK(a_arr[2] == start_arr[2]);
+      CHECK(a_arr[3] == start_arr[3]);
+      CHECK(a_arr[4] == start_arr[4]);
+
+      CHECK(a_pos_idxs[0] == start_group_pos[0]);
+      CHECK(a_pos_idxs[1] == start_group_pos[1]);
+      CHECK(a_pos_idxs[2] == start_group_pos[2]);
+      CHECK(a_pos_idxs[3] == start_group_pos[3]);
+      CHECK(a_pos_idxs[4] == start_group_pos[4]);
+      CHECK(a_pos_idxs[5] == start_group_pos[5]);
+
+      free(a_arr);
+      free(a_pos_idxs);
+    }
   }
 }


### PR DESCRIPTION
When switching to external resource management, we've missed updating the short circuit logic for handling the "everything will end up in its own group anyway"-case.

That resulted in a weird edge case where sometimes things would crash because the pointers of two memory regions would converge and freeing the temporary memory region would result in also freeing the result memory. 