### PR TITLE
Re-enable append_bitsets

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
@@ -214,7 +214,7 @@ namespace cyclone {
     auto additional_elements_to_fit = space_in_tail > second_bit_count ? 0 : second_bit_count - space_in_tail;
 
     // How many additional containers are necessary to fit the spill-over
-    auto additional_container_count = additional_elements_to_fit / bits_per_T;
+    auto additional_container_count = frovedis::ceil_div(additional_elements_to_fit, bits_per_T);
 
     // How many steps *can* be done using the current T size?
     auto big_step_count = second_bit_count / bits_per_T;
@@ -254,7 +254,7 @@ namespace cyclone {
     // T steps
 #pragma _NEC vector
 #pragma _NEC ivdep
-    for (auto i = 0; i < additional_container_count; i++) {
+    for (size_t i = 0; i < additional_container_count; i++) {
       // Set the dangling bits of all follow up Ts
       first_tail[i + 1] = second[i] >> space_in_tail;
       //std::cout << "[append_bitsets] "<< std::bitset<sizeof(T)*CHAR_BIT>(first_tail[i + 1]) << " = " << std::bitset<sizeof(T)*CHAR_BIT>(second[i]) << " >> " << space_in_tail << std::endl;
@@ -263,7 +263,7 @@ namespace cyclone {
     //std::cout << "[append_bitsets] setting values " << std::endl;
 #pragma _NEC vector
 #pragma _NEC ivdep
-    for (auto i = 0; i < big_step_count; i++) {
+    for (size_t i = 0; i < big_step_count; i++) {
       // Fill the free space in the tail of all Ts
       //std::cout << "[append_bitsets] "<< std::bitset<sizeof(T)*CHAR_BIT>(first_tail[i]) << " |= " << std::bitset<sizeof(T)*CHAR_BIT>(second[i]) << " << " << dangling_bits;
       first_tail[i] |= second[i] << dangling_bits;

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
@@ -242,8 +242,8 @@ namespace cyclone {
 
     // Ensure space_in_tail is actually all empty and not some random crap
     // Building mask in a single step results in a signed shift, which we don't want
-    T mask = 0;
-    mask = (~mask) >> space_in_tail;
+    T mask = ~0;
+    mask = mask >> space_in_tail;
 
     //std::cout << "[append_bitsets] first_tail[0] = "<< std::bitset<sizeof(T)*CHAR_BIT>(first_tail[0]) << std::endl;
     //std::cout << "[append_bitsets] mask = "<< std::bitset<sizeof(T)*CHAR_BIT>(mask) << std::endl;

--- a/src/main/resources/com/nec/cyclone/cpp/tests/cyclone_utils_spec.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/cyclone_utils_spec.cc
@@ -271,54 +271,108 @@ namespace cyclone::tests {
   }
 
   TEST_CASE("Merging into tail works after several big steps landing on full byte") {
-    uint64_t a[3] = {64, 128, 255};
-    uint64_t b[3] = {32, 32 + 64, 128};
+    uint64_t a[3] = {
+      0b0000000000000000000000000000000000000000000000000000000001000000,
+      0b0000000000000000000000000000000000000000000000000000000010000000,
+      0b0000000000000000000000000000000000000000000000000000000011111111
+//              ^ valid until here
+    };
+
+    uint64_t b[3] = {
+        0b1110000000000000000000000000000000000000000000000000000001100001,
+        0b0000000000000000000000000000000000000000000000000000000011100001,
+        0b0000000000000000000000000000000000000000000000000000000000111101
+//                                                                  ^ valid until here
+    };
+
+    uint64_t expected[5] = {
+        0b0000000000000000000000000000000000000000000000000000000001000000,
+        0b0000000000000000000000000000000000000000000000000000000010000000,
+        0b1000010000000000000000000000000000000000000000000000000011111111,
+//    from b[0] ^ from a[3]
+        0b1000011110000000000000000000000000000000000000000000000000000001,
+//    from b[1] ^ from b[0]
+        0b1111010000000000000000000000000000000000000000000000000000000011
+//    from b[2] ^ from b[1]
+  };
 
     uint64_t* output = static_cast<uint64_t *>(malloc(5 * sizeof(uint64_t)));
 
     auto dangling = cyclone::append_bitsets(output, 0, a, 2 * 64 + 58);
     auto final_dangling = cyclone::append_bitsets(&output[2], dangling, b, 134);
 
-    std::cout << "output[0]  = " << std::bitset<64>(output[0]) << std::endl;
-    std::cout << "expected_0 = " << std::bitset<64>(a[0]) << std::endl;
-    std::cout << "output[1]  = " << std::bitset<64>(output[1]) << std::endl;
-    std::cout << "expected_1 = " << std::bitset<64>(a[1]) << std::endl;
-    std::cout << "output[2]  = " << std::bitset<64>(output[2]) << std::endl;
-    std::cout << "output[3]  = " << std::bitset<64>(output[3]) << std::endl;
-    std::cout << "output[4]  = " << std::bitset<64>(output[4]) << std::endl;
+    //std::cout << "output[0]  = " << std::bitset<64>(output[0]) << std::endl;
+    //std::cout << "expected_0 = " << std::bitset<64>(expected[0]) << std::endl;
+    //std::cout << "output[1]  = " << std::bitset<64>(output[1]) << std::endl;
+    //std::cout << "expected_1 = " << std::bitset<64>(expected[1]) << std::endl;
+    //std::cout << "output[2]  = " << std::bitset<64>(output[2]) << std::endl;
+    //std::cout << "expected_2 = " << std::bitset<64>(expected[2]) << std::endl;
+    //std::cout << "output[3]  = " << std::bitset<64>(output[3]) << std::endl;
+    //std::cout << "expected_3 = " << std::bitset<64>(expected[3]) << std::endl;
+    //std::cout << "output[4]  = " << std::bitset<64>(output[4]) << std::endl;
+    //std::cout << "expected_4 = " << std::bitset<64>(expected[4]) << std::endl;
 
     CHECK(dangling == 58);
     CHECK(final_dangling == 0);
-    CHECK(output[0] == a[0]);
-    CHECK(output[1] == a[1]);
+    CHECK(output[0] == expected[0]);
+    CHECK(output[1] == expected[1]);
+    CHECK(output[2] == expected[2]);
+    CHECK(output[3] == expected[3]);
+    CHECK(output[4] == expected[4]);
     free(output);
 
     // TODO: Add actual checks on the last elements
   }
 
   TEST_CASE("Merging into tail works after several big steps landing on non-full byte") {
-    uint64_t a[3] = {64, 128, 255};
-    uint64_t b[3] = {32, 32 + 64, 128};
+    uint64_t a[3] = {
+        0b0000000000000000000000000000000000000000000000000000000001000000,
+        0b0000000000000000000000000000000000000000000000000000000010000000,
+        0b0000000000000000000000000000000000000000000000000000000011111111
+//              ^ valid until here
+    };
+    uint64_t b[3] = {
+        0b1110000000000000000000000000000000000000000000000000000001100001,
+        0b0000000000000000000000000000000000000000000000000000000011100001,
+        0b0000000000000000000000000000000000000000000000000000000000001101
+//                                                                    ^ valid until here
+    };
+
+    uint64_t expected[5] = {
+        0b0000000000000000000000000000000000000000000000000000000001000000,
+        0b0000000000000000000000000000000000000000000000000000000010000000,
+        0b1000010000000000000000000000000000000000000000000000000011111111,
+//    from b[0] ^ from a[3]
+        0b1000011110000000000000000000000000000000000000000000000000000001,
+//    from b[1] ^ from b[0]
+//        vv empty
+        0b0011010000000000000000000000000000000000000000000000000000000011
+//    from b[2] ^ from b[1]
+    };
 
     uint64_t* output = static_cast<uint64_t *>(malloc(5 * sizeof(uint64_t)));
 
     auto dangling = cyclone::append_bitsets(output, 0, a, 2 * 64 + 58);
     auto final_dangling = cyclone::append_bitsets(&output[2], dangling, b, 132);
 
-    std::cout << "output[0]  = " << std::bitset<64>(output[0]) << std::endl;
-    std::cout << "expected_0 = " << std::bitset<64>(a[0]) << std::endl;
-    std::cout << "output[1]  = " << std::bitset<64>(output[1]) << std::endl;
-    std::cout << "expected_1 = " << std::bitset<64>(a[1]) << std::endl;
-    std::cout << "output[2]  = " << std::bitset<64>(output[2]) << std::endl;
-    std::cout << "output[3]  = " << std::bitset<64>(output[3]) << std::endl;
-    std::cout << "output[4]  = " << std::bitset<64>(output[4]) << std::endl;
+    //std::cout << "output[0]  = " << std::bitset<64>(output[0]) << std::endl;
+    //std::cout << "expected_0 = " << std::bitset<64>(expected[0]) << std::endl;
+    //std::cout << "output[1]  = " << std::bitset<64>(output[1]) << std::endl;
+    //std::cout << "expected_1 = " << std::bitset<64>(expected[1]) << std::endl;
+    //std::cout << "output[2]  = " << std::bitset<64>(output[2]) << std::endl;
+    //std::cout << "expected_2 = " << std::bitset<64>(expected[2]) << std::endl;
+    //std::cout << "output[3]  = " << std::bitset<64>(output[3]) << std::endl;
+    //std::cout << "expected_3 = " << std::bitset<64>(expected[3]) << std::endl;
+    //std::cout << "output[4]  = " << std::bitset<64>(output[4]) << std::endl;
+    //std::cout << "expected_4 = " << std::bitset<64>(expected[4]) << std::endl;
 
     CHECK(dangling == 58);
     CHECK(final_dangling == 62);
-    CHECK(output[0] == a[0]);
-    CHECK(output[1] == a[1]);
+    CHECK(output[0] == expected[0]);
+    CHECK(output[1] == expected[1]);
+    CHECK(output[2] == expected[2]);
+    CHECK(output[3] == expected[3]);
+    CHECK(output[4] == expected[4]);
     free(output);
-
-    // TODO: Add actual checks on the last elements
   }
 }

--- a/src/test/scala/com/nec/colvector/ArrayTConversionsUnitSpec.scala
+++ b/src/test/scala/com/nec/colvector/ArrayTConversionsUnitSpec.scala
@@ -3,11 +3,13 @@ package com.nec.colvector
 import com.nec.colvector.ArrayTConversions._
 import com.nec.colvector.SeqOptTConversions._
 import com.nec.spark.agile.core.VeScalarType
-import scala.reflect.ClassTag
-import scala.util.Random
-import java.util.UUID
+import com.nec.util.FixedBitSet
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.util.UUID
+import scala.reflect.ClassTag
+import scala.util.Random
 
 final class ArrayTConversionsUnitSpec extends AnyWordSpec {
   def runConversionTest[T <: AnyVal : ClassTag](input: Array[T]): Unit = {
@@ -28,8 +30,9 @@ final class ArrayTConversionsUnitSpec extends AnyWordSpec {
     // Check validity buffer
     val validityBuffer = colvec.buffers(1)
     validityBuffer.capacity() should be ((input.size / 64.0).ceil.toLong * 8)
-    for (i <- 0 until validityBuffer.capacity().toInt) {
-      validityBuffer.get(i) should be (-1.toByte)
+    val validityBitSet = FixedBitSet.from(validityBuffer)
+    for (i <- input.indices) {
+      validityBitSet.get(i) should be (true)
     }
 
     // Check conversion


### PR DESCRIPTION
The problem in NS-49 was that the packed transfer spec failed because during transfer only the bits for existing elements are considered when merging data into the validity buffer. padding bits are kept at 0. 

However, the default validity buffer created when converting an Array of scalars into a BytePointerColVector would be set to "all valid" even for the padding bits.

This created a discrepancy after a round trip VH->VE->VH.

In this PR I've adapted the conversion code to adopt the "padding bits are 0" default.

Something appears to be still wrong :/ the TPCH tests fail with just slightly wrong results. 