### PR TITLE
Add guard to only write non-zero buffers

### DIFF
--- a/src/main/scala/com/nec/colvector/VeColBatch.scala
+++ b/src/main/scala/com/nec/colvector/VeColBatch.scala
@@ -83,7 +83,7 @@ final case class VeColBatch(columns: Seq[VeColVector]) {
       // no bytes length as it's a stream here
       stream.writeInt(-1)
       stream.writeInt(VeColBatch.PayloadBytesId)
-      buffers.map(_.get()).foreach{ bytePointer =>
+      buffers.map(_.get()).filterNot(_.limit() == 0).foreach{ bytePointer =>
         val numWritten = channel.write(bytePointer.asBuffer())
         require(numWritten == bytePointer.limit(), s"Written ${numWritten}, expected ${bytePointer.limit()}")
       }


### PR DESCRIPTION
`bytePointer.asBuffer()` will create a buffer with capacity=1 for empty buffers, and therefore write something (= 1 byte) to the channel, even though we don't want it to write anything in that case.