### PR TITLE
[NS-37] Integrate partition level transfer into the new `VectorEngine` implementation

### DIFF
--- a/src/main/scala/com/nec/cache/TransferDescriptor.scala
+++ b/src/main/scala/com/nec/cache/TransferDescriptor.scala
@@ -7,7 +7,7 @@ import org.bytedeco.javacpp.{BytePointer, LongPointer, Pointer}
 import scala.collection.mutable.ListBuffer
 
 case class TransferDescriptor(
-  batches: List[List[BytePointerColVector]]) extends LazyLogging {
+  batches: Seq[Seq[BytePointerColVector]]) extends LazyLogging {
   lazy val isEmpty: Boolean = batches.flatten.isEmpty
   def nonEmpty: Boolean = !isEmpty
 

--- a/src/main/scala/com/nec/cache/TransferDescriptor.scala
+++ b/src/main/scala/com/nec/cache/TransferDescriptor.scala
@@ -69,11 +69,11 @@ case class TransferDescriptor(
       header.put(startPos, columnType)
       header.put(startPos + 1, column.numItems)
       header.put(startPos + 2, buffers(0).limit())
-      if(column.veType.isString){
+      if (column.veType.isString) {
         header.put(startPos + 3, buffers(1).limit())
         header.put(startPos + 4, buffers(2).limit())
         header.put(startPos + 5, buffers(3).limit())
-      }else{
+      } else {
         header.put(startPos + 3, buffers(1).limit())
       }
     }
@@ -159,9 +159,9 @@ case class TransferDescriptor(
 
   private def vectorAlignedSize(size: Long): Long = {
     val dangling = size % 8
-    if(dangling > 0){
+    if (dangling > 0) {
       size + (8 - dangling)
-    }else{
+    } else {
       size
     }
   }

--- a/src/main/scala/com/nec/cache/TransferDescriptor.scala
+++ b/src/main/scala/com/nec/cache/TransferDescriptor.scala
@@ -113,7 +113,7 @@ case class TransferDescriptor(
   def outputBufferToColBatch(): VeColBatch = {
     val od = new LongPointer(outputBuffer)
     val startingPositions = batches.head.map(_.veType.isString).map{
-      case true => 4
+      case true => 5
       case false => 3
     }.foldLeft(ListBuffer(0)){ case (acc, size) =>
       acc += acc.last + size

--- a/src/main/scala/com/nec/colvector/ArrayTConversions.scala
+++ b/src/main/scala/com/nec/colvector/ArrayTConversions.scala
@@ -153,14 +153,12 @@ object ArrayTConversions {
       val dataBuffer = buffers(0)
       val startsBuffer = new IntPointer(buffers(1))
       val lensBuffer = new IntPointer(buffers(2))
-      val validityBuffer = buffers(3)
+      val bitset = FixedBitSet.from(buffers(3))
 
       val output = new Array[String](numItems)
       for (i <- 0 until numItems) {
-        // Get the validity bit at psition i
-        val isValid = (validityBuffer.get(i / 8) & (1 << (i % 8))) > 0
-
-        if (isValid) {
+        // Get the validity bit at position i
+        if (bitset.get(i)) {
           // Read starts and lens as byte offsets (they are stored in BytePointerColVector as int32_t offsets)
           val start = startsBuffer.get(i) * 4
           val len = lensBuffer.get(i) * 4

--- a/src/main/scala/com/nec/colvector/ArrowVectorConversions.scala
+++ b/src/main/scala/com/nec/colvector/ArrowVectorConversions.scala
@@ -1,6 +1,7 @@
 package com.nec.colvector
 
 import com.nec.spark.agile.core._
+import com.nec.util.FixedBitSet
 import com.nec.util.ReflectionOps._
 import com.nec.ve.{VeProcess, VeProcessMetrics}
 import java.nio.charset.StandardCharsets
@@ -103,13 +104,11 @@ object ArrowVectorConversions {
         val dataBuffer = buffers(0)
         val startsBuffer = new IntPointer(buffers(1))
         val lensBuffer = new IntPointer(buffers(2))
-        val validityBuffer = buffers(3)
+        val bitset = FixedBitSet.from(buffers(3))
 
         for (i <- 0 until numItems) {
-          // Get the validity bit at psition i
-          val isValid = (validityBuffer.get(i / 8) & (1 << (i % 8))) > 0
-
-          if (isValid) {
+          // Get the validity bit at position i
+          if (bitset.get(i)) {
             // Read starts and lens as byte offsets (they are stored in BytePointerColVector as int32_t offsets)
             val start = startsBuffer.get(i.toLong) * 4
             val len = lensBuffer.get(i.toLong) * 4

--- a/src/main/scala/com/nec/colvector/SeqOptTConversions.scala
+++ b/src/main/scala/com/nec/colvector/SeqOptTConversions.scala
@@ -118,14 +118,12 @@ object SeqOptTConversions {
       val dataBuffer = buffers(0)
       val startsBuffer = new IntPointer(buffers(1))
       val lensBuffer = new IntPointer(buffers(2))
-      val validityBuffer = buffers(3)
+      val bitset = FixedBitSet.from(buffers(3))
 
       val output = MSeq.fill[Option[String]](numItems)(None)
       for (i <- 0 until numItems) {
-        // Get the validity bit at psition i
-        val isValid = (validityBuffer.get(i / 8) & (1 << (i % 8))) > 0
-
-        if (isValid) {
+        // Get the validity bit at position i
+        if (bitset.get(i)) {
           // Read starts and lens as byte offsets (they are stored in BytePointerColVector as int32_t offsets)
           val start = startsBuffer.get(i) * 4
           val len = lensBuffer.get(i) * 4

--- a/src/main/scala/com/nec/colvector/VeColBatch.scala
+++ b/src/main/scala/com/nec/colvector/VeColBatch.scala
@@ -130,6 +130,10 @@ final case class VeColBatch(columns: Seq[VeColVector]) {
     columns.foreach(_.free)
   }
 
+  def free2(implicit process: NewVeProcess): Unit = {
+    columns.foreach(_.free2)
+  }
+
   def toArrowColumnarBatch(implicit allocator: BufferAllocator,
                            process: VeProcess): ColumnarBatch = {
     val vecs = columns.map(_.toBytePointerColVector.toArrowVector)

--- a/src/main/scala/com/nec/spark/agile/CppResource.scala
+++ b/src/main/scala/com/nec/spark/agile/CppResource.scala
@@ -21,7 +21,6 @@ package com.nec.spark.agile
 
 import org.apache.commons.io.{FileUtils, IOUtils}
 import org.apache.hadoop.yarn.exceptions.ResourceNotFoundException
-
 import java.net.URL
 import java.nio.file.{Files, Path}
 

--- a/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
+++ b/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
@@ -58,6 +58,14 @@ final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess w
     underlying.allocate(size)
   }
 
+  def registerAllocation(address: Long, size: Long): VeAllocation = {
+    underlying.registerAllocation(address, size)
+  }
+
+  def unregisterAllocation(address: Long): Unit = {
+    underlying.unregisterAllocation(address)
+  }
+
   def free(address: Long, unsafe: Boolean): Unit = {
     // If the VeProcess is not even instantiated yet, skip
     if (instantiated) {

--- a/src/main/scala/com/nec/vectorengine/LibCyclone.scala
+++ b/src/main/scala/com/nec/vectorengine/LibCyclone.scala
@@ -1,0 +1,13 @@
+package com.nec.vectorengine
+
+import java.nio.file.{Path, Paths}
+
+object LibCyclone {
+  final val CppTargetPath = "/cycloneve"
+
+  lazy val SoPath: Path = {
+    Paths.get(getClass.getResource(s"${CppTargetPath}/libcyclone.so").toURI)
+  }
+
+  final val HandleTransferFn = "handle_transfer"
+}

--- a/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
+++ b/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
@@ -39,16 +39,22 @@ final case class WrappingVeo private (val node: Int,
   private val syncFnCallTimer = new Timer
   private val allocTimer = new Timer
   private val freeTimer = new Timer
+  private val allocSizesHistogram = new Histogram(new UniformReservoir)
+  private val putSizesHistogram = new Histogram(new UniformReservoir)
+  private val putThroughputsHistogram = new Histogram(new UniformReservoir)
 
   // Register the metrics with the MetricRegistry
-  metrics.register(VeProcess.VeAllocDurationsMetric, allocTimer)
-  metrics.register(VeProcess.VeFreeDurationsMetric, freeTimer)
-  metrics.register(VeProcess.VeSyncFnCallDurationsMetric, syncFnCallTimer)
-  metrics.register(VeProcess.NumAllocationsMetric, new Gauge[Long] {
+  metrics.register(VeProcess.VeAllocTimerMetric,            allocTimer)
+  metrics.register(VeProcess.VeFreeTimerMetric,             freeTimer)
+  metrics.register(VeProcess.VeSyncFnCallTimerMetric,       syncFnCallTimer)
+  metrics.register(VeProcess.AllocSizesHistogramMetric,     allocSizesHistogram)
+  metrics.register(VeProcess.PutSizesHistogramMetric,       putSizesHistogram)
+  metrics.register(VeProcess.PutThroughputHistogramMetric,  putThroughputsHistogram)
+  metrics.register(VeProcess.NumTrackedAllocationsMetric, new Gauge[Long] {
       def getValue: Long = heapRecords.size
     }
   )
-  metrics.register(VeProcess.BytesAllocatedMetric, new Gauge[Long] {
+  metrics.register(VeProcess.TrackBytesAllocatedMetric, new Gauge[Long] {
       def getValue: Long = heapRecords.valuesIterator.foldLeft(0L)(_ + _.size)
     }
   )
@@ -138,13 +144,51 @@ final case class WrappingVeo private (val node: Int,
       logger.trace(s"Allocated ${size} bytes ==> ${ptr}")
       ptr.close
 
-      // Record metric
+      // Record metrics
       allocTimer.update(Duration.ofNanos(duration))
+      allocSizesHistogram.update(size)
 
       // Create an allocation record to track the allocation
       val allocation = VeAllocation(address, size, new Exception().getStackTrace)
       heapRecords.put(address, allocation)
       allocation
+    }
+  }
+
+  def registerAllocation(address: Long, size: Long): VeAllocation = {
+    require(address > 0L, s"Memory address ${address} is invalid; cannot register allocation!")
+    require(size > 0L, s"Memory size ${size} is invalid; cannot register allocation!")
+    logger.trace(s"Registering externally-created VE memory allocation of ${size} bytes @ ${address}")
+
+    heapRecords.get(address) match {
+      case Some(allocation) if allocation.size == size =>
+        logger.warn(s"Allocation for ${size} bytes @ ${address} is already registered")
+        allocation
+
+      case Some(allocation) =>
+        throw new IllegalArgumentException(s"Allocation @ ${address} is already registered but with different byte sizes!")
+
+      case None =>
+        // Record metrics
+        allocSizesHistogram.update(size)
+
+        // Register the allocation
+        val allocation = VeAllocation(address, size, new Exception().getStackTrace)
+        heapRecords.put(address, allocation)
+        allocation
+    }
+  }
+
+  def unregisterAllocation(address: Long): Unit = {
+    require(address > 0L, s"Invalid VE memory address ${address}")
+
+    heapRecords.get(address) match {
+      case Some(allocation) =>
+        logger.trace(s"Unregistering VE memory allocation tracked by ${getClass.getSimpleName} (${allocation.size} bytes @ ${allocation.address})")
+        heapRecords.remove(address)
+
+      case None =>
+        logger.warn(s"VE memory location @ ${address} is not tracked by ${getClass.getSimpleName}; no allocation to unregister")
     }
   }
 
@@ -185,10 +229,20 @@ final case class WrappingVeo private (val node: Int,
 
   def put(buffer: Pointer): VeAllocation = {
     withVeoProc {
+      // Allocate VE memory
       requireValidBufferForPut(buffer)
       val allocation = allocate(buffer.nbytes)
-      val result = veo.veo_write_mem(handle, allocation.address, buffer, buffer.nbytes)
+
+      // Transfer over and measure time
+      val (result, duration) = measureTime { veo.veo_write_mem(handle, allocation.address, buffer, buffer.nbytes) }
       require(result == 0, s"veo_write_mem failed and returned ${result}")
+
+      // Log transfer metrics
+      val throughput = (buffer.nbytes / 1024 / 1024) / (duration / 1e9)
+      putThroughputsHistogram.update(throughput.toLong)
+      putSizesHistogram.update(buffer.nbytes)
+      logger.debug(s"Transfer of ${buffer.nbytes} bytes to the VE took ${duration / 1e6} ms (${throughput} MB/s")
+
       allocation
     }
   }

--- a/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
+++ b/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
@@ -157,7 +157,8 @@ final case class WrappingVeo private (val node: Int,
 
   def registerAllocation(address: Long, size: Long): VeAllocation = {
     require(address > 0L, s"Memory address ${address} is invalid; cannot register allocation!")
-    require(size > 0L, s"Memory size ${size} is invalid; cannot register allocation!")
+    // Explicitly allow registrations of zero-sized allocations
+    require(size >= 0L, s"Memory size ${size} is invalid; cannot register allocation!")
     logger.trace(s"Registering externally-created VE memory allocation of ${size} bytes @ ${address}")
 
     heapRecords.get(address) match {
@@ -169,6 +170,8 @@ final case class WrappingVeo private (val node: Int,
         throw new IllegalArgumentException(s"Allocation @ ${address} is already registered but with different byte sizes!")
 
       case None =>
+        if (size <= 0) { logger.debug(s"Allocation @ ${address} is of size 0") }
+
         // Record metrics
         allocSizesHistogram.update(size)
 

--- a/src/main/scala/com/nec/vectorengine/VectorEngineImpl.scala
+++ b/src/main/scala/com/nec/vectorengine/VectorEngineImpl.scala
@@ -1,5 +1,6 @@
 package com.nec.vectorengine
 
+import com.nec.cache.TransferDescriptor
 import com.nec.colvector._
 import com.nec.spark.agile.core.{CScalarVector, CVarChar, CVector, VeString}
 import com.nec.util.CallContext
@@ -18,8 +19,15 @@ class VectorEngineImpl(val process: VeProcess,
   // Declare implicit for use with VeAsyncResult contexts
   private implicit val p = process
 
-  def validateVectors(inputs: Seq[VeColVector]): Unit = {
-    inputs.foreach { vector =>
+  implicit class VeColVectorExtensions(vector: VeColVector) {
+    def register: VeColVector = {
+      vector.buffers.zip(vector.bufferSizes).foreach { case (address, size) =>
+        process.registerAllocation(address, size)
+      }
+      vector
+    }
+
+    def validate: Unit = {
       require(
         vector.source == process.source,
         s"Expecting source to be ${process.source}, but got ${vector.source} for vector ${vector}"
@@ -58,14 +66,14 @@ class VectorEngineImpl(val process: VeProcess,
     val argstack = process.newArgsStack(args)
 
     // Execute the function
-    logger.debug(s"Calling ${fnName}")
+    logger.debug(s"Calling VE function: ${fnName}")
     val outp = process.call(func, argstack)
 
     // Free the call args stack
     process.freeArgsStack(argstack)
 
     // All Cyclone C++ functions should return 0L on successful completion
-    require(outp.get == 0L, s"Expected 0 from function execution, got ${outp.get} instead.")
+    require(outp.get == 0L, s"Expected 0 from function execution, got ${outp.get} instead: ${fnName} (${lib.path})")
     outp.close
   }
 
@@ -99,7 +107,7 @@ class VectorEngineImpl(val process: VeProcess,
              (implicit context: CallContext): Seq[VeColVector] = {
     measureTime(fnName) {
       // Validate columns
-      validateVectors(inputs)
+      inputs.foreach(_.validate)
 
       // Set up the input buffer args
       val inbuffers = inputs.map { vec =>
@@ -124,7 +132,7 @@ class VectorEngineImpl(val process: VeProcess,
                   (implicit context: CallContext): Seq[(Int, Seq[VeColVector])] = {
     measureTime(fnName) {
       // Validate columns
-      validateVectors(inputs)
+      inputs.foreach(_.validate)
 
       // Set up the input buffer args
       val inbuffers = inputs.map { vec =>
@@ -164,7 +172,7 @@ class VectorEngineImpl(val process: VeProcess,
                     (implicit context: CallContext): Seq[VeColVector] = {
     measureTime(fnName) {
       // Validate columns
-      inputs.batches.foreach(batch => validateVectors(batch.columns))
+      inputs.batches.flatMap(_.columns).foreach(_.validate)
 
       // Set up the input count args
       val countargs = Seq(
@@ -203,8 +211,8 @@ class VectorEngineImpl(val process: VeProcess,
                  (implicit context: CallContext): Seq[VeColVector] = {
     measureTime(fnName) {
       // Validate columns
-      left.batches.foreach(batch => validateVectors(batch.columns))
-      right.batches.foreach(batch => validateVectors(batch.columns))
+      left.batches.flatMap(_.columns).foreach(_.validate)
+      right.batches.flatMap(_.columns).foreach(_.validate)
 
       // Set up the input count args
       val countargs = Seq(
@@ -254,7 +262,7 @@ class VectorEngineImpl(val process: VeProcess,
                                   (implicit context: CallContext): Seq[(K, Seq[VeColVector])] = {
     measureTime(fnName) {
       // Validate columns
-      inputs.batches.foreach(batch => validateVectors(batch.columns))
+      inputs.batches.flatMap(_.columns).foreach(_.validate)
 
       // Set up the input count args
       val countargs = Seq(
@@ -321,5 +329,37 @@ class VectorEngineImpl(val process: VeProcess,
       scope.close
       results
     }
+  }
+
+  def executeTransfer(lib: LibraryReference,
+                      descriptor: TransferDescriptor)
+                     (implicit context: CallContext): VeColBatch = {
+    require(descriptor.nonEmpty, "TransferDescriptor is empty")
+
+    // Allocate the buffer in VE and transfer the data over
+    logger.debug("Allocating VE memory and transferring data over using TransferDescriptor...")
+    val allocation = process.put(descriptor.buffer)
+
+    // Unregister from VeProcess tracking, as the memory is going to be freed on the VE during transfer handling
+    process.unregisterAllocation(allocation.address)
+
+    // Free the transfer buffer on the VH side
+    descriptor.closeTransferBuffer
+
+    // Unpack and construct nullabble_t_struct's from the VE side
+    execFn(lib, "handle_transfer", Seq(
+      BuffArg(VeArgIntent.In, new LongPointer(1).put(allocation.address)),
+      BuffArg(VeArgIntent.Out, descriptor.outputBuffer)
+    ))
+
+    // Construct VeColBatch from the output buffer
+    val batch = descriptor.outputBufferToColBatch
+
+    // Close the output buffer
+    descriptor.closeOutputBuffer
+
+    // Register the allocations made from the VE
+    batch.columns.foreach(_.register)
+    batch
   }
 }

--- a/src/main/scala/com/nec/vectorengine/VectorEngineImpl.scala
+++ b/src/main/scala/com/nec/vectorengine/VectorEngineImpl.scala
@@ -44,11 +44,14 @@ class VectorEngineImpl(val process: VeProcess,
       require(location > 0, s"Expected nullable_t_struct container location to be > 0L, got ${location}")
       val buffer = new BytePointer(descriptor.veType.containerSize)
 
-      // Copy the nullable_t_struct to VH memory and wait before creating the VeColVector
+      // Copy the nullable_t_struct to VH memory and wait
       VeAsyncResult(process.getAsync(buffer, location)) { () =>
+        // Create the VeColVector from the contents of the nullable_t_struct buffer in VH memory
         val vector = VeColVector.fromBuffer(buffer, location, descriptor)(process.source)
+        // Close the buffer
         buffer.close
-        vector
+        // Register the VE-allocated memory for VeProcess tracking and return
+        vector.register
       }
     }
   }

--- a/src/main/scala/com/nec/vectorengine/VectorEngineTraits.scala
+++ b/src/main/scala/com/nec/vectorengine/VectorEngineTraits.scala
@@ -1,5 +1,6 @@
 package com.nec.vectorengine
 
+import com.nec.cache.TransferDescriptor
 import com.nec.colvector._
 import com.nec.spark.agile.core.CVector
 import com.nec.util.CallContext
@@ -47,6 +48,9 @@ trait VectorEngine {
                                    inputs: VeBatchOfBatches,
                                    outputs: Seq[CVector])
                                   (implicit context: CallContext): Seq[(K, Seq[VeColVector])]
+
+  def executeTransfer(descriptor: TransferDescriptor)
+                     (implicit context: CallContext): VeColBatch
 }
 
 object VectorEngine {

--- a/src/test/scala/com/nec/vectorengine/VeProcessUnitSpec.scala
+++ b/src/test/scala/com/nec/vectorengine/VeProcessUnitSpec.scala
@@ -77,10 +77,10 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
       process.heapAllocations shouldBe empty
 
       // Metrics should be zero
-      process.metrics.getGauges.get(VeProcess.NumAllocationsMetric).getValue should be (0L)
-      process.metrics.getGauges.get(VeProcess.BytesAllocatedMetric).getValue should be (0L)
-      process.metrics.getTimers.get(VeProcess.VeAllocDurationsMetric).getCount should be (0L)
-      process.metrics.getTimers.get(VeProcess.VeFreeDurationsMetric).getCount should be (0L)
+      process.metrics.getGauges.get(VeProcess.NumTrackedAllocationsMetric).getValue should be (0L)
+      process.metrics.getGauges.get(VeProcess.TrackBytesAllocatedMetric).getValue should be (0L)
+      process.metrics.getTimers.get(VeProcess.VeAllocTimerMetric).getCount should be (0L)
+      process.metrics.getTimers.get(VeProcess.VeFreeTimerMetric).getCount should be (0L)
 
       val allocation = process.allocate(size)
       allocation.address should be > 0L
@@ -90,10 +90,10 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
       process.heapAllocations.keys should be (Set(allocation.address))
 
       // Metrics should be non-zero
-      process.metrics.getGauges.get(VeProcess.NumAllocationsMetric).getValue should be (1L)
-      process.metrics.getGauges.get(VeProcess.BytesAllocatedMetric).getValue should be (size.toLong)
-      process.metrics.getTimers.get(VeProcess.VeAllocDurationsMetric).getCount should be (1L)
-      process.metrics.getTimers.get(VeProcess.VeFreeDurationsMetric).getCount should be (0L)
+      process.metrics.getGauges.get(VeProcess.NumTrackedAllocationsMetric).getValue should be (1L)
+      process.metrics.getGauges.get(VeProcess.TrackBytesAllocatedMetric).getValue should be (size.toLong)
+      process.metrics.getTimers.get(VeProcess.VeAllocTimerMetric).getCount should be (1L)
+      process.metrics.getTimers.get(VeProcess.VeFreeTimerMetric).getCount should be (0L)
 
       // First call to `free()` should work
       noException should be thrownBy {
@@ -104,10 +104,10 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
       process.heapAllocations shouldBe empty
 
       // Metrics should be back to zero
-      process.metrics.getGauges.get(VeProcess.NumAllocationsMetric).getValue should be (0L)
-      process.metrics.getGauges.get(VeProcess.BytesAllocatedMetric).getValue should be (0L)
-      process.metrics.getTimers.get(VeProcess.VeAllocDurationsMetric).getCount should be (1L)
-      process.metrics.getTimers.get(VeProcess.VeFreeDurationsMetric).getCount should be (1L)
+      process.metrics.getGauges.get(VeProcess.NumTrackedAllocationsMetric).getValue should be (0L)
+      process.metrics.getGauges.get(VeProcess.TrackBytesAllocatedMetric).getValue should be (0L)
+      process.metrics.getTimers.get(VeProcess.VeAllocTimerMetric).getCount should be (1L)
+      process.metrics.getTimers.get(VeProcess.VeFreeTimerMetric).getCount should be (1L)
 
       // Double `free()` should fail without crashing the JVM
       intercept[IllegalArgumentException] {
@@ -136,6 +136,56 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
       // VE memory address is valid but has never been allocated before
       intercept[IllegalArgumentException] {
         process.free(Random.nextInt(10000).toLong)
+      }
+    }
+
+    "correctly register, de-register, and re-register memory allocations for tracking" in {
+      val size = Random.nextInt(10000) + 100
+
+      // Allocate
+      val allocation = process.allocate(size)
+
+      // Tracker should contain the record
+      process.heapAllocations.keys should be (Set(allocation.address))
+
+      // VE memory address is invalid
+      intercept[IllegalArgumentException] {
+        process.registerAllocation(- Random.nextInt(10000).toLong, Random.nextInt(10000) + 100)
+      }
+
+      // Zero or negative allocation size
+      intercept[IllegalArgumentException] {
+        process.registerAllocation(Random.nextInt(10000) + 100, - Random.nextInt(10000).toLong + 100)
+      }
+
+      // VE memory address is invalid
+      intercept[IllegalArgumentException] {
+        process.unregisterAllocation(- Random.nextInt(10000).toLong)
+      }
+
+      // Register a conflicting allocation (same address, different size)
+      intercept[IllegalArgumentException] {
+        process.registerAllocation(allocation.address, allocation.size + Random.nextInt(10000).toLong + 100)
+      }
+
+      // The same allocation
+      noException should be thrownBy {
+        process.registerAllocation(allocation.address, allocation.size) should be (allocation)
+      }
+
+      // Un-register allocation from tracking
+      noException should be thrownBy {
+        process.unregisterAllocation(allocation.address)
+      }
+
+      // Re-register allocation for tracking
+      noException should be thrownBy {
+        process.registerAllocation(allocation.address, allocation.size)
+      }
+
+      // Free should work
+      noException should be thrownBy {
+        process.free(allocation.address)
       }
     }
 
@@ -446,7 +496,7 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
         // Metrics should be zero
         process.metrics.getGauges.get(VeProcess.VeSyncFnCallsCountMetric).getValue should be (0L)
         process.metrics.getGauges.get(VeProcess.VeSyncFnCallTimesMetric).getValue should be (0L)
-        process.metrics.getTimers.get(VeProcess.VeSyncFnCallDurationsMetric).getCount should be (0L)
+        process.metrics.getTimers.get(VeProcess.VeSyncFnCallTimerMetric).getCount should be (0L)
 
         // Call the function (sync)
         val retp = process.call(func, stack)
@@ -455,7 +505,7 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
         // Metrics should be non-zero
         process.metrics.getGauges.get(VeProcess.VeSyncFnCallsCountMetric).getValue should be (1L)
         process.metrics.getGauges.get(VeProcess.VeSyncFnCallTimesMetric).getValue shouldNot be (0L)
-        process.metrics.getTimers.get(VeProcess.VeSyncFnCallDurationsMetric).getCount should be (1L)
+        process.metrics.getTimers.get(VeProcess.VeSyncFnCallTimerMetric).getCount should be (1L)
 
         // Dereference the output pointer and move output from VE to VH
         val outbuffer = new DoublePointer(input.size)

--- a/src/test/scala/com/nec/vectorengine/VeProcessUnitSpec.scala
+++ b/src/test/scala/com/nec/vectorengine/VeProcessUnitSpec.scala
@@ -54,6 +54,16 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
   }
 
   "VeProcess" should {
+    "be able to load the Cyclone C++ Library" in {
+      noException should be thrownBy {
+        // Load libcyclone
+        val lib = process.load(LibCyclone.SoPath)
+
+        // Unload libcyclone
+        process.unload(lib)
+      }
+    }
+
     "correctly indicate that the underlying VE process is open" in {
       process.isOpen should be (true)
     }
@@ -168,7 +178,7 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
         process.registerAllocation(allocation.address, allocation.size + Random.nextInt(10000).toLong + 100)
       }
 
-      // The same allocation
+      // Registering the same allocation should be a no-op
       noException should be thrownBy {
         process.registerAllocation(allocation.address, allocation.size) should be (allocation)
       }
@@ -176,16 +186,19 @@ final class VeProcessUnitSpec extends AnyWordSpec with BeforeAndAfterAll with Ev
       // Un-register allocation from tracking
       noException should be thrownBy {
         process.unregisterAllocation(allocation.address)
+        process.heapAllocations shouldBe empty
       }
 
       // Re-register allocation for tracking
       noException should be thrownBy {
         process.registerAllocation(allocation.address, allocation.size)
+        process.heapAllocations.keys should be (Set(allocation.address))
       }
 
       // Free should work
       noException should be thrownBy {
         process.free(allocation.address)
+        process.heapAllocations shouldBe empty
       }
     }
 

--- a/src/test/scala/com/nec/vectorengine/VectorEngineFunSpec.scala
+++ b/src/test/scala/com/nec/vectorengine/VectorEngineFunSpec.scala
@@ -44,6 +44,11 @@ final class VectorEngineFunSpec extends AnyWordSpec with WithVeProcess with VeKe
 
         val expected = inputs.map(_.map(_ * 2))
         outputs.map(_.toBytePointerColVector2.toSeqOpt[Double]) should be (Seq(expected))
+
+        // Allocations should have been registered for tracking by VeProcess
+        noException should be thrownBy {
+          outputs.map(_.free2)
+        }
       }
     }
 
@@ -76,6 +81,10 @@ final class VectorEngineFunSpec extends AnyWordSpec with WithVeProcess with VeKe
         }.toSeq
 
         outputs.map(_.toBytePointerColVector2.toSeqOpt[Double]) should be (Seq(expected1, expected2))
+
+        noException should be thrownBy {
+          outputs.map(_.free2)
+        }
       }
     }
 
@@ -113,6 +122,10 @@ final class VectorEngineFunSpec extends AnyWordSpec with WithVeProcess with VeKe
         )
 
         results should be (expected)
+
+        noException should be thrownBy {
+          outputs.flatMap(_._2).map(_.free2)
+        }
       }
     }
 
@@ -157,6 +170,10 @@ final class VectorEngineFunSpec extends AnyWordSpec with WithVeProcess with VeKe
 
         results.map(_._2.size).toSet == Set(1, 2)
         results.flatMap(_._2).toSet should be (Set[(Double, String, Double)]((1, "a", 9), (2, "b", 8), (3, lastString, 7)))
+
+        noException should be thrownBy {
+          outputs.flatMap(_._2).map(_.free2)
+        }
       }
     }
 
@@ -190,6 +207,10 @@ final class VectorEngineFunSpec extends AnyWordSpec with WithVeProcess with VeKe
         outputs.size should be (2)
         outputs(0).toBytePointerColVector2.toSeqOpt[Double].flatten should be (Seq[Double](1, 2, 3, -1, 2, 3, 4))
         outputs(1).toBytePointerColVector2.toSeqOpt[String].flatten should be (Seq("a", "b", "c", "x", "d", "e", "f"))
+
+        noException should be thrownBy {
+          outputs.map(_.free2)
+        }
       }
     }
 
@@ -250,6 +271,10 @@ final class VectorEngineFunSpec extends AnyWordSpec with WithVeProcess with VeKe
         outputs(1).toBytePointerColVector2.toSeqOpt[String].flatten should be (Seq("a", "b", "d"))
         outputs(2).toBytePointerColVector2.toSeqOpt[String].flatten should be (Seq("vv", "xx", "xx"))
         outputs(3).toBytePointerColVector2.toSeqOpt[Float].flatten should be (Seq[Float](3.14f, 2.71f, 2.71f))
+
+        noException should be thrownBy {
+          outputs.map(_.free2)
+        }
       }
     }
 
@@ -308,6 +333,10 @@ final class VectorEngineFunSpec extends AnyWordSpec with WithVeProcess with VeKe
         )
 
         results should be (expected)
+
+        noException should be thrownBy {
+          outputs.flatMap(_._2).map(_.free2)
+        }
       }
     }
 

--- a/src/test/scala/com/nec/vectorengine/WithVeProcess.scala
+++ b/src/test/scala/com/nec/vectorengine/WithVeProcess.scala
@@ -7,10 +7,6 @@ import com.codahale.metrics._
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
 trait WithVeProcess extends BeforeAndAfterAll { self: Suite =>
-  final val LibCyclonePath: Path = {
-    Paths.get("target/scala-2.12/classes/cycloneve/libcyclone.so")
-  }
-
   // TODO: Remove
   implicit val metrics0 = VeProcessMetrics.noOp
 


### PR DESCRIPTION
Summary:

- Port the `TransferDescriptor`-based data transfer feature over from the old `VeProcess` to the new `VectorEngine` implementation
- Add histogram-based metrics to the new `VeProcess` implementation
- Add support for registering and unregistering memory allocations, which is useful for tracking memory allocations made on the VE side during function calls
- Add functional tests for `TransferDescriptor`-based data transfer support in the new `VectorEngine` implementation
- Add `LibCyclone` object to hold souce of truth information about `libcyclone.so`
- Add test cases with concrete example inputs to highlight failing test cases with `TransferDescriptor`-based bulk data transfer
- Update existing `BytePointerColVector` conversion tests to be more strict with verifying the content of the validity buffers
- Bugfix: Correctly specify offset for varchar vectors.

There is an outstanding issue with the `TransferDescriptor`-based data transfer feature where the validity buffer transfer does not maintain fidelity between transfers to the VE via `TransferDescriptor` and back via `VeColVector`.  This issue is still under investigation.