### PR TITLE
[NS-41][metrics] Add metrics to the new `VeProcess` and `VectorEngine` implementations

### DIFF
--- a/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
+++ b/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
@@ -2,6 +2,7 @@ package com.nec.vectorengine
 
 import com.nec.colvector.{VeColVectorSource => VeSource}
 import java.nio.file.Path
+import com.codahale.metrics.MetricRegistry
 import com.typesafe.scalalogging.LazyLogging
 import org.bytedeco.javacpp.{BytePointer, LongPointer, Pointer}
 import org.bytedeco.veoffload.veo_proc_handle
@@ -19,6 +20,10 @@ final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess w
 
   def node: Int = {
     underlying.node
+  }
+
+  def metrics: MetricRegistry = {
+    underlying.metrics
   }
 
   def source: VeSource = {

--- a/src/main/scala/com/nec/vectorengine/VectorEngineImpl.scala
+++ b/src/main/scala/com/nec/vectorengine/VectorEngineImpl.scala
@@ -4,19 +4,19 @@ import com.nec.colvector._
 import com.nec.spark.agile.core.{CScalarVector, CVarChar, CVector, VeString}
 import com.nec.util.CallContext
 import scala.reflect.ClassTag
+import scala.util.Try
+import java.time.Duration
+import com.codahale.metrics._
 import com.typesafe.scalalogging.LazyLogging
 import org.bytedeco.javacpp.{BytePointer, IntPointer, LongPointer, PointerScope}
 
 class VectorEngineImpl(val process: VeProcess,
-                       metrics: VectorEngineMetrics)
+                       val metrics: MetricRegistry)
                        extends VectorEngine with LazyLogging {
   require(process.isOpen, s"VE process is closed: ${process.source}")
 
   // Declare implicit for use with VeAsyncResult contexts
   private implicit val p = process
-
-  private[vectorengine] var calls = 0
-  private[vectorengine] var veSeconds = 0.0
 
   def validateVectors(inputs: Seq[VeColVector]): Unit = {
     inputs.foreach { vector =>
@@ -57,11 +57,9 @@ class VectorEngineImpl(val process: VeProcess,
     // Load call args stack
     val argstack = process.newArgsStack(args)
 
-    // Execute the function and measure the duration
+    // Execute the function
     logger.debug(s"Calling ${fnName}")
-    val (outp, duration) = metrics.measureTime(_ => ()) {
-      process.call(func, argstack)
-    }
+    val outp = process.call(func, argstack)
 
     // Free the call args stack
     process.freeArgsStack(argstack)
@@ -69,14 +67,29 @@ class VectorEngineImpl(val process: VeProcess,
     // All Cyclone C++ functions should return 0L on successful completion
     require(outp.get == 0L, s"Expected 0 from function execution, got ${outp.get} instead.")
     outp.close
+  }
 
-    // Update counters
-    veSeconds += duration.toNanos / 1e9
-    calls += 1
+  private[vectorengine] def measureTime[T](fnName: String)(thunk: => T): T = {
+    val start = System.nanoTime
+    // Perform the execution
+    val result = thunk
+    val duration = System.nanoTime - start
 
-    logger.debug(
-      s"Finished call to '${func.name}': ${calls} VeSeconds: (${veSeconds} s)"
-    )
+    // Add metric to timer
+    val tname = s"${VectorEngine.ExecCallDurationsMetric}.${fnName}"
+    val timer = Option(metrics.getTimers.get(tname)) match {
+      case Some(timer) =>
+        timer
+
+      case None =>
+        val timer = new Timer
+        Try { metrics.register(tname, timer) }
+        timer
+    }
+    timer.update(Duration.ofNanos(duration))
+
+    // Return result
+    result
   }
 
   def execute(lib: LibraryReference,
@@ -84,22 +97,24 @@ class VectorEngineImpl(val process: VeProcess,
               inputs: Seq[VeColVector],
               outputs: Seq[CVector])
              (implicit context: CallContext): Seq[VeColVector] = {
-    // Validate columns
-    validateVectors(inputs)
+    measureTime(fnName) {
+      // Validate columns
+      validateVectors(inputs)
 
-    // Set up the input buffer args
-    val inbuffers = inputs.map { vec =>
-      BuffArg(VeArgIntent.In, new LongPointer(1).put(vec.container))
+      // Set up the input buffer args
+      val inbuffers = inputs.map { vec =>
+        BuffArg(VeArgIntent.In, new LongPointer(1).put(vec.container))
+      }
+
+      // Set up the output buffer args
+      val outptrs = outputs.map { _ => new LongPointer(1).put(-118) }
+
+      // Execute the function
+      execFn(lib, fnName, inbuffers ++ outptrs.map(BuffArg(VeArgIntent.Out, _)))
+
+      // Read the VeColVector structs back
+      readVectors(outptrs.map(_.get).zip(outputs))
     }
-
-    // Set up the output buffer args
-    val outptrs = outputs.map { _ => new LongPointer(1).put(-118) }
-
-    // Execute the function
-    execFn(lib, fnName, inbuffers ++ outptrs.map(BuffArg(VeArgIntent.Out, _)))
-
-    // Read the VeColVector structs back
-    readVectors(outptrs.map(_.get).zip(outputs))
   }
 
   def executeMulti(lib: LibraryReference,
@@ -107,39 +122,39 @@ class VectorEngineImpl(val process: VeProcess,
                    inputs: Seq[VeColVector],
                    outputs: Seq[CVector])
                   (implicit context: CallContext): Seq[(Int, Seq[VeColVector])] = {
-    val MaxSetsCount = 64
+    measureTime(fnName) {
+      // Validate columns
+      validateVectors(inputs)
 
-    // Validate columns
-    validateVectors(inputs)
+      // Set up the input buffer args
+      val inbuffers = inputs.map { vec =>
+        BuffArg(VeArgIntent.In, new LongPointer(1).put(vec.container))
+      }
 
-    // Set up the input buffer args
-    val inbuffers = inputs.map { vec =>
-      BuffArg(VeArgIntent.In, new LongPointer(1).put(vec.container))
+      // Set up the output count arg
+      val countsp = new IntPointer(1L).put(-919)
+
+      // Set up the output buffer args
+      val outptrs = outputs.map { _ => new LongPointer(VectorEngine.MaxSetsCount).put(-99) }
+
+      // Execute the function
+      execFn(lib, fnName, inbuffers ++ Seq(BuffArg(VeArgIntent.Out, countsp)) ++ outptrs.map(BuffArg(VeArgIntent.Out, _)))
+
+      // Ensure that counts is properly set by the function
+      val counts = countsp.get
+      require(
+        counts >= 0 && counts <= VectorEngine.MaxSetsCount,
+        s"Expected 0 to ${VectorEngine.MaxSetsCount} counts; got ${counts} instead. Input args are ${inputs}, outputs are ${outputs}"
+      )
+
+      (0 until counts)
+        // Read the Nth pointer of each outptrs, and fetch them all to VeColVectors
+        .map { set => readVectorsAsync(outptrs.map(_.get(set)).zip(outputs)) }
+        // Await each batch fetch
+        .map(_.map(_.get))
+        // Return with batch indices
+        .zipWithIndex.map(_.swap).toSeq
     }
-
-    // Set up the output count arg
-    val countsp = new IntPointer(1L).put(-919)
-
-    // Set up the output buffer args
-    val outptrs = outputs.map { _ => new LongPointer(MaxSetsCount).put(-99) }
-
-    // Execute the function
-    execFn(lib, fnName, inbuffers ++ Seq(BuffArg(VeArgIntent.Out, countsp)) ++ outptrs.map(BuffArg(VeArgIntent.Out, _)))
-
-    // Ensure that counts is properly set by the function
-    val counts = countsp.get
-    require(
-      counts >= 0 && counts <= MaxSetsCount,
-      s"Expected 0 to ${MaxSetsCount} counts; got ${counts} instead. Input args are ${inputs}, outputs are ${outputs}"
-    )
-
-    (0 until counts)
-      // Read the Nth pointer of each outptrs, and fetch them all to VeColVectors
-      .map { set => readVectorsAsync(outptrs.map(_.get(set)).zip(outputs)) }
-      // Await each batch fetch
-      .map(_.map(_.get))
-      // Return with batch indices
-      .zipWithIndex.map(_.swap).toSeq
   }
 
   def executeMultiIn(lib: LibraryReference,
@@ -147,35 +162,37 @@ class VectorEngineImpl(val process: VeProcess,
                      inputs: VeBatchOfBatches,
                      outputs: Seq[CVector])
                     (implicit context: CallContext): Seq[VeColVector] = {
-    // Validate columns
-    inputs.batches.foreach(batch => validateVectors(batch.columns))
+    measureTime(fnName) {
+      // Validate columns
+      inputs.batches.foreach(batch => validateVectors(batch.columns))
 
-    // Set up the input count args
-    val countargs = Seq(
-      // Total batches count for input pointers
-      I32Arg(inputs.batches.size),
-      // Output count of rows - better to know this in advance
-      I32Arg(inputs.numRows)
-    )
+      // Set up the input count args
+      val countargs = Seq(
+        // Total batches count for input pointers
+        I32Arg(inputs.batches.size),
+        // Output count of rows - better to know this in advance
+        I32Arg(inputs.numRows)
+      )
 
-    // Set up the input buffer args
-    val inbuffers = inputs.groupedColumns.map { group =>
-      // For each group, create an array of pointers
-      val array = group.columns.zipWithIndex
-        .foldLeft(new LongPointer(group.columns.size.toLong)) { case (accum, (col, i)) =>
-          accum.put(i.toLong, col.container)
-        }
-      BuffArg(VeArgIntent.In, array)
+      // Set up the input buffer args
+      val inbuffers = inputs.groupedColumns.map { group =>
+        // For each group, create an array of pointers
+        val array = group.columns.zipWithIndex
+          .foldLeft(new LongPointer(group.columns.size.toLong)) { case (accum, (col, i)) =>
+            accum.put(i.toLong, col.container)
+          }
+        BuffArg(VeArgIntent.In, array)
+      }
+
+      // Set up the output buffer args
+      val outptrs = outputs.map { _ => new LongPointer(1).put(-118) }
+
+      // Execute the function
+      execFn(lib, fnName, countargs ++ inbuffers ++ outptrs.map(BuffArg(VeArgIntent.Out, _)))
+
+      // Read the VeColVector structs back
+      readVectors(outptrs.map(_.get).zip(outputs))
     }
-
-    // Set up the output buffer args
-    val outptrs = outputs.map { _ => new LongPointer(1).put(-118) }
-
-    // Execute the function
-    execFn(lib, fnName, countargs ++ inbuffers ++ outptrs.map(BuffArg(VeArgIntent.Out, _)))
-
-    // Read the VeColVector structs back
-    readVectors(outptrs.map(_.get).zip(outputs))
   }
 
   def executeJoin(lib: LibraryReference,
@@ -184,48 +201,50 @@ class VectorEngineImpl(val process: VeProcess,
                   right: VeBatchOfBatches,
                   outputs: Seq[CVector])
                  (implicit context: CallContext): Seq[VeColVector] = {
-    // Validate columns
-    left.batches.foreach(batch => validateVectors(batch.columns))
-    right.batches.foreach(batch => validateVectors(batch.columns))
+    measureTime(fnName) {
+      // Validate columns
+      left.batches.foreach(batch => validateVectors(batch.columns))
+      right.batches.foreach(batch => validateVectors(batch.columns))
 
-    // Set up the input count args
-    val countargs = Seq(
-      // Total batches count for the left & right input pointers
-      U64Arg(left.batches.size),
-      U64Arg(right.batches.size),
-      // Input count of rows - better to know this in advance
-      U64Arg(left.numRows),
-      U64Arg(right.numRows)
-    )
+      // Set up the input count args
+      val countargs = Seq(
+        // Total batches count for the left & right input pointers
+        U64Arg(left.batches.size),
+        U64Arg(right.batches.size),
+        // Input count of rows - better to know this in advance
+        U64Arg(left.numRows),
+        U64Arg(right.numRows)
+      )
 
-    // Set up the left buffer args
-    val leftbuffers = left.groupedColumns.map { group =>
-      // For each group, create an array of pointers
-      val array = group.columns.zipWithIndex
-        .foldLeft(new LongPointer(group.columns.size.toLong)) { case (accum, (col, i)) =>
-          accum.put(i.toLong, col.container)
-        }
-      BuffArg(VeArgIntent.In, array)
+      // Set up the left buffer args
+      val leftbuffers = left.groupedColumns.map { group =>
+        // For each group, create an array of pointers
+        val array = group.columns.zipWithIndex
+          .foldLeft(new LongPointer(group.columns.size.toLong)) { case (accum, (col, i)) =>
+            accum.put(i.toLong, col.container)
+          }
+        BuffArg(VeArgIntent.In, array)
+      }
+
+      // Set up the right buffer args
+      val rightbuffers = right.groupedColumns.map { group =>
+        // For each group, create an array of pointers
+        val array = group.columns.zipWithIndex
+          .foldLeft(new LongPointer(group.columns.size.toLong)) { case (accum, (col, i)) =>
+            accum.put(i.toLong, col.container)
+          }
+        BuffArg(VeArgIntent.In, array)
+      }
+
+      // Set up the output buffer args
+      val outptrs = outputs.map { _ => new LongPointer(1).put(-118) }
+
+      // Execute the function
+      execFn(lib, fnName, countargs ++ leftbuffers ++ rightbuffers ++ outptrs.map(BuffArg(VeArgIntent.Out, _)))
+
+      // Read the VeColVector structs back
+      readVectors(outptrs.map(_.get).zip(outputs))
     }
-
-    // Set up the right buffer args
-    val rightbuffers = right.groupedColumns.map { group =>
-      // For each group, create an array of pointers
-      val array = group.columns.zipWithIndex
-        .foldLeft(new LongPointer(group.columns.size.toLong)) { case (accum, (col, i)) =>
-          accum.put(i.toLong, col.container)
-        }
-      BuffArg(VeArgIntent.In, array)
-    }
-
-    // Set up the output buffer args
-    val outptrs = outputs.map { _ => new LongPointer(1).put(-118) }
-
-    // Execute the function
-    execFn(lib, fnName, countargs ++ leftbuffers ++ rightbuffers ++ outptrs.map(BuffArg(VeArgIntent.Out, _)))
-
-    // Read the VeColVector structs back
-    readVectors(outptrs.map(_.get).zip(outputs))
   }
 
   def executeGrouping[K: ClassTag](lib: LibraryReference,
@@ -233,72 +252,74 @@ class VectorEngineImpl(val process: VeProcess,
                                    inputs: VeBatchOfBatches,
                                    outputs: Seq[CVector])
                                   (implicit context: CallContext): Seq[(K, Seq[VeColVector])] = {
-    // Validate columns
-    inputs.batches.foreach(batch => validateVectors(batch.columns))
+    measureTime(fnName) {
+      // Validate columns
+      inputs.batches.foreach(batch => validateVectors(batch.columns))
 
-    // Set up the input count args
-    val countargs = Seq(
-      // Total batches count for input pointers
-      U64Arg(inputs.batches.size)
-    )
+      // Set up the input count args
+      val countargs = Seq(
+        // Total batches count for input pointers
+        U64Arg(inputs.batches.size)
+      )
 
-    // Set up the groups output arg
-    val groupsp = new LongPointer(1L).put(-919)
+      // Set up the groups output arg
+      val groupsp = new LongPointer(1L).put(-919)
 
-    // Set up the input buffer args
-    val inbuffers = inputs.groupedColumns.map { group =>
-      // For each group, create an array of pointers
-      val array = group.columns.zipWithIndex
-        .foldLeft(new LongPointer(group.columns.size.toLong)) { case (accum, (col, i)) =>
-          accum.put(i.toLong, col.container)
+      // Set up the input buffer args
+      val inbuffers = inputs.groupedColumns.map { group =>
+        // For each group, create an array of pointers
+        val array = group.columns.zipWithIndex
+          .foldLeft(new LongPointer(group.columns.size.toLong)) { case (accum, (col, i)) =>
+            accum.put(i.toLong, col.container)
+          }
+        BuffArg(VeArgIntent.In, array)
+      }
+
+      // Set up the output buffer args
+      val outptrs = outputs.map { _ => new LongPointer(1).put(-118) }
+
+      // Execute the function
+      execFn(lib, fnName, countargs ++ Seq(BuffArg(VeArgIntent.Out, groupsp)) ++ inbuffers ++ outptrs.map(BuffArg(VeArgIntent.Out, _)))
+
+      // Ensure that groups output pointer is properly set by the function
+      require(groupsp.get >= 0, s"Groups address is invalid: ${groupsp.get}")
+
+      // Fetch the groups
+      val groups = VeColBatch(readVectors(Seq((groupsp.get, outputs.head))))
+      val ngroups = groups.numRows
+
+      // Fetch the group keys
+      val groupKeys = groups.toArray2[K](0)
+
+      // Declare pointer scope
+      val scope = new PointerScope
+
+      // Each of the output buffers is an array of pointers to nullable_t_vector's
+      // so we dereference them first
+      val actualOutPointers = outptrs.map(_.get)
+        .map { source =>
+          val buffer = new LongPointer(ngroups.toLong)
+          (buffer, process.getAsync(buffer, source))
         }
-      BuffArg(VeArgIntent.In, array)
+        .map { case (buffer, handle) =>
+          process.awaitResult(handle)
+          buffer
+        }
+
+      val results = (0 until ngroups)
+        // Read the Nth pointer of each actualOutPointers, and fetch them all to VeColVectors
+        .map { set => readVectorsAsync(actualOutPointers.map(_.get(set)).zip(outputs)) }
+        // Await each batch fetch
+        .map(_.map(_.get))
+        // Return with batch indices
+        .zip(groupKeys).map(_.swap).toSeq
+
+      // Free the referenced nullable_t_vector's created from the function call
+      outptrs.foreach(p => process.free(p.get, unsafe = true))
+
+      // Close scope and return results
+      scope.close
+      results
     }
-
-    // Set up the output buffer args
-    val outptrs = outputs.map { _ => new LongPointer(1).put(-118) }
-
-    // Execute the function
-    execFn(lib, fnName, countargs ++ Seq(BuffArg(VeArgIntent.Out, groupsp)) ++ inbuffers ++ outptrs.map(BuffArg(VeArgIntent.Out, _)))
-
-    // Ensure that groups output pointer is properly set by the function
-    require(groupsp.get >= 0, s"Groups address is invalid: ${groupsp.get}")
-
-    // Fetch the groups
-    val groups = VeColBatch(readVectors(Seq((groupsp.get, outputs.head))))
-    val ngroups = groups.numRows
-
-    // Fetch the group keys
-    val groupKeys = groups.toArray2[K](0)
-
-    // Declare pointer scope
-    val scope = new PointerScope
-
-    // Each of the output buffers is an array of pointers to nullable_t_vector's
-    // so we dereference them first
-    val actualOutPointers = outptrs.map(_.get)
-      .map { source =>
-        val buffer = new LongPointer(ngroups.toLong)
-        (buffer, process.getAsync(buffer, source))
-      }
-      .map { case (buffer, handle) =>
-        process.awaitResult(handle)
-        buffer
-      }
-
-    val results = (0 until ngroups)
-      // Read the Nth pointer of each actualOutPointers, and fetch them all to VeColVectors
-      .map { set => readVectorsAsync(actualOutPointers.map(_.get(set)).zip(outputs)) }
-      // Await each batch fetch
-      .map(_.map(_.get))
-      // Return with batch indices
-      .zip(groupKeys).map(_.swap).toSeq
-
-    // Free the referenced nullable_t_vector's created from the function call
-    outptrs.foreach(p => process.free(p.get, unsafe = true))
-
-    // Close scope and return results
-    scope.close
-    results
   }
 }

--- a/src/main/scala/com/nec/vectorengine/VectorEngineTraits.scala
+++ b/src/main/scala/com/nec/vectorengine/VectorEngineTraits.scala
@@ -5,24 +5,13 @@ import com.nec.spark.agile.core.CVector
 import com.nec.util.CallContext
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
-
-/*
-  NOTE: This is s work in progress
-*/
-trait VectorEngineMetrics {
-  def measureTime[T](collect: FiniteDuration => Unit)(thunk: => T): (T, FiniteDuration) = {
-    val start = System.nanoTime
-    val result = thunk
-    val duration = (System.nanoTime - start).nanoseconds
-
-    collect(duration)
-    (result, duration)
-  }
-}
+import com.codahale.metrics.MetricRegistry
 
 trait VectorEngine {
   /** The VE process handle that the VectorEngine has access to */
   def process: VeProcess
+
+  def metrics: MetricRegistry
 
   /** Return a single dataset - e.g. for maps and filters */
   def execute(lib: LibraryReference,
@@ -58,4 +47,9 @@ trait VectorEngine {
                                    inputs: VeBatchOfBatches,
                                    outputs: Seq[CVector])
                                   (implicit context: CallContext): Seq[(K, Seq[VeColVector])]
+}
+
+object VectorEngine {
+  final val ExecCallDurationsMetric = "ve.durations.exec"
+  final val MaxSetsCount = 64
 }

--- a/src/test/scala/com/nec/colvector/InputSamples.scala
+++ b/src/test/scala/com/nec/colvector/InputSamples.scala
@@ -10,7 +10,7 @@ object InputSamples {
   }
 
   def seqOpt[T: ClassTag]: Seq[Option[T]] = {
-    seqOpt[T](Random.nextInt(100))
+    seqOpt[T](Random.nextInt(100) + 1)
   }
 
   def array[T: ClassTag](size: Int): Array[T] = {
@@ -18,7 +18,7 @@ object InputSamples {
   }
 
   def array[T: ClassTag]: Array[T] = {
-    seq[T](Random.nextInt(100)).toArray
+    seq[T](Random.nextInt(100) + 1).toArray
   }
 
   def seq[T: ClassTag](size: Int): Seq[T] = {

--- a/src/test/scala/com/nec/vectorengine/WithVeProcess.scala
+++ b/src/test/scala/com/nec/vectorengine/WithVeProcess.scala
@@ -2,10 +2,14 @@ package com.nec.vectorengine
 
 import com.nec.ve.VeProcessMetrics
 import com.nec.colvector.{VeColVectorSource => VeSource}
+import com.codahale.metrics._
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
 trait WithVeProcess extends BeforeAndAfterAll { self: Suite =>
-  implicit val metrics = VeProcessMetrics.noOp
+  // TODO: Remove
+  implicit val metrics0 = VeProcessMetrics.noOp
+
+  implicit val metrics = new MetricRegistry
 
   /*
     Initialization is explicitly deferred to avoid creation of VeProcess when
@@ -13,7 +17,7 @@ trait WithVeProcess extends BeforeAndAfterAll { self: Suite =>
     classes is eager even if annotated with @VectorEngineTest
   */
   implicit val process: VeProcess = DeferredVeProcess { () =>
-    VeProcess.create(getClass.getName)
+    VeProcess.create(getClass.getName, metrics)
   }
 
   implicit def source: VeSource = {
@@ -24,7 +28,7 @@ trait WithVeProcess extends BeforeAndAfterAll { self: Suite =>
 
   override def beforeAll: Unit = {
     super.beforeAll
-    engine = new VectorEngineImpl(process, new VectorEngineMetrics {})
+    engine = new VectorEngineImpl(process, metrics)
   }
 
   override def afterAll: Unit = {

--- a/src/test/scala/com/nec/vectorengine/WithVeProcess.scala
+++ b/src/test/scala/com/nec/vectorengine/WithVeProcess.scala
@@ -2,10 +2,15 @@ package com.nec.vectorengine
 
 import com.nec.ve.VeProcessMetrics
 import com.nec.colvector.{VeColVectorSource => VeSource}
+import java.nio.file.{Path, Paths}
 import com.codahale.metrics._
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
 trait WithVeProcess extends BeforeAndAfterAll { self: Suite =>
+  final val LibCyclonePath: Path = {
+    Paths.get("target/scala-2.12/classes/cycloneve/libcyclone.so")
+  }
+
   // TODO: Remove
   implicit val metrics0 = VeProcessMetrics.noOp
 


### PR DESCRIPTION
Summary:

- Hook up metrics for memory allocations, de-allocations, and sync calls to `MetricRegistry`
- Add both gauge and timer metrics for better observability
- Add unit tests for the integration of metrics to the new `VeProcess` and `VectorEngine` implementations
- Add support for loading `libcyclone.so` using `WithVeProcess`