### PR TITLE
Bugfix: Handle alignment correctly

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
@@ -30,8 +30,6 @@
 #include <type_traits>
 #include <iostream>
 
-#define VECTOR_ALIGNED(n) ((n + (7UL)) & ~(7UL))
-
 void merge_varchar_transfer(size_t batch_count, size_t total_element_count, char* col_header, char* input_data, char* out_data, uint64_t* out_validity_buffer, char* out_lengths, char* out_offsets, uintptr_t* od, size_t &output_pos){
   //std::cout << "merge_varchar_transfer" << std::endl;
   size_t cur_col_pos = 0;

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
@@ -30,6 +30,7 @@
 #include <type_traits>
 #include <iostream>
 
+#define VECTOR_ALIGNED(n) ((n + (7UL)) & ~(7UL))
 
 void merge_varchar_transfer(size_t batch_count, size_t total_element_count, char* col_header, char* input_data, char* out_data, uint64_t* out_validity_buffer, char* out_lengths, char* out_offsets, uintptr_t* od, size_t &output_pos){
   //std::cout << "merge_varchar_transfer" << std::endl;
@@ -57,7 +58,7 @@ void merge_varchar_transfer(size_t batch_count, size_t total_element_count, char
 
     size_t start_out_data_pos = cur_out_data_pos;
     std::memcpy(&out_data[cur_out_data_pos], &input_data[cur_data_pos], col_in->data_size);
-    cur_data_pos += col_in->data_size;
+    cur_data_pos += VECTOR_ALIGNED(col_in->data_size);
     cur_out_data_pos += col_in->data_size;
 
     //std::cout << "merge_varchar_transfer: copy offsets" << std::endl;
@@ -75,12 +76,12 @@ void merge_varchar_transfer(size_t batch_count, size_t total_element_count, char
         offsets_int[oi] += offset_correction;
       }
     }
-    cur_data_pos += col_in->offsets_size;
+    cur_data_pos += VECTOR_ALIGNED(col_in->offsets_size);
     cur_out_offsets_pos += col_in->offsets_size;
 
     //std::cout << "merge_varchar_transfer: copy lengths" << std::endl;
     std::memcpy(&out_lengths[cur_out_lengths_pos], &input_data[cur_data_pos], col_in->lengths_size);
-    cur_data_pos += col_in->lengths_size;
+    cur_data_pos += VECTOR_ALIGNED(col_in->lengths_size);
     cur_out_lengths_pos += col_in->lengths_size;
 
     //std::cout << "merge_varchar_transfer: copy validity buffer" << std::endl;
@@ -96,7 +97,7 @@ void merge_varchar_transfer(size_t batch_count, size_t total_element_count, char
       }
     }
 
-    cur_data_pos += col_in->validity_buffer_size;
+    cur_data_pos += VECTOR_ALIGNED(col_in->validity_buffer_size);
   }
 
   //std::cout << "merge_varchar_transfer: allocate vector" << std::endl;
@@ -135,7 +136,7 @@ void merge_scalar_transfer(size_t batch_count, size_t total_element_count, char*
 
     //std::cout << "merge_scalar_transfer: copy data" << std::endl;
     std::memcpy(&out_data[cur_out_data_pos], &input_data[cur_data_pos], col_in->data_size);
-    cur_data_pos += col_in->data_size;
+    cur_data_pos += VECTOR_ALIGNED(col_in->data_size);
     cur_out_data_pos += col_in->data_size;
 
     //std::cout << "merge_scalar_transfer: copy validity" << std::endl;
@@ -151,7 +152,7 @@ void merge_scalar_transfer(size_t batch_count, size_t total_element_count, char*
       }
     }
 
-    cur_data_pos += col_in->validity_buffer_size;
+    cur_data_pos += VECTOR_ALIGNED(col_in->validity_buffer_size);
   }
 
   //std::cout << "merge_scalar_transfer: allocate vector" << std::endl;

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
@@ -41,6 +41,7 @@ void merge_varchar_transfer(size_t batch_count, size_t total_element_count, char
   size_t cur_out_validity_data_pos = 0;
   size_t dangling_bits = 0;
 
+  size_t i = 0;
   for(auto b = 0; b < batch_count; b++){
     cur_col_pos += sizeof(column_type); // Don't care about column type anymore - it has been asserted to be correct previously
     varchar_col_in* col_in = reinterpret_cast<varchar_col_in *>(&col_header[cur_col_pos]);
@@ -83,14 +84,16 @@ void merge_varchar_transfer(size_t batch_count, size_t total_element_count, char
     cur_out_lengths_pos += col_in->lengths_size;
 
     //std::cout << "merge_varchar_transfer: copy validity buffer" << std::endl;
-    uint64_t* batch_validity_buffer = reinterpret_cast<uint64_t *>(&input_data[cur_data_pos]);
-    dangling_bits = cyclone::append_bitsets(
-        &out_validity_buffer[cur_out_validity_data_pos], dangling_bits,
-        batch_validity_buffer, col_in->element_count);
-    cur_out_validity_data_pos += frovedis::ceil_div(col_in->element_count, size_t(64));
-    if(dangling_bits > 0){
-      // last part is not entirely filled yet
-      cur_out_validity_data_pos -= 1;
+    if(b == 0){
+      // just copy over the given validity buffer for the first batch
+      std::memcpy(out_validity_buffer, &input_data[cur_data_pos], col_in->validity_buffer_size);
+      i = col_in->element_count;
+    }else{
+      uint64_t* batch_validity_buffer = reinterpret_cast<uint64_t *>(&input_data[cur_data_pos]);
+      #pragma _NEC novector
+      for(auto ci = 0; ci < col_in->element_count; ci++){
+        set_valid_bit(out_validity_buffer, i++, get_valid_bit(batch_validity_buffer, ci));
+      }
     }
 
     cur_data_pos += col_in->validity_buffer_size;
@@ -124,6 +127,7 @@ void merge_scalar_transfer(size_t batch_count, size_t total_element_count, char*
   size_t cur_out_validity_data_pos = 0;
   size_t dangling_bits = 0;
 
+  size_t i = 0;
   for(auto b = 0; b < batch_count; b++){
     cur_col_pos += sizeof(column_type); // Don't care about column type anymore - it has been asserted to be correct previously
     scalar_col_in* col_in = reinterpret_cast<scalar_col_in *>(&col_header[cur_col_pos]);
@@ -135,14 +139,16 @@ void merge_scalar_transfer(size_t batch_count, size_t total_element_count, char*
     cur_out_data_pos += col_in->data_size;
 
     //std::cout << "merge_scalar_transfer: copy validity" << std::endl;
-    uint64_t* batch_validity_buffer = reinterpret_cast<uint64_t *>(&input_data[cur_data_pos]);
-    dangling_bits = cyclone::append_bitsets(
-        &out_validity_buffer[cur_out_validity_data_pos], dangling_bits,
-        batch_validity_buffer, col_in->element_count);
-    cur_out_validity_data_pos += frovedis::ceil_div(col_in->element_count, size_t(64));
-    if(dangling_bits > 0){
-      // last part is not entirely filled yet
-      cur_out_validity_data_pos -= 1;
+    if(b == 0){
+      // just copy over the given validity buffer for the first batch
+      std::memcpy(out_validity_buffer, &input_data[cur_data_pos], col_in->validity_buffer_size);
+      i = col_in->element_count;
+    }else{
+      uint64_t* batch_validity_buffer = reinterpret_cast<uint64_t *>(&input_data[cur_data_pos]);
+      #pragma _NEC novector
+      for(auto ci = 0; ci < col_in->element_count; ci++){
+        set_valid_bit(out_validity_buffer, i++, get_valid_bit(batch_validity_buffer, ci));
+      }
     }
 
     cur_data_pos += col_in->validity_buffer_size;

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
@@ -216,7 +216,8 @@ void merge_scalar_transfer(size_t batch_count, size_t total_element_count, char*
  * - *column type* specifies which type the buffer is
  * - *element count* specifies how many elements there are in this particular
  *   column
- * - *buffer size* specifies how large each buffer for that column is
+ * - *buffer size* specifies how large each buffer (including alignment padding!)
+ *   for that column is
  *
  * The number of *buffer size* definitions that follow the first two fields
  * depends entirely on the column type.

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.hpp
@@ -22,6 +22,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define VECTOR_ALIGNED(n) ((n + (7UL)) & ~(7UL))
+
 extern "C" int handle_transfer(char** td, uintptr_t* od);
 
 void merge_varchar_transfer(size_t batch_count, size_t total_element_count, char* col_header, char* input_data, char* data, uint64_t* validity_buffer, char* lengths, char* offsets, uintptr_t* od, size_t &output_pos);

--- a/src/main/resources/com/nec/cyclone/cpp/tests/packed_transfer_spec.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/packed_transfer_spec.cc
@@ -49,10 +49,10 @@ namespace cyclone::tests {
       header_pos += sizeof(scalar_col_in);
 
       std::memcpy(&data[data_pos], vec->data, data_size);
-      data_pos += data_size;
+      data_pos += VECTOR_ALIGNED(data_size);
 
       std::memcpy(&data[data_pos], vec->validityBuffer, validity_buffer_size);
-      data_pos += validity_buffer_size;
+      data_pos += VECTOR_ALIGNED(validity_buffer_size);
     }
 
     void copy_varchar_vec_to_transfer_buffer(nullable_varchar_vector* vec, char* header, char* data, size_t &header_pos, size_t &data_pos){
@@ -75,16 +75,16 @@ namespace cyclone::tests {
       header_pos += sizeof(varchar_col_in);
 
       std::memcpy(&data[data_pos], vec->data, data_size);
-      data_pos += data_size;
+      data_pos += VECTOR_ALIGNED(data_size);
 
       std::memcpy(&data[data_pos], vec->offsets, offsets_size);
-      data_pos += offsets_size;
+      data_pos += VECTOR_ALIGNED(offsets_size);
 
       std::memcpy(&data[data_pos], vec->lengths, lengths_size);
-      data_pos += lengths_size;
+      data_pos += VECTOR_ALIGNED(lengths_size);
 
       std::memcpy(&data[data_pos], vec->validityBuffer, validity_buffer_size);
-      data_pos += validity_buffer_size;
+      data_pos += VECTOR_ALIGNED(validity_buffer_size);
     }
 
     TEST_CASE_TEMPLATE("Unpacking works for single scalar vector of T=", T, int32_t, int64_t, float, double) {
@@ -96,8 +96,8 @@ namespace cyclone::tests {
       auto header_size = sizeof(transfer_header) + sizeof(size_t) + sizeof(scalar_col_in);
 
       size_t element_count = static_cast<size_t>(vec1->count);
-      size_t data_size = sizeof(T) * element_count;
-      size_t validity_buffer_size = frovedis::ceil_div(vec1->count, int32_t(64)) * sizeof(uint64_t);
+      size_t data_size = VECTOR_ALIGNED(sizeof(T) * element_count);
+      size_t validity_buffer_size = VECTOR_ALIGNED(frovedis::ceil_div(vec1->count, int32_t(64)) * sizeof(uint64_t));
 
       char* transfer = static_cast<char*>(malloc(header_size + data_size + validity_buffer_size));
 
@@ -139,10 +139,10 @@ namespace cyclone::tests {
       auto header_size = sizeof(transfer_header) + sizeof(size_t) + sizeof(varchar_col_in);
 
       size_t element_count = static_cast<size_t>(vec1->count);
-      size_t data_size = vec1->dataSize * sizeof(int32_t);
-      size_t offsets_size = element_count * sizeof(int32_t);
-      size_t lengths_size = element_count * sizeof(int32_t);
-      size_t validity_buffer_size = frovedis::ceil_div(vec1->count, int32_t(64)) * sizeof(uint64_t);
+      size_t data_size = VECTOR_ALIGNED(vec1->dataSize * sizeof(int32_t));
+      size_t offsets_size = VECTOR_ALIGNED(element_count * sizeof(int32_t));
+      size_t lengths_size = VECTOR_ALIGNED(element_count * sizeof(int32_t));
+      size_t validity_buffer_size = VECTOR_ALIGNED(frovedis::ceil_div(vec1->count, int32_t(64)) * sizeof(uint64_t));
 
       char* transfer = static_cast<char*>(malloc(header_size + data_size + offsets_size + lengths_size + validity_buffer_size));
 
@@ -191,10 +191,10 @@ namespace cyclone::tests {
       auto header_size = sizeof(transfer_header) + (2 * (sizeof(size_t) + sizeof(scalar_col_in))) + sizeof(size_t) + sizeof(varchar_col_in);
 
       size_t element_count = static_cast<size_t>(vec1->count);
-      size_t data_size = vec1->dataSize * sizeof(int32_t) + (vec2->count * sizeof(int32_t)) + (vec3->count * sizeof(double));
-      size_t offsets_size = element_count * sizeof(int32_t);
-      size_t lengths_size = element_count * sizeof(int32_t);
-      size_t validity_buffer_size = sizeof(uint64_t) * (frovedis::ceil_div(vec1->count, int32_t(64)) + frovedis::ceil_div(vec2->count, int32_t(64)) + frovedis::ceil_div(vec3->count, int32_t(64)));
+      size_t data_size = VECTOR_ALIGNED(vec1->dataSize * sizeof(int32_t)) + VECTOR_ALIGNED(vec2->count * sizeof(int32_t)) + VECTOR_ALIGNED(vec3->count * sizeof(double));
+      size_t offsets_size = VECTOR_ALIGNED(element_count * sizeof(int32_t));
+      size_t lengths_size = VECTOR_ALIGNED(element_count * sizeof(int32_t));
+      size_t validity_buffer_size = VECTOR_ALIGNED(sizeof(uint64_t) * (frovedis::ceil_div(vec1->count, int32_t(64)) + frovedis::ceil_div(vec2->count, int32_t(64)) + frovedis::ceil_div(vec3->count, int32_t(64))));
 
       char* transfer = static_cast<char*>(malloc(header_size + data_size + offsets_size + lengths_size + validity_buffer_size));
 
@@ -267,13 +267,13 @@ namespace cyclone::tests {
 
       auto header_size = sizeof(transfer_header) + (2 * (sizeof(size_t) + sizeof(scalar_col_in))) + (2* (sizeof(size_t) + sizeof(varchar_col_in)));
 
-      size_t data_size = vc_vec1->dataSize * sizeof(int32_t) + vc_vec2->dataSize * sizeof(int32_t) + (sc_vec1->count * sizeof(int32_t)) + (sc_vec2->count * sizeof(int32_t));
-      size_t offsets_size = vc_vec1->count * sizeof(int32_t) + vc_vec2->count * sizeof(int32_t);
-      size_t lengths_size = vc_vec1->count * sizeof(int32_t) + vc_vec2->count * sizeof(int32_t);
-      size_t validity_buffer_size = sizeof(uint64_t) * ( frovedis::ceil_div(vc_vec1->count, int32_t(64))
+      size_t data_size = VECTOR_ALIGNED(vc_vec1->dataSize * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec2->dataSize * sizeof(int32_t)) + VECTOR_ALIGNED(sc_vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(sc_vec2->count * sizeof(int32_t));
+      size_t offsets_size = VECTOR_ALIGNED(vc_vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec2->count * sizeof(int32_t));
+      size_t lengths_size = VECTOR_ALIGNED(vc_vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec2->count * sizeof(int32_t));
+      size_t validity_buffer_size = VECTOR_ALIGNED(sizeof(uint64_t) * ( frovedis::ceil_div(vc_vec1->count, int32_t(64))
                                                        + frovedis::ceil_div(vc_vec2->count, int32_t(64))
                                                        + frovedis::ceil_div(sc_vec1->count, int32_t(64))
-                                                       + frovedis::ceil_div(sc_vec2->count, int32_t(64)));
+                                                       + frovedis::ceil_div(sc_vec2->count, int32_t(64))));
 
       char* transfer = static_cast<char*>(malloc(header_size + data_size + offsets_size + lengths_size + validity_buffer_size));
 
@@ -353,16 +353,16 @@ namespace cyclone::tests {
 
           auto header_size = sizeof(transfer_header) + (3 * (sizeof(size_t) + sizeof(scalar_col_in))) + (3 * (sizeof(size_t) + sizeof(varchar_col_in)));
 
-          size_t data_size = (vc_vec1->dataSize * sizeof(int32_t) + vc_vec2->dataSize * sizeof(int32_t) + vc_vec3->dataSize * sizeof(int32_t)
-                             + (sc_vec1->count * sizeof(int32_t)) + (sc_vec2->count * sizeof(int32_t)) + (sc_vec3->count * sizeof(int32_t)));
-          size_t offsets_size = vc_vec1->count * sizeof(int32_t) + vc_vec2->count * sizeof(int32_t) + vc_vec3->count * sizeof(int32_t);
-          size_t lengths_size = vc_vec1->count * sizeof(int32_t) + vc_vec2->count * sizeof(int32_t) + vc_vec3->count * sizeof(int32_t);
-          size_t validity_buffer_size = sizeof(uint64_t) * ( frovedis::ceil_div(vc_vec1->count, int32_t(64))
+          size_t data_size = (VECTOR_ALIGNED(vc_vec1->dataSize * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec2->dataSize * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec3->dataSize * sizeof(int32_t))
+                             + VECTOR_ALIGNED(sc_vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(sc_vec2->count * sizeof(int32_t)) + VECTOR_ALIGNED(sc_vec3->count * sizeof(int32_t)));
+          size_t offsets_size = VECTOR_ALIGNED(vc_vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec2->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec3->count * sizeof(int32_t));
+          size_t lengths_size = VECTOR_ALIGNED(vc_vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec2->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec3->count * sizeof(int32_t));
+          size_t validity_buffer_size = VECTOR_ALIGNED(sizeof(uint64_t) * ( frovedis::ceil_div(vc_vec1->count, int32_t(64))
                                                            + frovedis::ceil_div(vc_vec2->count, int32_t(64))
                                                            + frovedis::ceil_div(vc_vec3->count, int32_t(64))
                                                            + frovedis::ceil_div(sc_vec1->count, int32_t(64))
                                                            + frovedis::ceil_div(sc_vec2->count, int32_t(64))
-                                                           + frovedis::ceil_div(sc_vec3->count, int32_t(64)));
+                                                           + frovedis::ceil_div(sc_vec3->count, int32_t(64))));
 
           char* transfer = static_cast<char*>(malloc(header_size + data_size + offsets_size + lengths_size + validity_buffer_size));
 

--- a/src/main/resources/com/nec/cyclone/cpp/tests/packed_transfer_spec.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/packed_transfer_spec.cc
@@ -320,5 +320,96 @@ namespace cyclone::tests {
       transferred2->print();
       CHECK(transferred2->equals(sc_merged));
     }
+
+    TEST_CASE("Unpacking and merging three batches works for multiple vectors of different types"){
+          std::vector<std::string> raw1 { "JAN", "FEB", "MAR", "APR", "MAY", "JUN"};
+          std::vector<std::string> raw2 { "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
+          std::vector<std::string> raw3 { "A", "b", "C"};
+          auto *vc_vec1 = new nullable_varchar_vector(raw1);
+          vc_vec1->set_validity(1, 0);
+          vc_vec1->set_validity(3, 0);
+          vc_vec1->set_validity(5, 0);
+
+          auto *vc_vec2 = new nullable_varchar_vector(raw2);
+          vc_vec2->set_validity(0, 0);
+          vc_vec2->set_validity(2, 0);
+          vc_vec2->set_validity(4, 0);
+
+          auto *vc_vec3 = new nullable_varchar_vector(raw3);
+          vc_vec3->set_validity(1, 0);
+
+          auto *sc_vec1 = new NullableScalarVec<int32_t>({586, 951, 106, 318, 538, 620});
+          sc_vec1->set_validity(1, 0);
+          sc_vec1->set_validity(3, 0);
+          sc_vec1->set_validity(5, 0);
+
+          auto *sc_vec2 = new NullableScalarVec<int32_t>({553, 605, 822, 941});
+          sc_vec2->set_validity(2, 0);
+          sc_vec2->set_validity(3, 0);
+
+          auto *sc_vec3 = new NullableScalarVec<int32_t>({53, 5, 22, 94});
+          sc_vec2->set_validity(0, 0);
+          sc_vec2->set_validity(1, 0);
+
+          auto header_size = sizeof(transfer_header) + (3 * (sizeof(size_t) + sizeof(scalar_col_in))) + (3 * (sizeof(size_t) + sizeof(varchar_col_in)));
+
+          size_t data_size = (vc_vec1->dataSize * sizeof(int32_t) + vc_vec2->dataSize * sizeof(int32_t) + vc_vec3->dataSize * sizeof(int32_t)
+                             + (sc_vec1->count * sizeof(int32_t)) + (sc_vec2->count * sizeof(int32_t)) + (sc_vec3->count * sizeof(int32_t)));
+          size_t offsets_size = vc_vec1->count * sizeof(int32_t) + vc_vec2->count * sizeof(int32_t) + vc_vec3->count * sizeof(int32_t);
+          size_t lengths_size = vc_vec1->count * sizeof(int32_t) + vc_vec2->count * sizeof(int32_t) + vc_vec3->count * sizeof(int32_t);
+          size_t validity_buffer_size = sizeof(uint64_t) * ( frovedis::ceil_div(vc_vec1->count, int32_t(64))
+                                                           + frovedis::ceil_div(vc_vec2->count, int32_t(64))
+                                                           + frovedis::ceil_div(vc_vec3->count, int32_t(64))
+                                                           + frovedis::ceil_div(sc_vec1->count, int32_t(64))
+                                                           + frovedis::ceil_div(sc_vec2->count, int32_t(64))
+                                                           + frovedis::ceil_div(sc_vec3->count, int32_t(64)));
+
+          char* transfer = static_cast<char*>(malloc(header_size + data_size + offsets_size + lengths_size + validity_buffer_size));
+
+          size_t pos = 0;
+          transfer_header* header = reinterpret_cast<transfer_header *>(&transfer[pos]);
+          header->header_size = header_size;
+          header->batch_count = 3;
+          header->column_count = 2;
+          pos += sizeof(transfer_header);
+
+          size_t data_pos = 0;
+          size_t col_pos = 0;
+          copy_varchar_vec_to_transfer_buffer(vc_vec1, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+          copy_varchar_vec_to_transfer_buffer(vc_vec2, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+          copy_varchar_vec_to_transfer_buffer(vc_vec3, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+          copy_scalar_vec_to_transfer_buffer(sc_vec1, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+          copy_scalar_vec_to_transfer_buffer(sc_vec2, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+          copy_scalar_vec_to_transfer_buffer(sc_vec3, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+
+          uintptr_t* od = static_cast<uintptr_t*>(malloc(sizeof(uintptr_t) * (5 + 3)));
+
+          char* target[1] = {transfer};
+
+          int res = handle_transfer(target, od);
+          CHECK(res == 0);
+
+          nullable_varchar_vector* varchars[3] = {vc_vec1, vc_vec2, vc_vec3};
+          NullableScalarVec<int32_t>* scalars[3] = {sc_vec1, sc_vec2, sc_vec3};
+
+          nullable_varchar_vector* vc_merged = nullable_varchar_vector::merge(varchars, 3);
+          NullableScalarVec<int32_t>* sc_merged = NullableScalarVec<int32_t>::merge(scalars, 3);
+
+          nullable_varchar_vector* transferred1 = reinterpret_cast<nullable_varchar_vector*>(od[0]);
+
+          std::cout << "vc_merged = " << std::endl;
+          vc_merged->print();
+          std::cout << "transferred1 = " << std::endl;
+          transferred1->print();
+          CHECK(transferred1->equals(vc_merged));
+
+          NullableScalarVec<int32_t>* transferred2 = reinterpret_cast<NullableScalarVec<int32_t>*>(od[5]);
+
+          std::cout << "sc_merged = " << std::endl;
+          sc_merged->print();
+          std::cout << "transferred2 = " << std::endl;
+          transferred2->print();
+          CHECK(transferred2->equals(sc_merged));
+        }
   }
 }

--- a/src/main/scala/com/nec/cache/TransferDescriptor.scala
+++ b/src/main/scala/com/nec/cache/TransferDescriptor.scala
@@ -15,6 +15,11 @@ case class TransferDescriptor(
   lazy val buffer: BytePointer = {
     require(nonEmpty, "Can not create transfer buffer for empty TransferDescriptor!")
 
+    val batchCount: Long = batches.size
+    val columnCount: Long = batches.head.size
+
+    logger.debug(s"Preparing transfer buffer for ${batchCount} batches of ${columnCount} columns")
+
     val sizeOfSizeT = 8
 
     // Columns are arranged such that the first column of all batches comes first, then the second one of all batches
@@ -30,8 +35,6 @@ case class TransferDescriptor(
     }.toList
     // As startingPositions starts after the header, its cum-sum reflects the total number of elements in the header
     val totalHeaderSize: Long = startingPositions.last * sizeOfSizeT
-    val batchCount: Long = batches.size
-    val columnCount: Long = batches.head.size
 
     val dataSize = batches.flatten.flatMap(_.buffers).map(it => vectorAlignedSize(it.limit())).sum
 

--- a/src/main/scala/com/nec/cache/TransferDescriptor.scala
+++ b/src/main/scala/com/nec/cache/TransferDescriptor.scala
@@ -68,13 +68,13 @@ case class TransferDescriptor(
 
       header.put(startPos, columnType)
       header.put(startPos + 1, column.numItems)
-      header.put(startPos + 2, vectorAlignedSize(buffers(0).limit()))
+      header.put(startPos + 2, buffers(0).limit())
       if(column.veType.isString){
-        header.put(startPos + 3, vectorAlignedSize(buffers(1).limit()))
-        header.put(startPos + 4, vectorAlignedSize(buffers(2).limit()))
-        header.put(startPos + 5, vectorAlignedSize(buffers(3).limit()))
+        header.put(startPos + 3, buffers(1).limit())
+        header.put(startPos + 4, buffers(2).limit())
+        header.put(startPos + 5, buffers(3).limit())
       }else{
-        header.put(startPos + 3, vectorAlignedSize(buffers(1).limit()))
+        header.put(startPos + 3, buffers(1).limit())
       }
     }
 

--- a/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
+++ b/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
@@ -68,12 +68,12 @@ object VeRewriteStrategyOptions {
     VeRewriteStrategyOptions(
       enableVeSorting = false,
       projectOnVe = false,
-      filterOnVe = true,
+      filterOnVe = false,
       aggregateOnVe = true,
       exchangeOnVe = false,
       passThroughProject = false,
       failFast = false,
-      joinOnVe = true,
+      joinOnVe = false,
       amplifyBatches = true,
       rewriteEnabled = true
     )

--- a/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
+++ b/src/main/scala/com/nec/spark/planning/VeRewriteStrategyOptions.scala
@@ -66,11 +66,11 @@ object VeRewriteStrategyOptions {
 
   val default: VeRewriteStrategyOptions =
     VeRewriteStrategyOptions(
-      enableVeSorting = true,
+      enableVeSorting = false,
       projectOnVe = false,
       filterOnVe = true,
       aggregateOnVe = true,
-      exchangeOnVe = true,
+      exchangeOnVe = false,
       passThroughProject = false,
       failFast = false,
       joinOnVe = true,

--- a/src/main/scala/com/nec/spark/planning/plans/SparkToVectorEnginePlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/SparkToVectorEnginePlan.scala
@@ -71,18 +71,13 @@ case class SparkToVectorEnginePlan(childPlan: SparkPlan, parentVeFunction: VeFun
             val arrowSchema = CycloneCacheBase.makeArrowSchema(child.output)
 
             val transferDescriptor = withInvocationMetrics("Conversion"){
-              println("Preparing VH -> VE Transfer")
               collectBatchMetrics(INPUT, columnarBatches).zipWithIndex.map { case (columnarBatch, idx) =>
-                println(s"Batch $idx")
                 (0 until columnarBatch.numCols())
                   .map { i =>
-                    println(s"Col $i")
                     columnarBatch.column(i).getOptionalArrowValueVector match {
                       case Some(acv) =>
-                        println(s"Some($acv): ${acv.getValueCount}, ${acv.getNullCount}")
                         acv.toBytePointerColVector
                       case None =>
-                        println(s"None: ${columnarBatch.numRows()}")
                         val field = arrowSchema.getFields.get(i)
                         columnarBatch.column(i)
                           .toBytePointerColVector(field.getName, columnarBatch.numRows)

--- a/src/main/scala/com/nec/spark/planning/plans/SparkToVectorEnginePlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/SparkToVectorEnginePlan.scala
@@ -27,7 +27,7 @@ case class SparkToVectorEnginePlan(childPlan: SparkPlan, parentVeFunction: VeFun
   with PlanCallsVeFunction
   with PlanMetrics {
 
-  override lazy val metrics = invocationMetrics(PLAN) ++ invocationMetrics(VE) ++ batchMetrics(INPUT) ++ batchMetrics(OUTPUT) ++ invocationMetrics("Conversion")
+  override lazy val metrics = invocationMetrics(PLAN) ++ invocationMetrics(VE) ++ batchMetrics(INPUT) ++ batchMetrics(OUTPUT) ++ invocationMetrics("Conversion") ++ batchMetrics("byte")
 
   override protected def doCanonicalize(): SparkPlan = super.doCanonicalize()
 
@@ -41,8 +41,8 @@ case class SparkToVectorEnginePlan(childPlan: SparkPlan, parentVeFunction: VeFun
 
   override def executeVeColumnar(): RDD[VeColBatch] = {
     require(!child.isInstanceOf[SupportsVeColBatch], "Child should not be a VE plan")
-
     initializeMetrics()
+    val byteTotalBatchRowCount = longMetric(s"byteTotalBatchRowCount")
 
     // Instead of creating a new config we are reusing columnBatchSize. In the future if we do
     // combine with some of the Arrow conversion tools we will need to unify some of the configs.
@@ -70,21 +70,24 @@ case class SparkToVectorEnginePlan(childPlan: SparkPlan, parentVeFunction: VeFun
 
             val arrowSchema = CycloneCacheBase.makeArrowSchema(child.output)
 
-            val batches = collectBatchMetrics(INPUT, columnarBatches).toList
-            logger.debug(s"Creating Transfer descriptor for ${batches.size} batches of ${batches.headOption.map{ b => s"${b.numCols()} Columns"}}")
             val transferDescriptor = withInvocationMetrics("Conversion"){
-              batches.map { columnarBatch =>
+              println("Preparing VH -> VE Transfer")
+              collectBatchMetrics(INPUT, columnarBatches).zipWithIndex.map { case (columnarBatch, idx) =>
+                println(s"Batch $idx")
                 (0 until columnarBatch.numCols())
-                  .map(i =>
+                  .map { i =>
+                    println(s"Col $i")
                     columnarBatch.column(i).getOptionalArrowValueVector match {
                       case Some(acv) =>
+                        println(s"Some($acv): ${acv.getValueCount}, ${acv.getNullCount}")
                         acv.toBytePointerColVector
                       case None =>
+                        println(s"None: ${columnarBatch.numRows()}")
                         val field = arrowSchema.getFields.get(i)
                         columnarBatch.column(i)
                           .toBytePointerColVector(field.getName, columnarBatch.numRows)
                     }
-                  )
+                  }
               }.foldLeft(new TransferDescriptor.Builder()){ case (builder, batch) =>
                 builder.newBatch().addColumns(batch)
               }.build()

--- a/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
+++ b/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
@@ -140,8 +140,8 @@ final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
       val col2_merged = Array[String]("a", "b", "c", "d", "e", "f", "g", "h").toBytePointerColVector("expected_col2").toBytes
 
 
-      col1.toBytePointerColVector.toBytes should be(col1_merged)
-      col2.toBytePointerColVector.toBytes should be(col2_merged)
+      col1.toBytePointerColVector.toBytes should equal(col1_merged)
+      col2.toBytePointerColVector.toBytes should equal(col2_merged)
     }
   }
 }

--- a/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
+++ b/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
@@ -1,0 +1,147 @@
+package com.nec.colvector
+
+import com.nec.cache.TransferDescriptor
+import com.nec.colvector.ArrayTConversions._
+import com.nec.cyclone.annotations.VectorEngineTest
+import com.nec.ve.WithVeProcess
+import org.bytedeco.javacpp.LongPointer
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Paths
+
+
+@VectorEngineTest
+final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
+  val libraryPath = Paths.get("target/scala-2.12/classes/cycloneve/libcyclone.so")
+
+  private def batch1() = Seq(
+    Array[Double](1, 2, 3).toBytePointerColVector("col1_b1"),
+    Array[String]("a", "b", "c").toBytePointerColVector("col2_b1")
+  )
+  private def batch2() = Seq(
+    Array[Double](4, 5, 6).toBytePointerColVector("col1_b2"),
+    Array[String]("d", "e", "f").toBytePointerColVector("col2_b2")
+  )
+  private def batch3() = Seq(
+    Array[Double](7, 8).toBytePointerColVector("col1_b3"),
+    Array[String]("g", "h").toBytePointerColVector("col2_b3")
+  )
+
+  private def transferDescriptor() = {
+    val descriptor = new TransferDescriptor.Builder()
+      .newBatch().addColumns(batch1())
+      .newBatch().addColumns(batch2())
+      .newBatch().addColumns(batch3())
+      .build()
+
+    descriptor
+  }
+
+  "TransferDescriptor" should {
+    "correctly create the transfer buffer header" in {
+      val descriptor = transferDescriptor()
+      val buffer = descriptor.buffer
+      val longBuffer = new LongPointer(buffer)
+      val header = new Array[Long](3)
+      longBuffer.get(header)
+
+      val expectedBatchCount = 3
+      val expectedColumnCount = 2
+      val expectedHeaderSize = (3 + (expectedBatchCount * (4  + 6))) * 8
+      val expectedHeader = Array[Long](expectedHeaderSize, expectedBatchCount, expectedColumnCount)
+
+      header should be (expectedHeader)
+    }
+
+    "correctly read the output buffer" in {
+      val descriptor = transferDescriptor()
+      val outputBuffer = descriptor.outputBuffer
+
+      val expectedOutputBufferSize = (5 + 3) * 8
+      outputBuffer.limit() should be (expectedOutputBufferSize)
+
+      // put up some imaginary values
+      val longOD = new LongPointer(outputBuffer)
+      // Col 1
+        .put(0, 1)
+        .put(1, 2)
+        .put(2, 3)
+      // Col 2
+        .put(3, 4)
+        .put(4, 5)
+        .put(5, 6)
+        .put(6, 7)
+        .put(7, 8)
+
+      val batch = descriptor.outputBufferToColBatch()
+      batch.numRows should be (8)
+      batch.columns.size should be (2)
+
+      val col1 = batch.columns(0)
+      val col2 = batch.columns(1)
+
+      col1.numItems should be (8)
+      col2.numItems should be (8)
+
+      col1.container should be (1)
+      col1.buffers should be (Seq(2, 3))
+
+      col2.container should be (4)
+      col2.buffers should be (Seq(5, 6, 7, 8))
+    }
+  }
+
+  "handle_transfer" should {
+    import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+
+    "correctly unpack a single batch of mixed vector types" in {
+      val cols = batch1()
+      val descriptor = new TransferDescriptor.Builder()
+        .newBatch().addColumns(cols)
+        .build()
+
+      val libRef = veProcess.loadLibrary(libraryPath)
+      val batch = veProcess.executeTransfer(libRef, descriptor)
+
+      batch.numRows should be (3)
+      batch.columns.size should be (2)
+
+      val col1 = batch.columns(0)
+      val col2 = batch.columns(1)
+
+      col1.numItems should be(3)
+      col2.numItems should be(3)
+
+      col1.toBytePointerColVector.toBytes should equal (cols(0).toBytes)
+      col2.toBytePointerColVector.toBytes should equal (cols(1).toBytes)
+    }
+
+    "correctly unpack multiple batches of mixed vector types" in {
+      val descriptor = transferDescriptor()
+      println("Transfer Buffer = ")
+      val buffer = Array.ofDim[Byte](descriptor.buffer.limit().toInt)
+      descriptor.buffer.get(buffer)
+      println(buffer.mkString("Array(", ", ", ")"))
+
+      val libRef = veProcess.loadLibrary(libraryPath)
+      val batch = veProcess.executeTransfer(libRef, descriptor)
+
+      batch.numRows should be (8)
+      batch.columns.size should be (2)
+
+      val col1 = batch.columns(0)
+      val col2 = batch.columns(1)
+
+      col1.numItems should be (8)
+      col2.numItems should be (8)
+
+      val col1_merged = Array[Double](1,2,3,4,5,6,7,8).toBytePointerColVector("expected_col1").toBytes
+      val col2_merged = Array[String]("a", "b", "c", "d", "e", "f", "g", "h").toBytePointerColVector("expected_col2").toBytes
+
+
+      col1.toBytePointerColVector.toBytes should be(col1_merged)
+      col2.toBytePointerColVector.toBytes should be(col2_merged)
+    }
+  }
+}


### PR DESCRIPTION
There are two bugs fixed here:
* Alignment related garbage copying when data was coming from the JVM
* Unexpected behavior when collecting a partition iterator into a list instead of working directly off the iterator and collecting the results afterwards. 

As part of the debugging process additional tests for transfers from the JVM were added. This has highlighted a difference in default values for unused validity buffer bits. For this reason the usage of "append_bitsets" has been disabled until it is adapted for the same defaults.