### PR TITLE
[NS-38] New `VeProcess` implementation

### DIFF
--- a/src/main/scala/com/nec/util/CallContext.scala
+++ b/src/main/scala/com/nec/util/CallContext.scala
@@ -1,0 +1,19 @@
+package com.nec.util
+
+import sourcecode._
+
+final case class CallContext(file: File,
+                             line: Line,
+                             fullName: FullName) {
+  override def toString: String = {
+    s"${fullName.value} (${file.value}#${line.value})"
+  }
+}
+
+object CallContextOps {
+  implicit def make(implicit file: File,
+                    line: Line,
+                    fullName: FullName): CallContext = {
+    CallContext(file, line, fullName)
+  }
+}

--- a/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
+++ b/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
@@ -1,0 +1,99 @@
+package com.nec.vectorengine
+
+import com.nec.colvector.{VeColVectorSource => VeSource}
+import java.nio.file.Path
+import com.typesafe.scalalogging.LazyLogging
+import org.bytedeco.javacpp.{BytePointer, LongPointer}
+import org.bytedeco.veoffload.veo_proc_handle
+
+final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess with LazyLogging {
+  private lazy val underlying = newproc()
+
+  def node: Int = {
+    underlying.node
+  }
+
+  def source: VeSource = {
+    underlying.source
+  }
+
+  def isOpen: Boolean = {
+    underlying.isOpen
+  }
+
+  lazy val apiVersion: Int = {
+    underlying.apiVersion
+  }
+
+  lazy val version: String = {
+    underlying.version
+  }
+
+  def allocate(size: Long): Long = {
+    underlying.allocate(size)
+  }
+
+  def free(location: Long): Unit = {
+    underlying.free(location)
+  }
+
+  def put(buffer: BytePointer): Long = {
+    underlying.put(buffer)
+  }
+
+  def putAsync(buffer: BytePointer): Long = {
+    underlying.putAsync(buffer)
+  }
+
+  def putAsync(buffer: BytePointer, destination: Long): Long = {
+    underlying.putAsync(buffer, destination)
+  }
+
+  def get(source: Long, size: Long): BytePointer = {
+    underlying.get(source, size)
+  }
+
+  def getAsync(buffer: BytePointer, source: Long): Long = {
+    underlying.getAsync(buffer, source)
+  }
+
+  def peekResult(requestId: Long): (Int, Long) = {
+    underlying.peekResult(requestId)
+  }
+
+  def awaitResult(requestId: Long): Long = {
+    underlying.awaitResult(requestId)
+  }
+
+  def load(path: Path): LibraryReference = {
+    underlying.load(path)
+  }
+
+  def unload(lib: LibraryReference): Unit = {
+    underlying.unload(lib)
+  }
+
+  def getSymbol(lib: LibraryReference, symbol: String): LibrarySymbol = {
+    underlying.getSymbol(lib, symbol)
+  }
+
+  def newArgsStack(arguments: Seq[CallStackArgument]): VeCallArgsStack = {
+    underlying.newArgsStack(arguments)
+  }
+
+  def freeArgsStack(stack: VeCallArgsStack): Unit = {
+    underlying.freeArgsStack(stack)
+  }
+
+  def call(func: LibrarySymbol, stack: VeCallArgsStack): LongPointer = {
+    underlying.call(func, stack)
+  }
+
+  def callAsync(func: LibrarySymbol, stack: VeCallArgsStack): Long = {
+    underlying.callAsync(func, stack)
+  }
+
+  def close: Unit = {
+    underlying.close
+  }
+}

--- a/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
+++ b/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
@@ -3,7 +3,7 @@ package com.nec.vectorengine
 import com.nec.colvector.{VeColVectorSource => VeSource}
 import java.nio.file.Path
 import com.typesafe.scalalogging.LazyLogging
-import org.bytedeco.javacpp.{BytePointer, LongPointer}
+import org.bytedeco.javacpp.{BytePointer, LongPointer, Pointer}
 import org.bytedeco.veoffload.veo_proc_handle
 
 final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess with LazyLogging {
@@ -37,31 +37,31 @@ final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess w
     underlying.free(location)
   }
 
-  def put(buffer: BytePointer): Long = {
+  def put(buffer: Pointer): Long = {
     underlying.put(buffer)
   }
 
-  def putAsync(buffer: BytePointer): (Long, VeAsyncReqId) = {
+  def putAsync(buffer: Pointer): (Long, VeAsyncReqId) = {
     underlying.putAsync(buffer)
   }
 
-  def putAsync(buffer: BytePointer, destination: Long): VeAsyncReqId = {
+  def putAsync(buffer: Pointer, destination: Long): VeAsyncReqId = {
     underlying.putAsync(buffer, destination)
   }
 
-  def get(source: Long, size: Long): BytePointer = {
-    underlying.get(source, size)
+  def get(buffer: Pointer, source: Long): Unit = {
+    underlying.get(buffer, source)
   }
 
-  def getAsync(buffer: BytePointer, source: Long): VeAsyncReqId = {
+  def getAsync(buffer: Pointer, source: Long): VeAsyncReqId = {
     underlying.getAsync(buffer, source)
   }
 
-  def peekResult(id: VeAsyncReqId): (Int, Long) = {
+  def peekResult(id: VeAsyncReqId): (Int, LongPointer) = {
     underlying.peekResult(id)
   }
 
-  def awaitResult(id: VeAsyncReqId): Long = {
+  def awaitResult(id: VeAsyncReqId): LongPointer = {
     underlying.awaitResult(id)
   }
 

--- a/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
+++ b/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
@@ -41,11 +41,11 @@ final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess w
     underlying.put(buffer)
   }
 
-  def putAsync(buffer: BytePointer): Long = {
+  def putAsync(buffer: BytePointer): (Long, VeAsyncReqId) = {
     underlying.putAsync(buffer)
   }
 
-  def putAsync(buffer: BytePointer, destination: Long): Long = {
+  def putAsync(buffer: BytePointer, destination: Long): VeAsyncReqId = {
     underlying.putAsync(buffer, destination)
   }
 
@@ -53,16 +53,16 @@ final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess w
     underlying.get(source, size)
   }
 
-  def getAsync(buffer: BytePointer, source: Long): Long = {
+  def getAsync(buffer: BytePointer, source: Long): VeAsyncReqId = {
     underlying.getAsync(buffer, source)
   }
 
-  def peekResult(requestId: Long): (Int, Long) = {
-    underlying.peekResult(requestId)
+  def peekResult(id: VeAsyncReqId): (Int, Long) = {
+    underlying.peekResult(id)
   }
 
-  def awaitResult(requestId: Long): Long = {
-    underlying.awaitResult(requestId)
+  def awaitResult(id: VeAsyncReqId): Long = {
+    underlying.awaitResult(id)
   }
 
   def load(path: Path): LibraryReference = {
@@ -77,8 +77,8 @@ final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess w
     underlying.getSymbol(lib, symbol)
   }
 
-  def newArgsStack(arguments: Seq[CallStackArgument]): VeCallArgsStack = {
-    underlying.newArgsStack(arguments)
+  def newArgsStack(inputs: Seq[CallStackArgument]): VeCallArgsStack = {
+    underlying.newArgsStack(inputs)
   }
 
   def freeArgsStack(stack: VeCallArgsStack): Unit = {
@@ -89,7 +89,7 @@ final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess w
     underlying.call(func, stack)
   }
 
-  def callAsync(func: LibrarySymbol, stack: VeCallArgsStack): Long = {
+  def callAsync(func: LibrarySymbol, stack: VeCallArgsStack): VeAsyncReqId = {
     underlying.callAsync(func, stack)
   }
 

--- a/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
+++ b/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
@@ -7,7 +7,12 @@ import org.bytedeco.javacpp.{BytePointer, LongPointer, Pointer}
 import org.bytedeco.veoffload.veo_proc_handle
 
 final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess with LazyLogging {
-  private lazy val underlying = newproc()
+  private lazy val underlying = {
+    logger.info("Creating the underlying VeProcess")
+    val proc = newproc()
+    logger.info(s"New underlying VeProcess created: ${proc.source}")
+    proc
+  }
 
   def node: Int = {
     underlying.node
@@ -29,19 +34,31 @@ final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess w
     underlying.version
   }
 
-  def allocate(size: Long): Long = {
+  def heapAllocations: Map[Long, VeAllocation] = {
+    underlying.heapAllocations
+  }
+
+  def stackAllocations: Map[Long, VeCallArgsStack] = {
+    underlying.stackAllocations
+  }
+
+  def allocate(size: Long): VeAllocation = {
     underlying.allocate(size)
   }
 
-  def free(location: Long): Unit = {
-    underlying.free(location)
+  def free(address: Long): Unit = {
+    underlying.free(address)
   }
 
-  def put(buffer: Pointer): Long = {
+  def freeAll: Unit = {
+    underlying.freeAll
+  }
+
+  def put(buffer: Pointer): VeAllocation = {
     underlying.put(buffer)
   }
 
-  def putAsync(buffer: Pointer): (Long, VeAsyncReqId) = {
+  def putAsync(buffer: Pointer): (VeAllocation, VeAsyncReqId) = {
     underlying.putAsync(buffer)
   }
 

--- a/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
+++ b/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
@@ -1,6 +1,7 @@
 package com.nec.vectorengine
 
 import com.nec.colvector.{VeColVectorSource => VeSource}
+import scala.collection.mutable.{Map => MMap}
 import scala.util.Try
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
@@ -21,15 +22,23 @@ final case class WrappingVeo private (val node: Int,
     }
   }
 
+  // Declare this prior to the logging statements or else the logging statements will fail
+  private var opened = true
+  private var heapRecords = MMap.empty[Long, VeAllocation]
+  private var stackRecords = MMap.empty[Long, VeCallArgsStack]
+
   logger.info(s"Opened VE process (Node ${node}) @ ${handle.address}: ${handle}")
   logger.info(s"Opened VEO asynchronous context @ ${tcontext.address}: ${tcontext}")
   logger.info(s"VEO version ${version}; API version ${apiVersion}")
 
-  private var opened = true
-
   private[vectorengine] def requireValidBuffer(buffer: Pointer): Unit = {
     require(buffer.address > 0, s"Buffer has an invalid address ${buffer.address}; either it is un-initialized or already closed")
     require(buffer.nbytes > 0, s"Buffer has a declared size of ${buffer.nbytes}")
+  }
+
+  private[vectorengine] def withVeoProc[T](thunk: => T): T = {
+    require(opened, "VE process is closed")
+    thunk
   }
 
   def isOpen: Boolean = {
@@ -37,184 +46,292 @@ final case class WrappingVeo private (val node: Int,
   }
 
   lazy val apiVersion: Int = {
-    veo.veo_api_version
+    withVeoProc {
+      veo.veo_api_version
+    }
   }
 
   lazy val version: String = {
-    val bytes = veo.veo_version_string
-    bytes.getString(StandardCharsets.US_ASCII)
+    withVeoProc {
+      val bytes = veo.veo_version_string
+      bytes.getString(StandardCharsets.US_ASCII)
+    }
   }
 
   lazy val source: VeSource = {
     VeSource(identifier)
   }
 
-  def allocate(size: Long): Long = {
-    require(size > 0L, s"Requested size ${size} is invalid")
-    // Value is initialized to 0
-    val ptr = new LongPointer(1)
-    val result = veo.veo_alloc_mem(handle, ptr, size)
-    val location = ptr.get
-    require(result == 0, s"Memory allocation failed with code: ${result}")
-    require(location > 0, s"Memory allocation returned an invalid address: ${ptr.get}")
-    logger.trace(s"Allocated ${size} bytes ==> ${ptr}")
-    ptr.close
-    location
+  def heapAllocations: Map[Long, VeAllocation] = {
+    heapRecords.toMap
   }
 
-  def free(location: Long): Unit = {
-    require(location > 0L, s"Invalid VE memory address ${location}")
-    logger.trace(s"Deallocating pointer @ ${location}")
-    val result = veo.veo_free_mem(handle, location)
-    require(result == 0, s"Memory release failed with code: ${result}")
+  def stackAllocations: Map[Long, VeCallArgsStack] = {
+    stackRecords.toMap
   }
 
-  def put(buffer: Pointer): Long = {
-    requireValidBuffer(buffer)
-    val location = allocate(buffer.nbytes)
-    val result = veo.veo_write_mem(handle, location, buffer, buffer.nbytes)
-    require(result == 0, s"veo_write_mem failed and returned ${result}")
-    location
+  def allocate(size: Long): VeAllocation = {
+    withVeoProc {
+      require(size > 0L, s"Requested size ${size} is invalid")
+
+      // Value is initialized to 0
+      val ptr = new LongPointer(1)
+      val result = veo.veo_alloc_mem(handle, ptr, size)
+
+      // Ensure memory is properly allocated
+      val address = ptr.get
+      require(result == 0, s"Memory allocation failed with code: ${result}")
+      require(address > 0, s"Memory allocation returned an invalid address: ${ptr.get}")
+      logger.trace(s"Allocated ${size} bytes ==> ${ptr}")
+      ptr.close
+
+      // Create an allocation record to track the allocation
+      val allocation = VeAllocation(address, size, new Exception().getStackTrace)
+      heapRecords.put(address, allocation)
+      allocation
+    }
   }
 
-  def putAsync(buffer: Pointer): (Long, VeAsyncReqId) = {
-    requireValidBuffer(buffer)
-    val location = allocate(buffer.nbytes)
-    (location, putAsync(buffer, location))
+  def free(address: Long): Unit = {
+    withVeoProc {
+      require(address > 0L, s"Invalid VE memory address ${address}")
+
+      heapRecords.get(address) match {
+        case Some(allocation) =>
+          logger.trace(s"Deallocating pointer @ ${address}")
+          val result = veo.veo_free_mem(handle, address)
+          require(result == 0, s"Memory release failed with code: ${result}")
+          // Remove only after the free() was successful
+          heapRecords.remove(address)
+
+        case None =>
+          throw new IllegalArgumentException(s"VE memory address does not correspond to a tracked allocation: ${address}")
+      }
+    }
+  }
+
+  def freeAll: Unit = {
+    withVeoProc {
+      logger.debug(s"Releasing all ${heapRecords.size} heap allocations held by the process")
+      heapRecords.keys.foreach(free)
+
+      logger.debug(s"Releasing all ${heapRecords.size} veo_args allocations held by the process")
+      stackRecords.values.foreach(freeArgsStack)
+    }
+  }
+
+  def put(buffer: Pointer): VeAllocation = {
+    withVeoProc {
+      requireValidBuffer(buffer)
+      val allocation = allocate(buffer.nbytes)
+      val result = veo.veo_write_mem(handle, allocation.address, buffer, buffer.nbytes)
+      require(result == 0, s"veo_write_mem failed and returned ${result}")
+      allocation
+    }
+  }
+
+  def putAsync(buffer: Pointer): (VeAllocation, VeAsyncReqId) = {
+    withVeoProc {
+      requireValidBuffer(buffer)
+      val allocation = allocate(buffer.nbytes)
+      (allocation, putAsync(buffer, allocation.address))
+    }
   }
 
   def putAsync(buffer: Pointer, destination: Long): VeAsyncReqId = {
-    requireValidBuffer(buffer)
-    require(destination > 0L, s"Invalid VE memory address ${destination}")
-    val id = veo.veo_async_write_mem(tcontext, destination, buffer, buffer.nbytes)
-    require(id != veo.VEO_REQUEST_ID_INVALID, s"veo_async_write_mem failed and returned ${id}")
-    VeAsyncReqId(id)
+    withVeoProc {
+      requireValidBuffer(buffer)
+      require(destination > 0L, s"Invalid VE memory address ${destination}")
+      val id = veo.veo_async_write_mem(tcontext, destination, buffer, buffer.nbytes)
+      require(id != veo.VEO_REQUEST_ID_INVALID, s"veo_async_write_mem failed and returned ${id}")
+      VeAsyncReqId(id)
+    }
   }
 
   def get(buffer: Pointer, source: Long): Unit = {
-    requireValidBuffer(buffer)
-    require(source > 0L, s"Invalid VE memory address ${source}")
-    val result = veo.veo_read_mem(handle, buffer, source, buffer.nbytes)
-    require(result == 0, s"veo_read_mem failed and returned ${result}")
+    withVeoProc {
+      requireValidBuffer(buffer)
+      require(source > 0L, s"Invalid VE memory address ${source}")
+      val result = veo.veo_read_mem(handle, buffer, source, buffer.nbytes)
+      require(result == 0, s"veo_read_mem failed and returned ${result}")
+    }
   }
 
   def getAsync(buffer: Pointer, source: Long): VeAsyncReqId = {
-    requireValidBuffer(buffer)
-    require(source > 0L, s"Invalid VE memory address ${source}")
-    val id = veo.veo_async_read_mem(tcontext, buffer, source, buffer.nbytes)
-    require(id != veo.VEO_REQUEST_ID_INVALID, s"veo_async_read_mem failed and returned ${id}")
-    VeAsyncReqId(id)
+    withVeoProc {
+      requireValidBuffer(buffer)
+      require(source > 0L, s"Invalid VE memory address ${source}")
+      val id = veo.veo_async_read_mem(tcontext, buffer, source, buffer.nbytes)
+      require(id != veo.VEO_REQUEST_ID_INVALID, s"veo_async_read_mem failed and returned ${id}")
+      VeAsyncReqId(id)
+    }
   }
 
   def peekResult(id: VeAsyncReqId): (Int, LongPointer) = {
-    val retp = new LongPointer(1)
-    retp.put(Long.MinValue)
-    val res = veo.veo_call_peek_result(tcontext, id.value, retp)
-    (res, retp)
+    withVeoProc {
+      val retp = new LongPointer(1)
+      retp.put(Long.MinValue)
+      val res = veo.veo_call_peek_result(tcontext, id.value, retp)
+      (res, retp)
+    }
   }
 
   def awaitResult(id: VeAsyncReqId): LongPointer = {
-    val retp = new LongPointer(1)
-    retp.put(Long.MinValue)
-    val res = veo.veo_call_wait_result(tcontext, id.value, retp)
-    require(res == veo.VEO_COMMAND_OK, s"VE function returned value: ${res}")
-    retp
+    withVeoProc {
+      val retp = new LongPointer(1)
+      retp.put(Long.MinValue)
+      val res = veo.veo_call_wait_result(tcontext, id.value, retp)
+      require(res == veo.VEO_COMMAND_OK, s"VE function returned value: ${res}")
+      retp
+    }
   }
 
   def load(path: Path): LibraryReference = {
-    require(Files.exists(path), s"Path does not correspond to an existing file: ${path}")
-    logger.info(s"Loading from path as .SO: ${path}...")
-    val result = veo.veo_load_library(handle, path.toString)
-    require(result > 0, s"Expected library reference to be > 0, got ${result} (library at: ${path})")
-    LibraryReference(path, result)
+    withVeoProc {
+      require(Files.exists(path), s"Path does not correspond to an existing file: ${path}")
+      logger.info(s"Loading from path as .SO: ${path}...")
+      val result = veo.veo_load_library(handle, path.toString)
+      require(result > 0, s"Expected library reference to be > 0, got ${result} (library at: ${path})")
+      LibraryReference(path, result)
+    }
   }
 
   def unload(lib: LibraryReference): Unit = {
-    val result = veo.veo_unload_library(handle, lib.value)
-    require(result == 0, s"Failed to unload library reference, got ${result} (library at: ${lib.path})")
+    withVeoProc {
+      val result = veo.veo_unload_library(handle, lib.value)
+      require(result == 0, s"Failed to unload library reference, got ${result} (library at: ${lib.path})")
+    }
   }
 
   def getSymbol(lib: LibraryReference, name: String): LibrarySymbol = {
-    require(name.trim.nonEmpty, "Symbol name is empty or contains only whitespaces")
-    val result = veo.veo_get_sym(handle, lib.value, name)
-    require(result > 0, s"Expected > 0, but got ${result} when looking up symbol '${name}' (library at: ${lib.path})")
-    LibrarySymbol(lib, name, result)
+    withVeoProc {
+      require(name.trim.nonEmpty, "Symbol name is empty or contains only whitespaces")
+      val result = veo.veo_get_sym(handle, lib.value, name)
+      require(result > 0, s"Expected > 0, but got ${result} when looking up symbol '${name}' (library at: ${lib.path})")
+      LibrarySymbol(lib, name, result)
+    }
   }
 
   def newArgsStack(inputs: Seq[CallStackArgument]): VeCallArgsStack = {
-    val args = veo.veo_args_alloc
-    require(! args.isNull,  s"Fail to allocate arguments stack")
-    logger.trace(s"Allocated veo_args @ ${args.address}")
+    withVeoProc {
+      val args = veo.veo_args_alloc
+      require(! args.isNull,  s"Fail to allocate arguments stack")
+      logger.trace(s"Allocated veo_args @ ${args.address}")
 
-    inputs.zipWithIndex.foreach {
-      case (I32Arg(value), i) =>
-        val result = veo.veo_args_set_i32(args, i, value)
-        require(result == 0, s"Failed to set arguments stack at position ${i} to: ${value}")
-        logger.trace(s"[veo_args @ ${args.address}] Insert @ position ${i}: ${value}")
+      inputs.zipWithIndex.foreach {
+        case (I32Arg(value), i) =>
+          val result = veo.veo_args_set_i32(args, i, value)
+          require(result == 0, s"Failed to set arguments stack at position ${i} to: ${value}")
+          logger.trace(s"[veo_args @ ${args.address}] Insert @ position ${i}: ${value}")
 
-      case (U64Arg(value), i) =>
-        val result = veo.veo_args_set_u64(args, i, value)
-        require(result == 0, s"Failed to set arguments stack at position ${i} to: ${value}")
-        logger.trace(s"[veo_args @ ${args.address}] Insert @ position ${i}: ${value}")
+        case (U64Arg(value), i) =>
+          val result = veo.veo_args_set_u64(args, i, value)
+          require(result == 0, s"Failed to set arguments stack at position ${i} to: ${value}")
+          logger.trace(s"[veo_args @ ${args.address}] Insert @ position ${i}: ${value}")
 
-      case (BuffArg(intent, buffer), i) =>
-        val icode = intent match {
-          case VeArgIntent.In     => veo.VEO_INTENT_IN
-          case VeArgIntent.Out    => veo.VEO_INTENT_OUT
-          case VeArgIntent.InOut  => veo.VEO_INTENT_INOUT
-        }
-        val result = veo.veo_args_set_stack(args, icode, i, new BytePointer(buffer), buffer.nbytes)
-        require(result == 0, s"Failed to set arguments stack at position ${i} to: ${buffer}")
-        logger.trace(s"[veo_args @ ${args.address}] Insert @ position ${i}: ${buffer.getClass.getSimpleName} buffer @ VH ${buffer.address} (${buffer.nbytes} bytes)")
+        case (BuffArg(intent, buffer), i) =>
+          val icode = intent match {
+            case VeArgIntent.In     => veo.VEO_INTENT_IN
+            case VeArgIntent.Out    => veo.VEO_INTENT_OUT
+            case VeArgIntent.InOut  => veo.VEO_INTENT_INOUT
+          }
+          val result = veo.veo_args_set_stack(args, icode, i, new BytePointer(buffer), buffer.nbytes)
+          require(result == 0, s"Failed to set arguments stack at position ${i} to: ${buffer}")
+          logger.trace(s"[veo_args @ ${args.address}] Insert @ position ${i}: ${buffer.getClass.getSimpleName} buffer @ VH ${buffer.address} (${buffer.nbytes} bytes)")
+      }
+
+      // Create an allocation record to track the allocation
+      val allocation = VeCallArgsStack(inputs, args)
+      stackRecords.put(args.address, allocation)
+      allocation
     }
-
-    VeCallArgsStack(inputs, args)
   }
 
   def freeArgsStack(stack: VeCallArgsStack): Unit = {
-    logger.trace(s"Releasing veo_args @ ${stack.args.address}")
-    veo.veo_args_free(stack.args)
+    withVeoProc {
+      stackRecords.get(stack.args.address) match {
+        case Some(allocation) =>
+          logger.trace(s"Releasing veo_args @ ${stack.args.address}")
+          veo.veo_args_free(stack.args)
+          // Remove only after the free() was successful
+          stackRecords.remove(stack.args.address)
+
+        case None =>
+          throw new IllegalArgumentException(s"VeCallArgsStack does not correspond to a tracked veo_args allocation: ${stack.args.address}")
+      }
+    }
   }
 
   def call(func: LibrarySymbol, stack: VeCallArgsStack): LongPointer = {
-    logger.trace(s"Sync call '${func.name}' with veo_args @ ${stack.args.address}; argument values: ${stack.inputs}")
+    withVeoProc {
+      logger.trace(s"Sync call '${func.name}' with veo_args @ ${stack.args.address}; argument values: ${stack.inputs}")
 
-    // Set the output buffer
-    val retp = new LongPointer(1)
+      // Set the output buffer
+      val retp = new LongPointer(1)
 
-    // Call the function
-    val callResult = veo.veo_call_sync(handle, func.address, stack.args, retp)
+      // Call the function
+      val callResult = veo.veo_call_sync(handle, func.address, stack.args, retp)
 
-    // The VE call to the function should succeed
-    require(
-      callResult == 0,
-      s"VE call failed for function '${func.name}' (library at: ${func.lib.path}); got ${callResult}"
-    )
+      // The VE call to the function should succeed
+      require(
+        callResult == 0,
+        s"VE call failed for function '${func.name}' (library at: ${func.lib.path}); got ${callResult}"
+      )
 
-    retp
+      retp
+    }
   }
 
   def callAsync(func: LibrarySymbol, stack: VeCallArgsStack): VeAsyncReqId = {
-    logger.trace(s"Async call '${func.name}' with veo_args @ ${stack.args.address}")
+    withVeoProc {
+      logger.trace(s"Async call '${func.name}' with veo_args @ ${stack.args.address}")
 
-    val id = veo.veo_call_async(tcontext, func.address, stack.args)
-    require(
-      id != veo.VEO_REQUEST_ID_INVALID,
-      s"VE async call failed for function '${func.name}' (library at: ${func.lib.path})"
-    )
+      val id = veo.veo_call_async(tcontext, func.address, stack.args)
+      require(
+        id != veo.VEO_REQUEST_ID_INVALID,
+        s"VE async call failed for function '${func.name}' (library at: ${func.lib.path})"
+      )
 
-    VeAsyncReqId(id)
+      VeAsyncReqId(id)
+    }
   }
 
   def close: Unit = {
     if (opened) {
+      val MaxToShow = 5
+
+      // Complain about un-released heap allocations
+      val hRecords = heapRecords.take(MaxToShow)
+      if (hRecords.nonEmpty) {
+        logger.error(s"There were some unreleased heap allocations. First ${MaxToShow}:")
+        hRecords.foreach { case (_, record) =>
+          logger.error(s"Position: ${record.address}", record.toThrowable)
+        }
+      }
+
+      // Complain about un-released args stack allocations
+      val sRecords = stackRecords.take(MaxToShow)
+      if (sRecords.nonEmpty) {
+        logger.error(s"There were some unreleased stack allocations. First ${MaxToShow}:")
+        sRecords.foreach { case (_, record) =>
+          logger.error(s"Position: ${record.args.address}")
+        }
+      }
+
       Try {
         logger.info(s"Closing VEO asynchronous context @ ${tcontext.address}")
         veo.veo_context_close(tcontext)
 
         logger.info(s"Closing VE process (Node ${node}) @ ${handle.address}")
         veo.veo_proc_destroy(handle)
+
+        logger.info(s"Clearing the VE process' allocation records")
+        heapRecords.clear
+
+        logger.info(s"Clearing the VE process' veo_args allocations records")
+        stackRecords.clear
       }
+
       opened = false
     }
   }

--- a/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
+++ b/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
@@ -1,0 +1,207 @@
+package com.nec.vectorengine
+
+import com.nec.colvector.{VeColVectorSource => VeSource}
+import scala.util.Try
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import com.typesafe.scalalogging.LazyLogging
+import org.bytedeco.javacpp.{BytePointer, LongPointer}
+import org.bytedeco.veoffload.global.veo
+import org.bytedeco.veoffload.{veo_args, veo_proc_handle, veo_thr_ctxt}
+
+final case class WrappingVeo private (val node: Int,
+                                      identifier: String,
+                                      handle: veo_proc_handle,
+                                      tcontext: veo_thr_ctxt)
+                                      extends VeProcess with LazyLogging {
+  logger.info(s"Opened VE process (Node ${node}) @ ${handle.address}: ${handle}")
+  logger.info(s"Opened VEO asynchronous context @ ${tcontext.address}: ${tcontext}")
+  logger.info(s"VEO version: ${version}; API version ${apiVersion}")
+
+  private var opened = true
+
+  private[vectorengine] def requireValidBuffer(buffer: BytePointer): Unit = {
+    require(buffer.address > 0, s"Buffer has an invalid address ${buffer.address}; either it is un-initialized or already closed")
+    require(buffer.limit() > 0, s"Buffer has a declared size of ${buffer.limit()}")
+  }
+
+  def isOpen: Boolean = {
+    opened
+  }
+
+  lazy val apiVersion: Int = {
+    veo.veo_api_version
+  }
+
+  lazy val version: String = {
+    val bytes = veo.veo_version_string
+    bytes.getString(StandardCharsets.US_ASCII)
+  }
+
+  lazy val source: VeSource = {
+    VeSource(identifier)
+  }
+
+  def allocate(size: Long): Long = {
+    require(size > 0L, s"Requested size ${size} is invalid")
+    val ptr = new LongPointer(1)
+    val result = veo.veo_alloc_mem(handle, ptr, size)
+    val location = ptr.get
+    require(result == 0, s"Memory allocation failed with code: ${result}")
+    require(location > 0, s"Memory allocation returned an invalid address: ${ptr.get}")
+    logger.trace(s"Allocated ${size} bytes ==> ${ptr}")
+    ptr.close
+    location
+  }
+
+  def free(location: Long): Unit = {
+    require(location > 0L, s"Invalid VE memory address ${location}")
+    logger.trace(s"Deallocating pointer @ ${location}")
+    val result = veo.veo_free_mem(handle, location)
+    require(result == 0, s"Memory release failed with code: ${result}")
+  }
+
+  def put(buffer: BytePointer): Long = {
+    requireValidBuffer(buffer)
+    val location = allocate(buffer.limit())
+    val result = veo.veo_write_mem(handle, location, buffer, buffer.limit())
+    require(result == 0, s"veo_write_mem failed and returned ${result}")
+    location
+  }
+
+  def putAsync(buffer: BytePointer): Long = {
+    requireValidBuffer(buffer)
+    val location = allocate(buffer.limit())
+    putAsync(buffer, location)
+  }
+
+  def putAsync(buffer: BytePointer, destination: Long): Long = {
+    requireValidBuffer(buffer)
+    require(destination > 0L, s"Invalid VE memory address ${destination}")
+    val id = veo.veo_async_write_mem(tcontext, destination, buffer, buffer.limit())
+    require(id != veo.VEO_REQUEST_ID_INVALID, s"veo_async_write_mem failed and returned ${id}")
+    id
+  }
+
+  def get(source: Long, size: Long): BytePointer = {
+    require(source > 0L, s"Invalid VE memory address ${source}")
+    require(size > 0L, s"Requested size ${size} is invalid")
+    val buffer = new BytePointer(size)
+    val result = veo.veo_read_mem(handle, buffer, source, size)
+    require(result == 0, s"veo_read_mem failed and returned ${result}")
+    buffer
+  }
+
+  def getAsync(buffer: BytePointer, source: Long): Long = {
+    requireValidBuffer(buffer)
+    require(source > 0L, s"Invalid VE memory address ${source}")
+    val id = veo.veo_async_read_mem(tcontext, buffer, source, buffer.limit())
+    require(id != veo.VEO_REQUEST_ID_INVALID, s"veo_async_read_mem failed and returned ${id}")
+    id
+  }
+
+  def peekResult(requestId: Long): (Int, Long) = {
+    // Pre-initialize value to 0
+    val retp = new LongPointer(0)
+    val res = veo.veo_call_peek_result(tcontext, requestId, retp)
+    val retval = retp.get
+    require(retval >= 0L, s"Result should be >= 0, got ${retval}")
+    retp.close
+    (res, retval)
+  }
+
+  def awaitResult(requestId: Long): Long = {
+    // Pre-initialize value to 0
+    val retp = new LongPointer(0)
+    val res = veo.veo_call_wait_result(tcontext, requestId, retp)
+    val retval = retp.get
+    require(res == veo.VEO_COMMAND_OK, s"VE function returned value: ${res}")
+    require(retval >= 0L, s"Result should be >= 0, got ${retval}")
+    retp.close
+    retval
+  }
+
+  def load(path: Path): LibraryReference = {
+    require(Files.exists(path), s"Path does not correspond to an existing file: ${path}")
+    logger.info(s"Loading from path as .SO: ${path}...")
+    val result = veo.veo_load_library(handle, path.toString)
+    require(result > 0, s"Expected library reference to be > 0, got ${result} (library at: ${path})")
+    LibraryReference(path, result)
+  }
+
+  def unload(lib: LibraryReference): Unit = {
+    val result = veo.veo_unload_library(handle, lib.value)
+    require(result == 0, s"Failed to unload library reference, got ${result} (library at: ${lib.path})")
+  }
+
+  def getSymbol(lib: LibraryReference, name: String): LibrarySymbol = {
+    val result = veo.veo_get_sym(handle, lib.value, name)
+    require(result > 0, s"Expected > 0, but got ${result} when looking up symbol '${name}' (library at: ${lib.path})")
+    LibrarySymbol(lib, name, result)
+  }
+
+  def newArgsStack(arguments: Seq[CallStackArgument]): VeCallArgsStack = {
+    val stack = veo.veo_args_alloc
+    require(! stack.isNull,  s"Fail to allocate arguments stack")
+
+    arguments.zipWithIndex.foreach {
+      case (I32Arg(value), i) =>
+        val result = veo.veo_args_set_i32(stack, i, value)
+        require(result == 0, s"Failed to set arguments stack at position ${i} to: ${value}")
+
+      case (U64Arg(value), i) =>
+        val result = veo.veo_args_set_u64(stack, i, value)
+        require(result == 0, s"Failed to set arguments stack at position ${i} to: ${value}")
+
+      case (BuffArg(intent, buffer, size), i) =>
+        val result = veo.veo_args_set_stack(stack, intent, i, buffer, size)
+        require(result == 0, s"Failed to set arguments stack at position ${i} to: ${buffer}")
+    }
+
+    VeCallArgsStack(stack)
+  }
+
+  def freeArgsStack(stack: VeCallArgsStack): Unit = {
+    veo.veo_args_free(stack.args)
+  }
+
+  def call(func: LibrarySymbol, stack: VeCallArgsStack): LongPointer = {
+    // Initialize to 1.  All cyclone functions should return 0 on successful completion
+    val fnOutput = new LongPointer(1)
+    val callResult = veo.veo_call_sync(handle, func.address, stack.args, fnOutput)
+
+    // The VE call to the function should succeed
+    require(
+      callResult == 0,
+      s"VE call failed for function '${func.name}' (library at: ${func.lib.path}); got ${callResult}"
+    )
+
+    // The function itself should return 0
+    require(
+      fnOutput.get() == 0L,
+      s"Expected 0 from function execution, got ${fnOutput.get()} instead."
+    )
+
+    fnOutput
+  }
+
+  def callAsync(func: LibrarySymbol, stack: VeCallArgsStack): Long = {
+    val id = veo.veo_call_async(tcontext, func.address, stack.args)
+    require(
+      id != veo.VEO_REQUEST_ID_INVALID,
+      s"VE async call failed for function '${func.name}' (library at: ${func.lib.path})"
+    )
+    id
+  }
+
+  def close: Unit = {
+    if (opened) {
+      Try {
+        logger.info(s"Closing VE process (Node ${node}) @ ${handle.address}: ${handle}")
+        veo.veo_context_close(tcontext)
+        veo.veo_proc_destroy(handle)
+      }
+      opened = false
+    }
+  }
+}

--- a/src/main/scala/com/nec/vectorengine/VeProcessTraits.scala
+++ b/src/main/scala/com/nec/vectorengine/VeProcessTraits.scala
@@ -1,0 +1,224 @@
+package com.nec.vectorengine
+
+import com.nec.colvector.{VeColVectorSource => VeSource}
+import scala.util.Try
+import java.nio.file.Path
+import org.apache.spark.api.plugin.PluginContext
+import org.bytedeco.javacpp.{BytePointer, LongPointer}
+import org.bytedeco.veoffload.global.veo
+import org.bytedeco.veoffload.{veo_args, veo_proc_handle, veo_thr_ctxt}
+import com.typesafe.scalalogging.LazyLogging
+
+final case class LibraryReference private[vectorengine] (path: Path, value: Long)
+
+final case class LibrarySymbol private[vectorengine] (lib: LibraryReference, name: String, address: Long)
+
+final case class VeCallArgsStack private[vectorengine] (args: veo_args)
+
+sealed trait CallStackArgument
+
+case class I32Arg(value: Int) extends CallStackArgument
+
+case class U64Arg(value: Long) extends CallStackArgument
+
+case class BuffArg(intent: Int, buffer: BytePointer, size: Long) extends CallStackArgument
+
+trait VeProcess {
+  def node: Int
+
+  def source: VeSource
+
+  def isOpen: Boolean
+
+  def apiVersion: Int
+
+  def version: String
+
+  def allocate(size: Long): Long
+
+  def free(location: Long): Unit
+
+  def put(buffer: BytePointer): Long
+
+  def putAsync(buffer: BytePointer): Long
+
+  def putAsync(buffer: BytePointer, destination: Long): Long
+
+  def get(source: Long, size: Long): BytePointer
+
+  def getAsync(buffer: BytePointer, source: Long): Long
+
+  def peekResult(requestId: Long): (Int, Long)
+
+  def awaitResult(requestId: Long): Long
+
+  def load(path: Path): LibraryReference
+
+  def unload(lib: LibraryReference): Unit
+
+  def getSymbol(lib: LibraryReference, symbol: String): LibrarySymbol
+
+  def newArgsStack(arguments: Seq[CallStackArgument]): VeCallArgsStack
+
+  def freeArgsStack(stack: VeCallArgsStack): Unit
+
+  def call(func: LibrarySymbol, stack: VeCallArgsStack): LongPointer
+
+  def callAsync(func: LibrarySymbol, stack: VeCallArgsStack): Long
+
+  def close: Unit
+}
+
+object VeProcess extends LazyLogging {
+  final val DefaultVeNodeId = 0
+  final val MaxVeNodes = 8
+
+  private def createVeoTuple(venode: Int): Option[(Int, veo_proc_handle, veo_thr_ctxt)] = {
+    /*
+      If venode is -1, a VE process is created on the VE node specified by
+      environment variable VE_NODE_NUMBER. If venode is -1 and environment
+      variable VE_NODE_NUMBER is not set, a VE process is created on the VE
+      node #0.
+     */
+    val nnum = if (venode < -1) venode.abs else venode
+    logger.info(s"Attemping to allocate VE process on node ${nnum}...")
+
+    for {
+      // Create the process handle
+      handle <- {
+        val h = veo.veo_proc_create(nnum)
+        if (h != null && h.address > 0) Some(h) else None
+      }
+      _ = logger.info(s"Successfully allocated VE process on node ${nnum}")
+
+      // Create asynchronous context
+      tcontext <- {
+        val t = veo.veo_context_open(handle)
+        if (t != null && t.address > 0) Some(t) else None
+      }
+      _ = logger.info(s"Successfully allocated VEO asynchronous context on node ${nnum}")
+
+    } yield {
+      // Return the tuple
+      (nnum, handle, tcontext)
+    }
+  }
+
+  def create(identifier: String): VeProcess = {
+    val tupleO = 0.until(MaxVeNodes).foldLeft(Option.empty[(Int, veo_proc_handle, veo_thr_ctxt)]) {
+      case (Some(tuple), venode)  => Some(tuple)
+      case (None, venode)         => createVeoTuple(venode)
+    }
+
+    tupleO match {
+      case Some((venode, handle, tcontext)) =>
+        WrappingVeo(venode, identifier, handle, tcontext)
+
+      case None =>
+        throw new IllegalArgumentException(s"VE process could not be allocated; all nodes are either offline or occupied by another VE process")
+    }
+  }
+
+  def create(venode: Int, identifier: String): VeProcess = {
+    createVeoTuple(venode) match {
+      case Some((venode, handle, tcontext)) =>
+        WrappingVeo(venode, identifier, handle, tcontext)
+
+      case None =>
+        throw new IllegalArgumentException(s"VE process could not be allocated for node ${venode}; either the node is offline or another VE process is running")
+    }
+  }
+
+  // def createFromContext(context: PluginContext): VeProcess = {
+  //   val resources = context.resources
+  //   logger.info(s"Executor has the following resources available => ${resources}")
+
+  //   val selectedNodeId = if (!resources.containsKey("ve")) {
+  //     val id = Try { System.getenv("VE_NODE_NUMBER").toInt }.getOrElse(DefaultVeNodeId)
+  //     logger.info(s"VE resources are not available from the PluginContext; will use '${id}' as the main resource.")
+  //     id
+
+  //   } else {
+  //     val veResources = resources.get("ve")
+
+  //     // Executor IDs start at 1
+  //     val executorId = Try { context.executorID.toInt - 1 }.getOrElse(0)
+  //     val veMultiple = executorId / MaxVeNodes
+
+  //     if (veMultiple > veResources.addresses.size) {
+  //       logger.warn("Not enough VE resources allocated for the number of executors specified.")
+  //     }
+
+  //     veResources.addresses(veMultiple % veResources.addresses.size).toInt
+  //   }
+
+  //   logger.info(s"Attemping to use VE node = ${selectedNodeId}")
+
+  //   var currentNodeId = selectedNodeId
+  //   var handle: veo_proc_handle = null
+  //   var tcontext: veo_thr_ctxt = null
+
+  //   while (handle == null && currentNodeId < MaxVeNodes) {
+  //     handle = veo.veo_proc_create(currentNodeId)
+  //     tcontext = veo.veo_context_open(handle)
+
+  //     if (handle == null) {
+  //       logger.warn(s"VE process could not be allocated for node ${currentNodeId}, trying next.")
+  //       currentNodeId += 1
+  //     }
+  //   }
+
+  //   require(
+  //     handle != null && handle.address > 0,
+  //     s"VE process could not be allocated; all nodes are either offline or occupied by another VE process"
+  //   )
+
+  //   require(
+  //     tcontext != null && tcontext.address > 0,
+  //     s"VEO asynchronous context could not be allocated for node ${currentNodeId}"
+  //   )
+
+  //   val identifier = s"VE Process @ ${handle.address}, Executor ${Try { context.executorID }}"
+  //   WrappingVeo(currentNodeId, identifier, handle, tcontext)
+  // }
+
+  def createFromContext(context: PluginContext): VeProcess = {
+    val resources = context.resources
+    logger.info(s"Executor has the following resources available => ${resources}")
+
+    val selectedNodeId = if (!resources.containsKey("ve")) {
+      val id = Try { System.getenv("VE_NODE_NUMBER").toInt }.getOrElse(DefaultVeNodeId)
+      logger.info(s"VE resources are not available from the PluginContext; will use '${id}' as the main resource.")
+      id
+
+    } else {
+      val veResources = resources.get("ve")
+
+      // Executor IDs start at 1
+      val executorId = Try { context.executorID.toInt - 1 }.getOrElse(0)
+      val veMultiple = executorId / MaxVeNodes
+
+      if (veMultiple > veResources.addresses.size) {
+        logger.warn("Not enough VE resources allocated for the number of executors specified.")
+      }
+
+      veResources.addresses(veMultiple % veResources.addresses.size).toInt
+    }
+
+    logger.info(s"Attemping to use VE node = ${selectedNodeId}")
+
+    val tupleO = selectedNodeId.until(MaxVeNodes).foldLeft(Option.empty[(Int, veo_proc_handle, veo_thr_ctxt)]) {
+      case (Some(tuple), venode)  => Some(tuple)
+      case (None, venode)         => createVeoTuple(venode)
+    }
+
+    tupleO match {
+      case Some((venode, handle, tcontext)) =>
+        val identifier = s"VE Process @ ${handle.address}, Executor ${Try { context.executorID }}"
+        WrappingVeo(venode, identifier, handle, tcontext)
+
+      case None =>
+        throw new IllegalArgumentException(s"VE process could not be allocated; all nodes are either offline or occupied by another VE process")
+    }
+  }
+}

--- a/src/test/scala/com/nec/cache/ColumnarBatchToVeColBatchTest.scala
+++ b/src/test/scala/com/nec/cache/ColumnarBatchToVeColBatchTest.scala
@@ -1,7 +1,6 @@
 package com.nec.cache
 
 import com.nec.colvector.ArrowVectorConversions._
-import com.nec.cache.{ArrowEncodingSettings, ColumnarBatchToVeColBatch}
 import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.SparkAdditions
 import com.nec.ve.WithVeProcess

--- a/src/test/scala/com/nec/colvector/InputSamples.scala
+++ b/src/test/scala/com/nec/colvector/InputSamples.scala
@@ -42,6 +42,11 @@ object InputSamples {
     } else if (klass == classOf[String]) {
       0.until(size).map(_ => Random.nextString(Random.nextInt(30) + 1)).asInstanceOf[Seq[T]]
 
+    } else if (klass == classOf[Byte]) {
+      val bytes = Array.ofDim[Byte](size.abs)
+      Random.nextBytes(bytes)
+      bytes.toSeq.asInstanceOf[Seq[T]]
+
     } else {
       throw new NotImplementedError(s"Type not supported: ${klass}")
     }

--- a/src/test/scala/com/nec/vectorengine/VeProcessUnitSpec.scala
+++ b/src/test/scala/com/nec/vectorengine/VeProcessUnitSpec.scala
@@ -1,0 +1,52 @@
+package com.nec.vectorengine
+
+import com.nec.cyclone.annotations.VectorEngineTest
+import scala.util.Random
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.BeforeAndAfterAll
+
+@VectorEngineTest
+final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll {
+  val process = VeProcess.create(getClass.getName)
+
+  override def afterAll(): Unit = {
+    process.close
+  }
+
+  "VeProcess" should {
+    "correctly contain the node number where the VE process was allocated" in {
+      process.node should be >= 0
+    }
+
+    "correctly return the API version number" in {
+      process.apiVersion should be > 0
+    }
+
+    "correctly return a version string" in {
+      process.version shouldNot be (empty)
+    }
+
+    "correctly allocate and free memory" in {
+      val size = Random.nextInt(1000) + 100
+
+      noException should be thrownBy {
+        val location = process.allocate(size)
+        location should be > 0L
+        process.free(location)
+      }
+    }
+    // "NOT crash if a double-free were called" in {
+    //   val colvec1 = InputSamples.seqOpt[Int].toBytePointerColVector("_").toVeColVector
+    //   val colvec2 = InputSamples.seqOpt[Double].toBytePointerColVector("_").toVeColVector
+    //   val colvec3 = InputSamples.seqOpt[String].toBytePointerColVector("_").toVeColVector
+
+    //   noException should be thrownBy {
+    //     // Should call at least twice
+    //     0.to(Random.nextInt(3) + 1).foreach(_ => colvec1.free)
+    //     0.to(Random.nextInt(3) + 1).foreach(_ => colvec2.free)
+    //     0.to(Random.nextInt(3) + 1).foreach(_ => colvec3.free)
+    //   }
+    // }
+  }
+}

--- a/src/test/scala/com/nec/vectorengine/VeProcessUnitSpec.scala
+++ b/src/test/scala/com/nec/vectorengine/VeProcessUnitSpec.scala
@@ -1,17 +1,39 @@
 package com.nec.vectorengine
 
 import com.nec.cyclone.annotations.VectorEngineTest
+import scala.concurrent.duration._
 import scala.util.Random
+import org.bytedeco.javacpp.{BytePointer, LongPointer}
+import org.bytedeco.veoffload.global.veo
+import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.BeforeAndAfterAll
 
 @VectorEngineTest
-final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll {
+final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Eventually {
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(
+    timeout = scaled(3.seconds),
+    interval = scaled(0.5.seconds)
+  )
+
   val process = VeProcess.create(getClass.getName)
 
   override def afterAll(): Unit = {
     process.close
+
+    // Calling close twice should not break
+    noException should be thrownBy {
+      process.close
+    }
+
+    process.isOpen should be (false)
+  }
+
+  def randomBytes(size: Int): Array[Byte] = {
+    val bytes = Array.ofDim[Byte](size.abs)
+    Random.nextBytes(bytes)
+    bytes
   }
 
   "VeProcess" should {
@@ -36,17 +58,172 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll {
         process.free(location)
       }
     }
-    // "NOT crash if a double-free were called" in {
-    //   val colvec1 = InputSamples.seqOpt[Int].toBytePointerColVector("_").toVeColVector
-    //   val colvec2 = InputSamples.seqOpt[Double].toBytePointerColVector("_").toVeColVector
-    //   val colvec3 = InputSamples.seqOpt[String].toBytePointerColVector("_").toVeColVector
 
-    //   noException should be thrownBy {
-    //     // Should call at least twice
-    //     0.to(Random.nextInt(3) + 1).foreach(_ => colvec1.free)
-    //     0.to(Random.nextInt(3) + 1).foreach(_ => colvec2.free)
-    //     0.to(Random.nextInt(3) + 1).foreach(_ => colvec3.free)
-    //   }
-    // }
+    "handle the case where zero memory is requested for allocation" in {
+      intercept[IllegalArgumentException] {
+        process.allocate(0L)
+      }
+    }
+
+    "handle the case where an invalid VE address is requested to be freed" in {
+      intercept[IllegalArgumentException] {
+        process.free(- Random.nextInt(1000).toLong)
+      }
+    }
+
+    "correctly transfer data from VH to VE and back (sync)" in {
+      noException should be thrownBy {
+        val bytes1 = randomBytes(Random.nextInt(10000) + 10)
+        val bytes2 = Array.ofDim[Byte](bytes1.size)
+
+        // Bytes should not be equal right now
+        bytes1.toSeq should not be (bytes2.toSeq)
+
+        // Move from JVM to VH
+        val buffer1 = new BytePointer(bytes1.size)
+        buffer1.put(bytes1, 0, bytes1.size)
+
+        // Move from VH to VE
+        val location = process.put(buffer1)
+        location should be > 0L
+
+        // Move from VE to VH
+        val buffer2 = process.get(location, bytes2.size)
+
+        // Move from VH to JVM
+        buffer2.get(bytes2)
+
+        // Bytes should be the same
+        bytes1.toSeq should be (bytes2.toSeq)
+      }
+    }
+
+    "handle corner cases when transferring data from VH to VE (sync) (i.e. should not crash the JVM)" in {
+      // BytePointer is closed
+      intercept[IllegalArgumentException] {
+        val buffer = new BytePointer(Random.nextInt(10000))
+        buffer.close
+        process.put(buffer)
+      }
+
+      // BytePointer has size 0
+      intercept[IllegalArgumentException] {
+        val buffer = new BytePointer(0)
+        buffer.close
+        process.put(buffer)
+      }
+    }
+
+    "handle corner cases when transferring data from VE to VH (sync) (i.e. should not crash the JVM)" in {
+      // VE memory location is invalid
+      intercept[IllegalArgumentException] {
+        process.get(- Random.nextInt(10000).toLong, Random.nextInt(10000).toLong + 10)
+      }
+
+      // Fetch size is invalid
+      intercept[IllegalArgumentException] {
+        process.get(Random.nextInt(10000).toLong + 1, - Random.nextInt(10000).toLong)
+      }
+    }
+
+    "correctly transfer data from VH to VE and back (async)" in {
+      noException should be thrownBy {
+        val bytes1 = randomBytes(Random.nextInt(100000) + 10)
+        val bytes2 = Array.ofDim[Byte](bytes1.size)
+
+        // Bytes should not be equal right now
+        bytes1.toSeq should not be (bytes2.toSeq)
+
+        // Move from JVM to VH
+        val buffer1 = new BytePointer(bytes1.size)
+        buffer1.put(bytes1, 0, bytes1.size)
+
+        // Move from VH to VE (async)
+        val (location, id1) = process.putAsync(buffer1)
+        location should be > 0L
+
+        // Fetch the async transfer result using `peek`
+        eventually {
+          val (res, xx) = process.peekResult(id1)
+          res should be (veo.VEO_COMMAND_OK)
+        }
+
+        // Move from VE to VH (async)
+        val buffer2 = new BytePointer(bytes2.size)
+        val id2 = process.getAsync(buffer2, location)
+
+        // Fetch the async transfer result using `await`
+        process.awaitResult(id2)
+
+        // Move from VH to JVM
+        buffer2.get(bytes2)
+
+        // Bytes should be the same
+        bytes1.toSeq should be (bytes2.toSeq)
+      }
+    }
+
+    "handle corner cases when transferring data from VH to VE (async) (i.e. should not crash the JVM)" in {
+      // BytePointer is closed
+      intercept[IllegalArgumentException] {
+        val buffer = new BytePointer(Random.nextInt(10000))
+        buffer.close
+        process.putAsync(buffer)
+      }
+
+      // BytePointer has size 0
+      intercept[IllegalArgumentException] {
+        val buffer = new BytePointer(0)
+        buffer.close
+        process.putAsync(buffer)
+      }
+
+      // VE memory address is invalid
+      intercept[IllegalArgumentException] {
+        val buffer = new BytePointer(Random.nextInt(10000))
+        buffer.close
+        process.putAsync(buffer, - Random.nextInt(10000))
+      }
+    }
+
+    "handle corner cases when transferring data from VE to VH (async) (i.e. should not crash the JVM)" in {
+      // BytePointer is closed
+      intercept[IllegalArgumentException] {
+        val buffer = new BytePointer(Random.nextInt(10000))
+        buffer.close
+        process.getAsync(buffer, Random.nextInt(10000) + 100)
+      }
+
+      // BytePointer has size 0
+      intercept[IllegalArgumentException] {
+        val buffer = new BytePointer(0)
+        buffer.close
+        process.getAsync(buffer, Random.nextInt(10000) + 100)
+      }
+
+      // VE memory address is invalid
+      intercept[IllegalArgumentException] {
+        val buffer = new BytePointer(Random.nextInt(10000))
+        process.putAsync(buffer, - Random.nextInt(10000))
+      }
+    }
+
+    "correctly allocate and free a veo_args" in {
+      noException should be thrownBy {
+        val buffer = new LongPointer(Random.nextInt(4) + 1)
+        val inputs = Seq(
+          I32Arg(Random.nextInt),
+          U64Arg(Random.nextLong),
+          BuffArg(VeArgIntent.Out, buffer)
+        )
+
+        // Create the args stack with the veo_args
+        val stack = process.newArgsStack(inputs)
+        stack.inputs should be (inputs)
+
+        // Free the args stack
+        process.freeArgsStack(stack)
+      }
+    }
   }
 }

--- a/src/test/scala/com/nec/vectorengine/VeProcessUnitSpec.scala
+++ b/src/test/scala/com/nec/vectorengine/VeProcessUnitSpec.scala
@@ -1,23 +1,33 @@
 package com.nec.vectorengine
 
 import com.nec.cyclone.annotations.VectorEngineTest
+import com.nec.colvector.InputSamples
+import com.nec.ve.VeKernelInfra
 import scala.concurrent.duration._
 import scala.util.Random
-import org.bytedeco.javacpp.{BytePointer, LongPointer}
+import java.io.File
+import java.nio.file.FileSystems
+import java.util.UUID
+import org.bytedeco.javacpp.{BytePointer, DoublePointer, LongPointer}
 import org.bytedeco.veoffload.global.veo
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.BeforeAndAfterAll
 
 @VectorEngineTest
-final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Eventually {
+final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Eventually with VeKernelInfra {
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(
     timeout = scaled(3.seconds),
     interval = scaled(0.5.seconds)
   )
 
-  val process = VeProcess.create(getClass.getName)
+  // Don't open the process here because the ScalaTest classes are initialized
+  var process: VeProcess = _
+
+  override def beforeAll(): Unit = {
+    process = VeProcess.create(getClass.getName)
+  }
 
   override def afterAll(): Unit = {
     process.close
@@ -27,16 +37,15 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
       process.close
     }
 
+    // VE process should now be indicated as closed
     process.isOpen should be (false)
   }
 
-  def randomBytes(size: Int): Array[Byte] = {
-    val bytes = Array.ofDim[Byte](size.abs)
-    Random.nextBytes(bytes)
-    bytes
-  }
-
   "VeProcess" should {
+    "correctly indicate that the underlying VE process is open" in {
+      process.isOpen should be (true)
+    }
+
     "correctly contain the node number where the VE process was allocated" in {
       process.node should be >= 0
     }
@@ -71,9 +80,9 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
       }
     }
 
-    "correctly transfer data from VH to VE and back (sync)" in {
+    "correctly transfer Array[Byte] from VH to VE and back (sync)" in {
       noException should be thrownBy {
-        val bytes1 = randomBytes(Random.nextInt(10000) + 10)
+        val bytes1 = InputSamples.array[Byte](Random.nextInt(10000) + 10)
         val bytes2 = Array.ofDim[Byte](bytes1.size)
 
         // Bytes should not be equal right now
@@ -88,13 +97,42 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
         location should be > 0L
 
         // Move from VE to VH
-        val buffer2 = process.get(location, bytes2.size)
+        val buffer2 = new BytePointer(bytes2.size)
+        process.get(buffer2, location)
 
         // Move from VH to JVM
         buffer2.get(bytes2)
 
         // Bytes should be the same
         bytes1.toSeq should be (bytes2.toSeq)
+      }
+    }
+
+    "correctly transfer Array[Double] from VH to VE and back (sync)" in {
+      noException should be thrownBy {
+        val array1 = InputSamples.array[Double](Random.nextInt(10000) + 10)
+        val array2 = Array.ofDim[Double](array1.size)
+
+        // Bytes should not be equal right now
+        array1.toSeq should not be (array2.toSeq)
+
+        // Move from JVM to VH
+        val buffer1 = new DoublePointer(array1.size)
+        buffer1.put(array1, 0, array1.size)
+
+        // Move from VH to VE
+        val location = process.put(buffer1)
+        location should be > 0L
+
+        // Move from VE to VH
+        val buffer2 = new DoublePointer(array2.size)
+        process.get(buffer2, location)
+
+        // Move from VH to JVM
+        buffer2.get(array2)
+
+        // Bytes should be the same
+        array1.toSeq should be (array2.toSeq)
       }
     }
 
@@ -106,7 +144,7 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
         process.put(buffer)
       }
 
-      // BytePointer has size 0
+      // BytePointer buffer has size 0
       intercept[IllegalArgumentException] {
         val buffer = new BytePointer(0)
         buffer.close
@@ -115,20 +153,30 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
     }
 
     "handle corner cases when transferring data from VE to VH (sync) (i.e. should not crash the JVM)" in {
-      // VE memory location is invalid
+      // BytePointer is closed
       intercept[IllegalArgumentException] {
-        process.get(- Random.nextInt(10000).toLong, Random.nextInt(10000).toLong + 10)
+        val buffer = new BytePointer(Random.nextInt(10000))
+        buffer.close
+        process.get(buffer, Random.nextInt(10000) + 100)
       }
 
-      // Fetch size is invalid
+      // BytePointer buffer has size 0
       intercept[IllegalArgumentException] {
-        process.get(Random.nextInt(10000).toLong + 1, - Random.nextInt(10000).toLong)
+        val buffer = new BytePointer(0)
+        buffer.close
+        process.get(buffer, Random.nextInt(10000) + 100)
+      }
+
+      // VE memory address is invalid
+      intercept[IllegalArgumentException] {
+        val buffer = new BytePointer(Random.nextInt(10000))
+        process.get(buffer, - Random.nextInt(10000))
       }
     }
 
     "correctly transfer data from VH to VE and back (async)" in {
       noException should be thrownBy {
-        val bytes1 = randomBytes(Random.nextInt(100000) + 10)
+        val bytes1 = InputSamples.array[Byte](Random.nextInt(100000) + 10)
         val bytes2 = Array.ofDim[Byte](bytes1.size)
 
         // Bytes should not be equal right now
@@ -144,8 +192,9 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
 
         // Fetch the async transfer result using `peek`
         eventually {
-          val (res, xx) = process.peekResult(id1)
+          val (res, retp) = process.peekResult(id1)
           res should be (veo.VEO_COMMAND_OK)
+          retp.get should be (0L)
         }
 
         // Move from VE to VH (async)
@@ -153,7 +202,7 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
         val id2 = process.getAsync(buffer2, location)
 
         // Fetch the async transfer result using `await`
-        process.awaitResult(id2)
+        process.awaitResult(id2).get should be (0L)
 
         // Move from VH to JVM
         buffer2.get(bytes2)
@@ -171,7 +220,7 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
         process.putAsync(buffer)
       }
 
-      // BytePointer has size 0
+      // BytePointer buffer has size 0
       intercept[IllegalArgumentException] {
         val buffer = new BytePointer(0)
         buffer.close
@@ -194,7 +243,7 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
         process.getAsync(buffer, Random.nextInt(10000) + 100)
       }
 
-      // BytePointer has size 0
+      // BytePointer buffer has size 0
       intercept[IllegalArgumentException] {
         val buffer = new BytePointer(0)
         buffer.close
@@ -208,7 +257,7 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
       }
     }
 
-    "correctly allocate and free a veo_args" in {
+    "correctly create and release a `veo_args`" in {
       noException should be thrownBy {
         val buffer = new LongPointer(Random.nextInt(4) + 1)
         val inputs = Seq(
@@ -223,6 +272,182 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
 
         // Free the args stack
         process.freeArgsStack(stack)
+      }
+    }
+
+    "handle the case of loading a non-existent or invalid .SO file" in {
+      intercept[IllegalArgumentException] {
+        // Non-existent path
+        process.load(FileSystems.getDefault.getPath(s"/${UUID.randomUUID}/${UUID.randomUUID}"))
+      }
+
+      val path = File.createTempFile("tmp-",".so").toPath
+      intercept[IllegalArgumentException] {
+        // Invalid .SO file
+        process.load(path)
+      }
+    }
+
+    "handle the case of looking up a whitespace or non-existent symbol in a loaded library" in {
+      val fnName = "func"
+      val code = s"""
+        | extern "C" double ${fnName} (double input) {
+        |   return input * 2.0;
+        | }
+        """.stripMargin
+
+      withCompiled(code) { path =>
+        // Load the library
+        val library = process.load(path)
+
+        // Symbol with only whitespaces
+        intercept[IllegalArgumentException] {
+          process.getSymbol(library, "   ")
+        }
+
+        // Non-existent symbol
+        intercept[IllegalArgumentException] {
+          process.getSymbol(library, s"${UUID.randomUUID}")
+        }
+
+        noException should be thrownBy {
+          val func = process.getSymbol(library, fnName)
+          func.address should be > 0L
+        }
+
+        // Unload the library
+        process.unload(library)
+      }
+    }
+
+    "correctly load a library and execute a function call (sync)" in {
+      val fnName = s"func_${Random.nextInt(10)}"
+      val retval = Random.nextLong
+
+      // Define a function that multplies the input values by 2
+      val code = s"""
+        | #include <stddef.h>
+        |
+        | extern "C" long ${fnName} (double *inputs, size_t size, double **outputs) {
+        |   *outputs = new double[size];
+        |
+        |   for (auto i = 0; i < size; i++) {
+        |     (*outputs)[i] = inputs[i] * 2;
+        |   }
+        |
+        |   return ${retval};
+        | }
+        """.stripMargin
+
+      // Set up the input and output buffers on JVM
+      val input = InputSamples.array[Double](Random.nextInt(10000) + 10)
+      val output = Array.ofDim[Double](input.size)
+
+      // Move input to VH
+      val inbuffer = new DoublePointer(input.size)
+      inbuffer.put(input, 0, input.size)
+
+      // Set up the output pointer with an initial value
+      val outptr = new LongPointer(1)
+      outptr.put(-99)
+
+      // Set up the arguments stack
+      val stack = process.newArgsStack(Seq(
+        BuffArg(VeArgIntent.In, inbuffer),
+        U64Arg(input.size.toLong),
+        BuffArg(VeArgIntent.Out, outptr)
+      ))
+
+      withCompiled(code) { path =>
+        // Load the library
+        val library = process.load(path)
+
+        // Locate the function symbol
+        val func = process.getSymbol(library, fnName)
+
+        // Call the function (sync)
+        val retp = process.call(func, stack)
+        retp.get should be (retval)
+
+        // Dereference the output pointer and move output from VE to VH
+        val outbuffer = new DoublePointer(input.size)
+        process.get(outbuffer, outptr.get)
+
+        // Move output from VH to JVM
+        outbuffer.get(output)
+
+        // Output values should be the input values doubled
+        output.toSeq should be (input.toSeq.map(_ * 2))
+
+        // Unload the library
+        process.unload(library)
+      }
+    }
+
+    "correctly load a library and execute a function call (async)" in {
+      val fnName = s"func_${Random.nextInt(10)}"
+      // Need to return a positive value for peek and await to not throw exception
+      val retval = Random.nextLong.abs
+
+      // Define a function that takes the input values to the second power
+      val code = s"""
+        | #include <stddef.h>
+        |
+        | extern "C" long ${fnName} (double *inputs, size_t size, double **outputs) {
+        |   *outputs = new double[size];
+        |
+        |   for (auto i = 0; i < size; i++) {
+        |     (*outputs)[i] = inputs[i] * inputs[i];
+        |   }
+        |
+        |   return ${retval};
+        | }
+        """.stripMargin
+
+      // Set up the input and output buffers on JVM
+      val input = InputSamples.array[Double](Random.nextInt(10000) + 10)
+      val output = Array.ofDim[Double](input.size)
+
+      // Move input to VH
+      val inbuffer = new DoublePointer(input.size)
+      inbuffer.put(input, 0, input.size)
+
+      // Set up the output pointer with an initial value
+      val outptr = new LongPointer(1)
+      outptr.put(-99)
+
+      // Set up the arguments stack
+      val stack = process.newArgsStack(Seq(
+        BuffArg(VeArgIntent.In, inbuffer),
+        U64Arg(input.size.toLong),
+        BuffArg(VeArgIntent.Out, outptr)
+      ))
+
+      withCompiled(code) { path =>
+        // Load the library
+        val library = process.load(path)
+
+        // Locate the function symbol
+        val func = process.getSymbol(library, fnName)
+
+        // Call the function (async)
+        val id1 = process.callAsync(func, stack)
+
+        // Wait for the function call to complete using `await`
+        process.awaitResult(id1).get should be (retval)
+
+        // Dereference the output pointer and move output from VE to VH
+        val outbuffer = new DoublePointer(input.size)
+        process.get(outbuffer, outptr.get)
+
+        // Move output from VH to JVM
+        outbuffer.get(output)
+
+        // Output values should be the input values taken to the second power
+        output.toSeq should be (input.toSeq.map(x => x * x))
+
+        // Unload the library
+        process.unload(library)
       }
     }
   }


### PR DESCRIPTION
This PR only introduces the new `VeProcess` implementation.  More work will be done in subsequent PRs before integration with the rest of the codebase can commence.

Summary:

- Introduce a new implementation of `VeProcess` that is a simpler and stronger abstraction than the existing implementation
- Implement `CallContext` to eventually replace the `OriginalCallingContext` class that is nested in the old `VeProcess`
- Add algebraic data types to abstract over the creation and handling of the VE process call args stack
- Add models to abstract over library references and library symbols loaded by the VE process
- Add methods to abstract out the creation of the VE process and VEO thread contexts
- Add `VeAsyncReqId` model to abstract over async request IDs
- Add unit tests for the `VeProcess` class
- Update existing `VeProcess` methods to accept `Pointer` and automatically compute the byte sizes for data transfers
- Add more unit tests to check that compiling, loading, and executing C code works (absent of column vector abstractions)
- Add an internal allocation tracker inside `VeProcess` class to keep track of heap allocations made.  This allows the process to complain about un-released heap allocations on `close()` as well as prevent invalid `free()` requests (either `free()` on non-allocated memory or double `free()`)
- Add an internal allocation tracker inside `VeProcess` class to keep track of args stack allocations made.  This allows the process to complain about un-released stack allocations on `close()` as well as prevent invalid `veo_args_free()` requests (mainly double `veo_args_free()`)
- Wrap all existing methods to check that the process is open, to prevent illegal process calls after `close()`