### PR TITLE
[NS-43] Integrate the new `VeProcess`, part 1

### DIFF
--- a/aveobench/src/main/scala/com/nec/cyclone/benchmarks/CompressedBatchVeTransferBenchmarks.scala
+++ b/aveobench/src/main/scala/com/nec/cyclone/benchmarks/CompressedBatchVeTransferBenchmarks.scala
@@ -3,7 +3,7 @@ package com.nec.cyclone.benchmarks
 import com.nec.cyclone.colvector._
 import com.nec.colvector._
 import com.nec.colvector.SeqOptTConversions._
-import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+import com.nec.util.CallContextOps._
 import com.nec.ve._
 import org.bytedeco.veoffload.global.veo
 import scala.reflect._

--- a/aveobench/src/main/scala/com/nec/cyclone/benchmarks/CompressedVeTransferBenchmarks.scala
+++ b/aveobench/src/main/scala/com/nec/cyclone/benchmarks/CompressedVeTransferBenchmarks.scala
@@ -4,7 +4,7 @@ import com.nec.cyclone.colvector.BytePointerColVectorOps._
 import com.nec.cyclone.colvector.CompressedBytePointerColVector
 import com.nec.colvector._
 import com.nec.colvector.SeqOptTConversions._
-import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+import com.nec.util.CallContextOps._
 import com.nec.ve._
 import org.bytedeco.veoffload.global.veo
 import scala.reflect._

--- a/aveobench/src/main/scala/com/nec/cyclone/benchmarks/VeFreeBenchmarks.scala
+++ b/aveobench/src/main/scala/com/nec/cyclone/benchmarks/VeFreeBenchmarks.scala
@@ -2,7 +2,7 @@ package com.nec.cyclone.benchmarks
 
 import com.nec.colvector._
 import com.nec.colvector.SeqOptTConversions._
-import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+import com.nec.util.CallContextOps._
 import com.nec.ve._
 import org.bytedeco.veoffload.global.veo
 import org.bytedeco.veoffload.{veo_proc_handle, veo_thr_ctxt}

--- a/aveobench/src/main/scala/com/nec/cyclone/benchmarks/VeTransferBenchmarks.scala
+++ b/aveobench/src/main/scala/com/nec/cyclone/benchmarks/VeTransferBenchmarks.scala
@@ -2,7 +2,7 @@ package com.nec.cyclone.benchmarks
 
 import com.nec.colvector._
 import com.nec.colvector.SeqOptTConversions._
-import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+import com.nec.util.CallContextOps._
 import com.nec.ve._
 import org.bytedeco.veoffload.global.veo
 import scala.reflect._

--- a/aveobench/src/main/scala/com/nec/cyclone/colvector/CompressedBytePointerColBatch.scala
+++ b/aveobench/src/main/scala/com/nec/cyclone/colvector/CompressedBytePointerColBatch.scala
@@ -2,7 +2,7 @@ package com.nec.cyclone.colvector
 
 import com.nec.colvector._
 import com.nec.spark.agile.core.{VeScalarType, VeString}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.{VeAsyncResult, VeProcess, VeProcessMetrics}
 import org.bytedeco.javacpp.BytePointer
 
@@ -49,7 +49,7 @@ final case class CompressedBytePointerColBatch private[colvector] (columns: Seq[
 
   def asyncToCompressedVeColBatch(implicit source: VeColVectorSource,
                                   process: VeProcess,
-                                  context: OriginalCallingContext,
+                                  context: CallContext,
                                   metrics: VeProcessMetrics): () => VeAsyncResult[CompressedVeColBatch] = {
     // Allocate memory on the VE
     val veLocations = Seq(
@@ -79,7 +79,7 @@ final case class CompressedBytePointerColBatch private[colvector] (columns: Seq[
 
   def toCompressedVeColBatch(implicit source: VeColVectorSource,
                              process: VeProcess,
-                             context: OriginalCallingContext,
+                             context: CallContext,
                              metrics: VeProcessMetrics): CompressedVeColBatch = {
     asyncToCompressedVeColBatch.apply().get()
   }

--- a/aveobench/src/main/scala/com/nec/cyclone/colvector/CompressedBytePointerColVector.scala
+++ b/aveobench/src/main/scala/com/nec/cyclone/colvector/CompressedBytePointerColVector.scala
@@ -2,7 +2,7 @@ package com.nec.cyclone.colvector
 
 import com.nec.colvector._
 import com.nec.spark.agile.core.{VeScalarType, VeString, VeType}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.{VeAsyncResult, VeProcess, VeProcessMetrics}
 import org.bytedeco.javacpp.BytePointer
 
@@ -48,7 +48,7 @@ final case class CompressedBytePointerColVector private[colvector] (
 
   def asyncToVeColVector(implicit source: VeColVectorSource,
                          process: VeProcess,
-                         context: OriginalCallingContext,
+                         context: CallContext,
                          metrics: VeProcessMetrics): () => VeAsyncResult[VeColVector] = {
     // Allocate memory on the VE
     val veLocations = Seq(veType.containerSize.toLong, buffer.limit()).map(process.allocate)
@@ -81,7 +81,7 @@ final case class CompressedBytePointerColVector private[colvector] (
 
   def toVeColVector(implicit source: VeColVectorSource,
                     process: VeProcess,
-                    context: OriginalCallingContext,
+                    context: CallContext,
                     metrics: VeProcessMetrics): VeColVector = {
     asyncToVeColVector.apply().get()
   }

--- a/aveobench/src/main/scala/com/nec/cyclone/colvector/CompressedVeColBatch.scala
+++ b/aveobench/src/main/scala/com/nec/cyclone/colvector/CompressedVeColBatch.scala
@@ -1,7 +1,7 @@
 package com.nec.cyclone.colvector
 
 import com.nec.colvector._
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.VeProcess
 
 final case class CompressedVeColBatch private[colvector] (columns: Seq[UnitColVector],
@@ -9,7 +9,7 @@ final case class CompressedVeColBatch private[colvector] (columns: Seq[UnitColVe
                                                           buffer: Long) {
   def free()(implicit source: VeColVectorSource,
              process: VeProcess,
-             context: OriginalCallingContext): Unit = {
+             context: CallContext): Unit = {
     Seq(struct, buffer).foreach(process.free)
   }
 }

--- a/src/main/scala/com/nec/cache/ArrowBasedCacheSerializer.scala
+++ b/src/main/scala/com/nec/cache/ArrowBasedCacheSerializer.scala
@@ -71,7 +71,7 @@ class ArrowBasedCacheSerializer extends CycloneCacheBase {
         .newChildAllocator(s"Writer for partial collector (Arrow)", 0, Long.MaxValue)
       TaskContext.get().addTaskCompletionListener[Unit](_ => allocator.close())
       import com.nec.util.CallContextOps._
-      import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics._
+      import com.nec.spark.SparkCycloneExecutorPlugin._
       ArrowBasedCacheSerializer
         .sparkInternalRowsToArrowSerializedColBatch(
           internalRows = internalRows,

--- a/src/main/scala/com/nec/cache/ArrowBasedCacheSerializer.scala
+++ b/src/main/scala/com/nec/cache/ArrowBasedCacheSerializer.scala
@@ -2,7 +2,7 @@ package com.nec.cache
 
 import com.nec.colvector.ArrowVectorConversions._
 import com.nec.colvector.SparkSqlColumnVectorConversions._
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.VeProcessMetrics
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.types.pojo.Schema
@@ -34,9 +34,9 @@ object ArrowBasedCacheSerializer {
     internalRows: Iterator[InternalRow],
     arrowSchema: Schema
   )(implicit
-    bufferAllocator: BufferAllocator,
-    arrowEncodingSettings: ArrowEncodingSettings,
-    originalCallingContext: OriginalCallingContext,
+    allocator: BufferAllocator,
+    encoding: ArrowEncodingSettings,
+    context: CallContext,
     cycloneMetrics: VeProcessMetrics
   ): Iterator[CachedVeBatch] =
     SparkInternalRowsToArrowColumnarBatches
@@ -65,12 +65,12 @@ class ArrowBasedCacheSerializer extends CycloneCacheBase {
     storageLevel: StorageLevel,
     conf: SQLConf
   ): RDD[CachedBatch] = {
-    implicit val arrowEncodingSettings = ArrowEncodingSettings.fromConf(conf)(input.sparkContext)
+    implicit val encoding = ArrowEncodingSettings.fromConf(conf)(input.sparkContext)
     input.mapPartitions(f = internalRows => {
       implicit val allocator: BufferAllocator = ArrowUtilsExposed.rootAllocator
         .newChildAllocator(s"Writer for partial collector (Arrow)", 0, Long.MaxValue)
       TaskContext.get().addTaskCompletionListener[Unit](_ => allocator.close())
-      import OriginalCallingContext.Automatic._
+      import com.nec.util.CallContextOps._
       import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics._
       ArrowBasedCacheSerializer
         .sparkInternalRowsToArrowSerializedColBatch(

--- a/src/main/scala/com/nec/cache/ColumnarBatchToVeColBatch.scala
+++ b/src/main/scala/com/nec/cache/ColumnarBatchToVeColBatch.scala
@@ -3,7 +3,7 @@ package com.nec.cache
 import com.nec.colvector.ArrowVectorConversions._
 import com.nec.colvector.SparkSqlColumnVectorConversions._
 import com.nec.colvector.{VeColBatch, VeColVectorSource}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.{VeProcess, VeProcessMetrics}
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.types.pojo.Schema
@@ -16,9 +16,9 @@ object ColumnarBatchToVeColBatch {
     completeInSpark: Boolean,
     metricsFn: (() => VeColBatch) => VeColBatch = (x) => { x() }
   )(implicit
-    bufferAllocator: BufferAllocator,
-    arrowEncodingSettings: ArrowEncodingSettings,
-    originalCallingContext: OriginalCallingContext,
+    allocator: BufferAllocator,
+    encoding: ArrowEncodingSettings,
+    context: CallContext,
     veProcess: VeProcess,
     veColVectorSource: VeColVectorSource,
     cycloneMetrics: VeProcessMetrics,
@@ -48,9 +48,9 @@ object ColumnarBatchToVeColBatch {
     completeInSpark: Boolean,
     metricsFn: (() => VeColBatch) => VeColBatch = (x) => { x() }
   )(implicit
-    bufferAllocator: BufferAllocator,
-    arrowEncodingSettings: ArrowEncodingSettings,
-    originalCallingContext: OriginalCallingContext,
+    allocator: BufferAllocator,
+    encoding: ArrowEncodingSettings,
+    context: CallContext,
     veProcess: VeProcess,
     veColVectorSource: VeColVectorSource,
     cycloneMetrics: VeProcessMetrics

--- a/src/main/scala/com/nec/cache/CycloneCacheBase.scala
+++ b/src/main/scala/com/nec/cache/CycloneCacheBase.scala
@@ -61,7 +61,7 @@ object CycloneCacheBase {
 
   def makeArrowSchema(
     schema: Seq[Attribute]
-  )(implicit arrowEncodingSettings: ArrowEncodingSettings): Schema =
+  )(implicit encoding: ArrowEncodingSettings): Schema =
     ArrowUtilsExposed.toArrowSchema(
       schema = StructType(
         schema.map(att =>
@@ -73,6 +73,6 @@ object CycloneCacheBase {
           )
         )
       ),
-      timeZoneId = arrowEncodingSettings.timezone
+      timeZoneId = encoding.timezone
     )
 }

--- a/src/main/scala/com/nec/cache/DualColumnarBatchContainer.scala
+++ b/src/main/scala/com/nec/cache/DualColumnarBatchContainer.scala
@@ -2,7 +2,7 @@ package com.nec.cache
 
 import com.nec.colvector.ArrowVectorConversions._
 import com.nec.colvector._
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.{VeProcess, VeProcessMetrics}
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
@@ -22,7 +22,7 @@ final case class DualColumnarBatchContainer(vecs: List[Either[VeColVector, ByteA
   }
 
   def toArrowColumnarBatch()(implicit
-    bufferAllocator: BufferAllocator,
+    allocator: BufferAllocator,
     veProcess: VeProcess
   ): ColumnarBatch = {
     Option(vecs.flatMap(_.left.toSeq)).filter(_.nonEmpty) match {
@@ -41,7 +41,7 @@ final case class DualColumnarBatchContainer(vecs: List[Either[VeColVector, ByteA
   def toVEColBatch()(implicit
     veProcess: VeProcess,
     veColVectorSource: VeColVectorSource,
-    originalCallingContext: OriginalCallingContext,
+    context: CallContext,
     cycloneMetrics: VeProcessMetrics
   ): VeColBatch = {
     Option(vecs.flatMap(_.left.toSeq)).filter(_.nonEmpty) match {

--- a/src/main/scala/com/nec/cache/DualMode.scala
+++ b/src/main/scala/com/nec/cache/DualMode.scala
@@ -2,7 +2,7 @@ package com.nec.cache
 
 import com.nec.cache.VeColColumnarVector.CachedColumnVector
 import com.nec.util.ReflectionOps._
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.colvector.VeColVectorSource
 import com.nec.colvector.VeColVectorSource
 import com.nec.colvector.VeColBatch
@@ -94,11 +94,11 @@ object DualMode {
     arrowSchema: Schema,
     metricsFn: (() => VeColBatch) => VeColBatch = (x) => { x() }
   )(implicit
-    bufferAllocator: BufferAllocator,
+    allocator: BufferAllocator,
     veProcess: VeProcess,
     source: VeColVectorSource,
-    arrowEncodingSettings: ArrowEncodingSettings,
-    originalCallingContext: OriginalCallingContext,
+    encoding: ArrowEncodingSettings,
+    context: CallContext,
     cycloneMetrics: VeProcessMetrics
   ): Iterator[VeColBatch] =
     DualMode.unwrapInternalRows(possiblyDualModeInternalRows) match {

--- a/src/main/scala/com/nec/cache/InVectorEngineCacheSerializer.scala
+++ b/src/main/scala/com/nec/cache/InVectorEngineCacheSerializer.scala
@@ -43,7 +43,7 @@ object InVectorEngineCacheSerializer {
       .map { columnarBatch =>
         import SparkCycloneExecutorPlugin._
         val veColBatch = VeColBatch.fromArrowColumnarBatch(columnarBatch)
-        //SparkCycloneExecutorPlugin.registerCachedBatch(veColBatch)
+        // SparkCycloneExecutorPlugin.batchesCache.register(veColBatch)
         try CachedVeBatch(DualColumnarBatchContainer(vecs = veColBatch.columns.map(cv => Left(cv)).toList))
         finally columnarBatch.close()
       }

--- a/src/main/scala/com/nec/cache/InVectorEngineCacheSerializer.scala
+++ b/src/main/scala/com/nec/cache/InVectorEngineCacheSerializer.scala
@@ -66,7 +66,7 @@ class InVectorEngineCacheSerializer extends CycloneCacheBase {
         .newChildAllocator(s"Writer for partial collector (Arrow)", 0, Long.MaxValue)
       TaskContext.get().addTaskCompletionListener[Unit](_ => allocator.close())
       import com.nec.util.CallContextOps._
-      import SparkCycloneExecutorPlugin.ImplicitMetrics._
+      import SparkCycloneExecutorPlugin._
       InVectorEngineCacheSerializer
         .internalRowToCachedVeColBatch(
           rowIterator = internalRows,
@@ -85,7 +85,6 @@ class InVectorEngineCacheSerializer extends CycloneCacheBase {
       .newChildAllocator(s"Writer for partial collector (Arrow)", 0, Long.MaxValue)
     TaskContext.get().addTaskCompletionListener[Unit](_ => allocator.close())
 
-    import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics._
     import com.nec.spark.SparkCycloneExecutorPlugin._
     columnarBatches.map { columnarBatch =>
       CachedVeBatch.apply(cachedColumnVectors =

--- a/src/main/scala/com/nec/cache/VeColBatchesCache.scala
+++ b/src/main/scala/com/nec/cache/VeColBatchesCache.scala
@@ -1,0 +1,34 @@
+package com.nec.cache
+
+import com.nec.colvector.VeColBatch
+import com.nec.spark.SparkCycloneExecutorPlugin.source
+import com.nec.util.CallContext
+import com.nec.ve.VeProcess
+import scala.collection.concurrent.TrieMap
+import com.typesafe.scalalogging.LazyLogging
+
+class VeColBatchesCache extends LazyLogging {
+  private[cache] val batches = TrieMap.empty[String, VeColBatch]
+
+  def register(name: String, batch: VeColBatch): Unit = {
+    batches += ((name, batch))
+  }
+
+  def cleanupIfNotCached(batch: VeColBatch)
+                        (implicit process: VeProcess,
+                         context: CallContext): Unit = {
+    if (batches.values.toSeq.contains(batch)) {
+      logger.trace(s"Data at ${batch.columns.map(_.container)} will not be cleaned up as it's cached: ${context}")
+
+    } else {
+      logger.trace(s"Will clean up data for ${batch.columns.map(_.container)}")
+      batch.free
+    }
+  }
+
+  def cleanup(implicit process: VeProcess): Unit = {
+    import com.nec.util.CallContextOps._
+    batches.values.foreach(_.free())
+    batches.clear
+  }
+}

--- a/src/main/scala/com/nec/colvector/ArrowVectorConversions.scala
+++ b/src/main/scala/com/nec/colvector/ArrowVectorConversions.scala
@@ -1,7 +1,7 @@
 package com.nec.colvector
 
 import com.nec.spark.agile.core._
-import com.nec.util.FixedBitSet
+import com.nec.util.{FixedBitSet, CallContext}
 import com.nec.util.ReflectionOps._
 import com.nec.ve.{VeProcess, VeProcessMetrics}
 import java.nio.charset.StandardCharsets
@@ -131,7 +131,7 @@ object ArrowVectorConversions {
       vec
     }
 
-    def toArrowVector(implicit bufferAllocator: BufferAllocator): FieldVector = {
+    def toArrowVector(implicit allocator: BufferAllocator): FieldVector = {
       input.veType match {
         case VeNullableShort =>
           // Specialize this case because Int values in VeNullableShort need to be cast to Short
@@ -289,7 +289,7 @@ object ArrowVectorConversions {
   implicit class ValueVectorToVeColVector(vector: ValueVector) {
     def toVeColVector(implicit veProcess: VeProcess,
                       source: VeColVectorSource,
-                      context: VeProcess.OriginalCallingContext,
+                      context: CallContext,
                       metrics: VeProcessMetrics): VeColVector = {
       vector.toBytePointerColVector.toVeColVector
     }

--- a/src/main/scala/com/nec/colvector/ByteArrayColVector.scala
+++ b/src/main/scala/com/nec/colvector/ByteArrayColVector.scala
@@ -3,6 +3,7 @@ package com.nec.colvector
 import com.nec.cache.VeColColumnarVector
 import com.nec.spark.agile.core.{VeString, VeType}
 import com.nec.ve.{VeAsyncResult, VeProcess, VeProcessMetrics}
+import com.nec.util.CallContext
 import org.apache.spark.sql.vectorized.ColumnVector
 import org.bytedeco.javacpp.BytePointer
 
@@ -65,14 +66,14 @@ final case class ByteArrayColVector private[colvector] (
 
   def toVeColVector(implicit veProcess: VeProcess,
                     source: VeColVectorSource,
-                    context: VeProcess.OriginalCallingContext,
+                    context: CallContext,
                     metrics: VeProcessMetrics): VeColVector = {
     toBytePointerColVector.toVeColVector
   }
 
   def asyncToVeColVector(implicit veProcess: VeProcess,
                     source: VeColVectorSource,
-                    context: VeProcess.OriginalCallingContext,
+                    context: CallContext,
                     metrics: VeProcessMetrics): () => VeAsyncResult[VeColVector] = {
     toBytePointerColVector.asyncToVeColVector
   }

--- a/src/main/scala/com/nec/colvector/BytePointerColVector.scala
+++ b/src/main/scala/com/nec/colvector/BytePointerColVector.scala
@@ -2,7 +2,7 @@ package com.nec.colvector
 
 import com.nec.spark.agile.core.{VeScalarType, VeString, VeType}
 import com.nec.util.CallContext
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.{VeAsyncResult, VeProcess, VeProcessMetrics}
 import com.nec.vectorengine.{VeProcess => NewVeProcess, VeAsyncResult => NewVeAsyncResult}
 import org.bytedeco.javacpp.BytePointer
@@ -46,7 +46,7 @@ final case class BytePointerColVector private[colvector] (
 
   def asyncToVeColVector(implicit source: VeColVectorSource,
                          process: VeProcess,
-                         context: OriginalCallingContext,
+                         context: CallContext,
                          metrics: VeProcessMetrics): () => VeAsyncResult[VeColVector] = {
     val veMemoryPositions = (Seq(veType.containerSize.toLong) ++ buffers.map(_.limit())).map(process.allocate)
     val structPtr = veType match {
@@ -153,7 +153,7 @@ final case class BytePointerColVector private[colvector] (
 
   def toVeColVector(implicit source: VeColVectorSource,
                     process: VeProcess,
-                    context: OriginalCallingContext,
+                    context: CallContext,
                     metrics: VeProcessMetrics): VeColVector = {
     asyncToVeColVector.apply().get()
   }

--- a/src/main/scala/com/nec/colvector/UnitColBatch.scala
+++ b/src/main/scala/com/nec/colvector/UnitColBatch.scala
@@ -1,12 +1,12 @@
 package com.nec.colvector
 
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.{VeProcess, VeProcessMetrics}
 
 final case class UnitColBatch(columns: Seq[UnitColVector]) {
   def withData(arrays: Seq[Array[Byte]])(implicit source: VeColVectorSource,
                                          process: VeProcess,
-                                         context: OriginalCallingContext,
+                                         context: CallContext,
                                          metrics: VeProcessMetrics): VeColBatch = {
     VeColBatch(columns.zip(arrays).map { case (colvec, bytes) => colvec.withData(bytes) }.map(_.apply()).map(_.get()))
   }

--- a/src/main/scala/com/nec/colvector/UnitColVector.scala
+++ b/src/main/scala/com/nec/colvector/UnitColVector.scala
@@ -28,7 +28,7 @@ final case class UnitColVector private[colvector] (
   def withData(stream: InputStream)(implicit source: VeColVectorSource,
                                     process: VeProcess,
                                     context: CallContext): () => VeAsyncResult[VeColVector] = {
-    import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics.processMetrics
+    import com.nec.spark.SparkCycloneExecutorPlugin.veMetrics
 
     val channel = Channels.newChannel(stream)
     val buffers = bufferSizes.map { size =>

--- a/src/main/scala/com/nec/colvector/UnitColVector.scala
+++ b/src/main/scala/com/nec/colvector/UnitColVector.scala
@@ -1,7 +1,7 @@
 package com.nec.colvector
 
 import com.nec.spark.agile.core.{VeString, VeType}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.{VeAsyncResult, VeProcess, VeProcessMetrics}
 import org.bytedeco.javacpp.BytePointer
 
@@ -27,7 +27,7 @@ final case class UnitColVector private[colvector] (
 
   def withData(stream: InputStream)(implicit source: VeColVectorSource,
                                     process: VeProcess,
-                                    context: OriginalCallingContext): () => VeAsyncResult[VeColVector] = {
+                                    context: CallContext): () => VeAsyncResult[VeColVector] = {
     import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics.processMetrics
 
     val channel = Channels.newChannel(stream)
@@ -48,7 +48,7 @@ final case class UnitColVector private[colvector] (
 
   def withData(array: Array[Byte])(implicit source: VeColVectorSource,
                                    process: VeProcess,
-                                   context: OriginalCallingContext,
+                                   context: CallContext,
                                    metrics: VeProcessMetrics): () => VeAsyncResult[VeColVector] = {
     metrics.measureRunningTime {
       val buffers = bufferSizes.scanLeft(0)(_ + _).zip(bufferSizes).map {

--- a/src/main/scala/com/nec/colvector/VeColBatch.scala
+++ b/src/main/scala/com/nec/colvector/VeColBatch.scala
@@ -4,7 +4,7 @@ import com.nec.colvector.ArrayTConversions._
 import com.nec.colvector.ArrowVectorConversions._
 import com.nec.colvector.SparkSqlColumnVectorConversions._
 import com.nec.spark.agile.core.VeType
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.{VeProcess, VeProcessMetrics}
 import com.nec.vectorengine.{VeProcess => NewVeProcess}
 import org.apache.arrow.memory.BufferAllocator
@@ -126,7 +126,7 @@ final case class VeColBatch(columns: Seq[VeColVector]) {
 
   def free()(implicit source: VeColVectorSource,
              process: VeProcess,
-             context: OriginalCallingContext): Unit = {
+             context: CallContext): Unit = {
     columns.foreach(_.free)
   }
 
@@ -168,7 +168,7 @@ object VeColBatch {
   def fromStream(din: DataInputStream)(implicit
     veProcess: VeProcess,
     source: VeColVectorSource,
-    originalCallingContext: OriginalCallingContext
+    context: CallContext
   ): VeColBatch = {
     ensureId(din.readInt(), ColLengthsId)
 
@@ -202,7 +202,7 @@ object VeColBatch {
 
   def fromBytes(data: Array[Byte])(implicit source: VeColVectorSource,
                                    process: VeProcess,
-                                   context: OriginalCallingContext,
+                                   context: CallContext,
                                    metrics: VeProcessMetrics): VeColBatch = {
     val stream = new ByteArrayInputStream(data)
     val reader = new ObjectInputStream(stream)
@@ -216,7 +216,7 @@ object VeColBatch {
 
   def fromArrowColumnarBatch(batch: ColumnarBatch)(implicit source: VeColVectorSource,
                                                    process: VeProcess,
-                                                   context: OriginalCallingContext,
+                                                   context: CallContext,
                                                    metrics: VeProcessMetrics): VeColBatch = {
     VeColBatch(
       (0 until batch.numCols).map { i =>

--- a/src/main/scala/com/nec/colvector/VeColVector.scala
+++ b/src/main/scala/com/nec/colvector/VeColVector.scala
@@ -2,7 +2,7 @@ package com.nec.colvector
 
 import com.nec.cache.VeColColumnarVector
 import com.nec.spark.agile.core._
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.{VeAsyncResult, VeProcess, VeProcessMetrics}
 import com.nec.vectorengine.{VeProcess => NewVeProcess}
 import org.apache.spark.sql.vectorized.ColumnVector
@@ -42,7 +42,7 @@ final case class VeColVector private[colvector] (
   }
 
   def toBytePointersAsync()(implicit process: VeProcess): Seq[VeAsyncResult[BytePointer]] = {
-    import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+   import com.nec.util.CallContextOps._
     buffers.zip(bufferSizes).map { case (start, size) =>
       val bp = new BytePointer(size)
       val handle = process.getAsync(bp, start, size)
@@ -105,7 +105,7 @@ final case class VeColVector private[colvector] (
 
   def free()(implicit dsource: VeColVectorSource,
              process: VeProcess,
-             context: OriginalCallingContext): Unit = {
+             context: CallContext): Unit = {
     if (memoryFreed) {
       logger.warn(s"[VE MEMORY ${container}] double free called!")
 

--- a/src/main/scala/com/nec/native/CompiledVeFunction.scala
+++ b/src/main/scala/com/nec/native/CompiledVeFunction.scala
@@ -3,7 +3,7 @@ package com.nec.native
 import com.nec.colvector.{VeColBatch, VeColVector, VeBatchOfBatches}
 import com.nec.spark.SparkCycloneDriverPlugin
 import com.nec.spark.agile.core.{CFunction2, CVector}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 
 import java.nio.file.Paths
 import scala.reflect.ClassTag
@@ -21,7 +21,7 @@ case class CompiledVeFunction(func: CFunction2, outputs: List[CVector], @transie
     }
   }
 
-  def evalFunction(batch: VeColBatch)(implicit ctx: OriginalCallingContext): VeColBatch = {
+  def evalFunction(batch: VeColBatch)(implicit ctx: CallContext): VeColBatch = {
     import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
     import com.nec.spark.SparkCycloneExecutorPlugin.source
 
@@ -31,7 +31,7 @@ case class CompiledVeFunction(func: CFunction2, outputs: List[CVector], @transie
     res
   }
 
-  def evalFunctionOnBatch(batches: Iterator[VeColBatch])(implicit ctx: OriginalCallingContext): Iterator[VeColBatch] = {
+  def evalFunctionOnBatch(batches: Iterator[VeColBatch])(implicit ctx: CallContext): Iterator[VeColBatch] = {
     batches.map { batch =>
       evalFunction(batch)
     }
@@ -39,7 +39,7 @@ case class CompiledVeFunction(func: CFunction2, outputs: List[CVector], @transie
 
   def evalGrouping[K: ClassTag](
     batchOfBatches: VeBatchOfBatches
-  )(implicit ctx: OriginalCallingContext): Seq[(K, List[VeColVector])] = {
+  )(implicit ctx: CallContext): Seq[(K, List[VeColVector])] = {
     import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
     import com.nec.spark.SparkCycloneExecutorPlugin.source
 
@@ -52,7 +52,7 @@ case class CompiledVeFunction(func: CFunction2, outputs: List[CVector], @transie
 
   def evalMultiInFunction(
     batchOfBatches: VeBatchOfBatches
-  )(implicit ctx: OriginalCallingContext): List[VeColVector] = {
+  )(implicit ctx: CallContext): List[VeColVector] = {
     import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
     import com.nec.spark.SparkCycloneExecutorPlugin.source
 
@@ -66,7 +66,7 @@ case class CompiledVeFunction(func: CFunction2, outputs: List[CVector], @transie
   def evalJoinFunction(
     leftBatchOfBatches: VeBatchOfBatches,
     rightBatchOfBatches: VeBatchOfBatches
-  )(implicit ctx: OriginalCallingContext): List[VeColVector] = {
+  )(implicit ctx: CallContext): List[VeColVector] = {
     import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
     import com.nec.spark.SparkCycloneExecutorPlugin.source
 

--- a/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
+++ b/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
@@ -19,8 +19,8 @@
  */
 package com.nec.spark
 
+import com.nec.cache.VeColBatchesCache
 import com.nec.colvector.{VeColBatch, VeColVector, VeColVectorSource}
-
 import com.nec.ve.VeProcess.LibraryReference
 import com.nec.ve.{VeProcess, VeProcessMetrics}
 import com.nec.util.CallContext
@@ -88,7 +88,7 @@ object SparkCycloneExecutorPlugin extends LazyLogging {
   var DefaultVeNodeId = 0
   var NodeCount = 1
 
-  def totalVeCores(): Int = {
+  def totalVeCores: Int = {
     NodeCount * 8
   }
 
@@ -97,77 +97,15 @@ object SparkCycloneExecutorPlugin extends LazyLogging {
     new ProcessExecutorMetrics(AllocationTracker.simple, pluginContext.metricRegistry)
   }
 
-  // var theMetrics: ProcessExecutorMetrics = _
-
-  // object ImplicitMetrics {
-  //   implicit def veMetrics: VeProcessMetrics = theMetrics
-  // }
-
   var CleanUpCache: Boolean = true
 
-  @transient private val cachedBatches: mutable.Map[String, VeColBatch] = mutable.HashMap.empty
-
-  @transient private val cachedCols: mutable.Map[String, VeColVector] = mutable.HashMap.empty
-
-  private def cleanCache()(implicit context: CallContext): Unit = {
-    cachedBatches.toList.foreach { colBatch =>
-      cachedBatches.remove(colBatch._1)
-      colBatch._2.columns.zipWithIndex.foreach { case (_, i) =>
-        freeCachedCol(s"${colBatch._1}-${i}")
-      }
-    }
-  }
-
-  def freeCachedCol(
-    col: String
-  )(implicit context: CallContext): Unit = {
-    if (cachedCols.contains(col)) {
-      cachedCols(col).free()
-      cachedCols.remove(col)
-    }
-  }
-
-  def containsCachedBatch(name: String): Boolean = cachedBatches.contains(name)
-  def getCachedBatch(name: String): VeColBatch = cachedBatches(name)
-
-  def registerCachedBatch(name: String, cb: VeColBatch): Unit = {
-    cachedBatches(name) = cb
-
-    cb.columns.zipWithIndex.foreach { case (col, i) =>
-      cachedCols(s"$name-$i") = col
-    }
-  }
-
-
-  def cleanUpIfNotCached(
-    veColBatch: VeColBatch
-  )(implicit context: CallContext): Unit = {
-    if (cachedBatches.values.contains(veColBatch)) {
-      logger.trace(
-        s"Data at ${
-          veColBatch.columns
-            .map(_.container)
-        } will not be cleaned up as it's cached (${context.fullName.value}#${context.line.value})"
-      )
-    } else {
-      val (cached, notCached) = veColBatch.columns.partition(cachedCols.values.contains)
-      logger.trace(s"Will clean up data for ${
-        cached
-          .map(_.buffers)
-      }, and not clean up for ${notCached.map(_.allocations)}")
-      notCached.foreach(_.free())
-    }
-  }
+  @transient val batchesCache = new VeColBatchesCache
 }
 
 class SparkCycloneExecutorPlugin extends ExecutorPlugin with Logging with LazyLogging {
   import com.nec.spark.SparkCycloneExecutorPlugin._
 
   override def init(ctx: PluginContext, extraConf: util.Map[String, String]): Unit = {
-    // SparkCycloneExecutorPlugin.theMetrics =
-    //   new ProcessExecutorMetrics(AllocationTracker.simple(), ctx.metricRegistry())
-    //SparkEnv.get.metricsSystem.registerSource(SparkCycloneExecutorPlugin.metrics)
-
     val resources = ctx.resources()
 
     logger.info(s"Executor has the following resources available => ${resources}")
@@ -221,7 +159,7 @@ class SparkCycloneExecutorPlugin extends ExecutorPlugin with Logging with LazyLo
     if (SparkCycloneExecutorPlugin.CleanUpCache) {
       import com.nec.util.CallContextOps._
 
-      SparkCycloneExecutorPlugin.cleanCache()
+      SparkCycloneExecutorPlugin.batchesCache.cleanup
     }
 
     import com.nec.spark.SparkCycloneExecutorPlugin.{CloseAutomatically, closeProcAndCtx}

--- a/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
+++ b/src/main/scala/com/nec/spark/agile/CFunctionGeneration.scala
@@ -230,20 +230,20 @@ object CFunctionGeneration {
     condition: Condition
   )
 
-  def allocateFrom(cVector: CVector)(implicit bufferAllocator: BufferAllocator): FieldVector =
+  def allocateFrom(cVector: CVector)(implicit allocator: BufferAllocator): FieldVector =
     cVector.veType match {
       case VeString =>
-        new VarCharVector(cVector.name, bufferAllocator)
+        new VarCharVector(cVector.name, allocator)
       case VeNullableDouble =>
-        new Float8Vector(cVector.name, bufferAllocator)
+        new Float8Vector(cVector.name, allocator)
       case VeNullableFloat =>
-        new Float8Vector(cVector.name, bufferAllocator)
+        new Float8Vector(cVector.name, allocator)
       case VeNullableInt =>
-        new IntVector(cVector.name, bufferAllocator)
+        new IntVector(cVector.name, allocator)
       case VeNullableLong =>
-        new BigIntVector(cVector.name, bufferAllocator)
+        new BigIntVector(cVector.name, allocator)
       case VeNullableShort =>
-        new SmallIntVector(cVector.name, bufferAllocator)
+        new SmallIntVector(cVector.name, allocator)
     }
 
   val KeyHeaders = CodeLines.from(

--- a/src/main/scala/com/nec/spark/agile/groupby/GroupByPartialGenerator.scala
+++ b/src/main/scala/com/nec/spark/agile/groupby/GroupByPartialGenerator.scala
@@ -30,7 +30,7 @@ final case class GroupByPartialGenerator(
   computedGroupingKeys: List[(GroupingKey, Either[StringReference, TypedCExpression2])],
   computedProjections: List[(StagedProjection, Either[StringReference, TypedCExpression2])],
   stringVectorComputations: List[StringHoleEvaluation],
-  nBuckets: Int = SparkCycloneExecutorPlugin.totalVeCores()
+  nBuckets: Int = SparkCycloneExecutorPlugin.totalVeCores
 ) {
   import finalGenerator._
   import stagedGroupBy._

--- a/src/main/scala/com/nec/spark/planning/DataCleanup.scala
+++ b/src/main/scala/com/nec/spark/planning/DataCleanup.scala
@@ -1,6 +1,6 @@
 package com.nec.spark.planning
 
-import com.nec.spark.SparkCycloneExecutorPlugin.cleanUpIfNotCached
+import com.nec.spark.SparkCycloneExecutorPlugin
 import com.nec.colvector.VeColBatch
 import com.nec.ve.VeProcess
 import com.nec.util.CallContext
@@ -35,7 +35,7 @@ object DataCleanup extends LazyLogging {
         s"Requesting to clean up data of ${veColBatch.columns
           .map(_.container)} at ${processId} by ${context.fullName.value}#${context.line.value}, directed by ${parent.getCanonicalName}"
       )
-      cleanUpIfNotCached(veColBatch)
+      SparkCycloneExecutorPlugin.batchesCache.cleanupIfNotCached(veColBatch)
     }
   }
 

--- a/src/main/scala/com/nec/spark/planning/DataCleanup.scala
+++ b/src/main/scala/com/nec/spark/planning/DataCleanup.scala
@@ -3,7 +3,7 @@ package com.nec.spark.planning
 import com.nec.spark.SparkCycloneExecutorPlugin.cleanUpIfNotCached
 import com.nec.colvector.VeColBatch
 import com.nec.ve.VeProcess
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.colvector.VeColVectorSource
 import com.typesafe.scalalogging.LazyLogging
 
@@ -11,7 +11,7 @@ trait DataCleanup {
   def cleanup(veColBatch: VeColBatch)(implicit
     veProcess: VeProcess,
     processId: VeColVectorSource,
-    originalCallingContext: OriginalCallingContext
+    context: CallContext
   ): Unit
 }
 object DataCleanup extends LazyLogging {
@@ -19,21 +19,21 @@ object DataCleanup extends LazyLogging {
     override def cleanup(veColBatch: VeColBatch)(implicit
       veProcess: VeProcess,
       processId: VeColVectorSource,
-      originalCallingContext: OriginalCallingContext
+      context: CallContext
     ): Unit = logger.trace(
       s"Not cleaning up data at ${processId} / ${veColBatch.columns
-        .map(_.container)} - from ${originalCallingContext.fullName.value}#${originalCallingContext.line.value}, directed by ${parent.getCanonicalName}"
+        .map(_.container)} - from ${context.fullName.value}#${context.line.value}, directed by ${parent.getCanonicalName}"
     )
   }
   def cleanup(parent: Class[_]): DataCleanup = new DataCleanup {
     override def cleanup(veColBatch: VeColBatch)(implicit
       veProcess: VeProcess,
       processId: VeColVectorSource,
-      originalCallingContext: OriginalCallingContext
+      context: CallContext
     ): Unit = {
       logger.trace(
         s"Requesting to clean up data of ${veColBatch.columns
-          .map(_.container)} at ${processId} by ${originalCallingContext.fullName.value}#${originalCallingContext.line.value}, directed by ${parent.getCanonicalName}"
+          .map(_.container)} at ${processId} by ${context.fullName.value}#${context.line.value}, directed by ${parent.getCanonicalName}"
       )
       cleanUpIfNotCached(veColBatch)
     }

--- a/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
+++ b/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
@@ -64,7 +64,7 @@ object VERewriteStrategy {
   val InputPrefix: String = "input_"
   val GroupPrefix: String = "group_"
 
-  val HashExchangeBuckets: Int = SparkCycloneExecutorPlugin.totalVeCores()
+  val HashExchangeBuckets: Int = SparkCycloneExecutorPlugin.totalVeCores
 }
 
 final case class VERewriteStrategy(options: VeRewriteStrategyOptions)

--- a/src/main/scala/com/nec/spark/planning/aggregation/VeFlattenPartition.scala
+++ b/src/main/scala/com/nec/spark/planning/aggregation/VeFlattenPartition.scala
@@ -3,7 +3,7 @@ package com.nec.spark.planning.aggregation
 import com.nec.colvector.{VeBatchOfBatches, VeColBatch}
 import com.nec.spark.SparkCycloneExecutorPlugin.{ImplicitMetrics, source, veProcess}
 import com.nec.spark.planning.{PlanCallsVeFunction, PlanMetrics, SupportsVeColBatch, VeFunction}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
@@ -44,7 +44,7 @@ case class VeFlattenPartition(flattenFunction: VeFunction, child: SparkPlan)
                   case Nil        => Iterator.empty
                   case _ =>
                     Iterator {
-                      import OriginalCallingContext.Automatic._
+                      import com.nec.util.CallContextOps._
 
                       withInvocationMetrics(VE){
                         VeColBatch(

--- a/src/main/scala/com/nec/spark/planning/aggregation/VeFlattenPartition.scala
+++ b/src/main/scala/com/nec/spark/planning/aggregation/VeFlattenPartition.scala
@@ -1,7 +1,7 @@
 package com.nec.spark.planning.aggregation
 
 import com.nec.colvector.{VeBatchOfBatches, VeColBatch}
-import com.nec.spark.SparkCycloneExecutorPlugin.{ImplicitMetrics, source, veProcess}
+import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess, veMetrics}
 import com.nec.spark.planning.{PlanCallsVeFunction, PlanMetrics, SupportsVeColBatch, VeFunction}
 import com.nec.util.CallContext
 import com.typesafe.scalalogging.LazyLogging
@@ -48,7 +48,7 @@ case class VeFlattenPartition(flattenFunction: VeFunction, child: SparkPlan)
 
                       withInvocationMetrics(VE){
                         VeColBatch(
-                          try ImplicitMetrics.processMetrics.measureRunningTime(
+                          try veMetrics.measureRunningTime(
                             veProcess.executeMultiIn(
                               libraryReference = libRefExchange,
                               functionName = flattenFunction.functionName,
@@ -56,7 +56,7 @@ case class VeFlattenPartition(flattenFunction: VeFunction, child: SparkPlan)
                               results = flattenFunction.namedResults
                             )
                           )(
-                            ImplicitMetrics.processMetrics
+                            veMetrics
                               .registerFunctionCallTime(_, veFunction.functionName)
                           )
                           finally {

--- a/src/main/scala/com/nec/spark/planning/aggregation/VeHashExchangePlan.scala
+++ b/src/main/scala/com/nec/spark/planning/aggregation/VeHashExchangePlan.scala
@@ -1,7 +1,7 @@
 package com.nec.spark.planning.aggregation
 
 import com.nec.colvector.VeColBatch
-import com.nec.spark.SparkCycloneExecutorPlugin.{ImplicitMetrics, source}
+import com.nec.spark.SparkCycloneExecutorPlugin.{veMetrics, source}
 import com.nec.spark.planning._
 import com.nec.util.CallContext
 import com.nec.ve.VeRDDOps.RichKeyedRDDL
@@ -37,18 +37,18 @@ case class VeHashExchangePlan(exchangeFunction: VeFunction, child: SparkPlan)
           collectBatchMetrics(OUTPUT, veColBatches.flatMap { veColBatch =>
             collectBatchMetrics(INPUT, veColBatch)
             withInvocationMetrics(BATCH){
-              import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
+              import com.nec.spark.SparkCycloneExecutorPlugin.{veProcess, veMetrics}
               try {
                 logger.debug(s"Mapping ${veColBatch} for exchange")
                 val multiBatches = withInvocationMetrics(VE){
-                  ImplicitMetrics.processMetrics.measureRunningTime(
+                  veMetrics.measureRunningTime(
                     veProcess.executeMulti(
                       libraryReference = libRefExchange,
                       functionName = exchangeFunction.functionName,
                       cols = veColBatch.columns.toList,
                       results = exchangeFunction.namedResults
                     )
-                  )(ImplicitMetrics.processMetrics.registerFunctionCallTime(_, veFunction.functionName))
+                  )(veMetrics.registerFunctionCallTime(_, veFunction.functionName))
                 }
                 logger.debug(s"Mapped to ${multiBatches} completed.")
 

--- a/src/main/scala/com/nec/spark/planning/aggregation/VeHashExchangePlan.scala
+++ b/src/main/scala/com/nec/spark/planning/aggregation/VeHashExchangePlan.scala
@@ -3,7 +3,7 @@ package com.nec.spark.planning.aggregation
 import com.nec.colvector.VeColBatch
 import com.nec.spark.SparkCycloneExecutorPlugin.{ImplicitMetrics, source}
 import com.nec.spark.planning._
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.VeRDDOps.RichKeyedRDDL
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.rdd.RDD
@@ -18,7 +18,7 @@ case class VeHashExchangePlan(exchangeFunction: VeFunction, child: SparkPlan)
   with PlanMetrics
   with SupportsKeyedVeColBatch {
 
-  import OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
   import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
 
   override lazy val metrics = invocationMetrics(PLAN) ++ invocationMetrics(BATCH) ++ invocationMetrics(VE) ++ batchMetrics(INPUT) ++ batchMetrics(OUTPUT)

--- a/src/main/scala/com/nec/spark/planning/plans/SparkToVectorEnginePlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/SparkToVectorEnginePlan.scala
@@ -7,7 +7,7 @@ import com.nec.colvector.VeColBatch
 import com.nec.spark.SparkCycloneExecutorPlugin
 import com.nec.spark.planning._
 import com.nec.ve.VeKernelCompiler
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.spark.TaskContext
@@ -46,7 +46,7 @@ case class SparkToVectorEnginePlan(childPlan: SparkPlan, parentVeFunction: VeFun
 
     // Instead of creating a new config we are reusing columnBatchSize. In the future if we do
     // combine with some of the Arrow conversion tools we will need to unify some of the configs.
-    implicit val arrowEncodingSettings = ArrowEncodingSettings.fromConf(conf)(sparkContext)
+    implicit val encoding = ArrowEncodingSettings.fromConf(conf)(sparkContext)
 
     if (child.supportsColumnar) {
       child
@@ -57,7 +57,7 @@ case class SparkToVectorEnginePlan(childPlan: SparkPlan, parentVeFunction: VeFun
             implicit val allocator: BufferAllocator = ArrowUtilsExposed.rootAllocator
               .newChildAllocator(s"Writer for partial collector (ColBatch-->Arrow)", 0, Long.MaxValue)
             TaskContext.get().addTaskCompletionListener[Unit](_ => allocator.close())
-            import OriginalCallingContext.Automatic._
+            import com.nec.util.CallContextOps._
 
             // Transfer entire partition, i.e. all batches, with a single transfer.
             // Steps:
@@ -114,7 +114,7 @@ case class SparkToVectorEnginePlan(childPlan: SparkPlan, parentVeFunction: VeFun
           implicit val allocator: BufferAllocator = ArrowUtilsExposed.rootAllocator
             .newChildAllocator(s"Writer for partial collector (Arrow)", 0, Long.MaxValue)
           TaskContext.get().addTaskCompletionListener[Unit](_ => allocator.close())
-          import OriginalCallingContext.Automatic._
+          import com.nec.util.CallContextOps._
 
           collectBatchMetrics(OUTPUT, DualMode.unwrapPossiblyDualToVeColBatches(
             possiblyDualModeInternalRows = internalRows,

--- a/src/main/scala/com/nec/spark/planning/plans/SparkToVectorEnginePlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/SparkToVectorEnginePlan.scala
@@ -108,7 +108,6 @@ case class SparkToVectorEnginePlan(childPlan: SparkPlan, parentVeFunction: VeFun
     } else {
       child.execute().mapPartitions { internalRows =>
         import SparkCycloneExecutorPlugin._
-        import ImplicitMetrics._
 
         withInvocationMetrics(PLAN){
           implicit val allocator: BufferAllocator = ArrowUtilsExposed.rootAllocator

--- a/src/main/scala/com/nec/spark/planning/plans/VeAmplifyBatchesPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VeAmplifyBatchesPlan.scala
@@ -4,7 +4,7 @@ import com.nec.cache.ArrowEncodingSettings
 import com.nec.colvector.{VeBatchOfBatches, VeColBatch}
 import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
 import com.nec.spark.planning.{PlanCallsVeFunction, PlanMetrics, SupportsVeColBatch, VeFunction}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -41,7 +41,7 @@ case class VeAmplifyBatchesPlan(amplifyFunction: VeFunction, child: SparkPlan)
               .map {
                 case inputBatches if inputBatches.size == 1 => inputBatches.head
                 case inputBatches =>
-                  import OriginalCallingContext.Automatic._
+                  import com.nec.util.CallContextOps._
                   try {
                       val res = withInvocationMetrics(VE) {
                         VeColBatch(

--- a/src/main/scala/com/nec/spark/planning/plans/VeFetchFromCachePlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VeFetchFromCachePlan.scala
@@ -43,10 +43,8 @@ case class VeFetchFromCachePlan(child: SparkPlan, requiresCleanup: Boolean)
 
         withInvocationMetrics(BATCH){
           val res = VeColBatch(unwrapBatch(cb).map {
-            case Left(veColVector)         => veColVector
-            case Right(baColVector) =>
-              import ImplicitMetrics._
-              baColVector.toVeColVector
+            case Left(veColVector)  => veColVector
+            case Right(baColVector) => baColVector.toVeColVector
           })
           logger.debug(s"Finished mapping ColumnarBatch ${cb} to VE: ${res}")
           collectBatchMetrics(OUTPUT, res)

--- a/src/main/scala/com/nec/spark/planning/plans/VeFetchFromCachePlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VeFetchFromCachePlan.scala
@@ -3,7 +3,7 @@ package com.nec.spark.planning.plans
 import com.nec.cache.{CycloneCacheBase, VeColColumnarVector}
 import com.nec.colvector.{ByteArrayColVector, VeColBatch, VeColVector}
 import com.nec.spark.planning.{DataCleanup, PlanMetrics, SupportsVeColBatch}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -37,7 +37,7 @@ case class VeFetchFromCachePlan(child: SparkPlan, requiresCleanup: Boolean)
       .executeColumnar()
       .map(cb => {
         logger.debug(s"Mapping ColumnarBatch ${cb} to VE")
-        import OriginalCallingContext.Automatic._
+        import com.nec.util.CallContextOps._
         import com.nec.spark.SparkCycloneExecutorPlugin._
         collectBatchMetrics(INPUT, cb)
 

--- a/src/main/scala/com/nec/spark/planning/plans/VeFinalAggregate.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VeFinalAggregate.scala
@@ -1,7 +1,7 @@
 package com.nec.spark.planning.plans
 
 import com.nec.colvector.VeColBatch
-import com.nec.spark.SparkCycloneExecutorPlugin.{ImplicitMetrics, source}
+import com.nec.spark.SparkCycloneExecutorPlugin.{veMetrics, source}
 import com.nec.spark.planning.{PlanCallsVeFunction, PlanMetrics, SupportsVeColBatch, VeFunction}
 import com.nec.util.CallContext
 import com.typesafe.scalalogging.LazyLogging
@@ -40,18 +40,18 @@ case class VeFinalAggregate(
             logger.debug(s"Preparing to final-aggregate a batch... ${veColBatch}")
             collectBatchMetrics(INPUT, veColBatch)
             withInvocationMetrics(BATCH){
-              import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
+              import com.nec.spark.SparkCycloneExecutorPlugin.{veProcess, veMetrics}
               collectBatchMetrics(OUTPUT, VeColBatch({
                 import com.nec.util.CallContextOps._
                 withInvocationMetrics(VE){
-                  try ImplicitMetrics.processMetrics.measureRunningTime(
+                  try veMetrics.measureRunningTime(
                     veProcess.execute(
                       libraryReference = libRef,
                       functionName = finalFunction.functionName,
                       cols = veColBatch.columns.toList,
                       results = finalFunction.namedResults
                     )
-                  )(ImplicitMetrics.processMetrics.registerFunctionCallTime(_, veFunction.functionName))
+                  )(veMetrics.registerFunctionCallTime(_, veFunction.functionName))
                   finally {
                     logger.debug("Completed a final-aggregate of  a batch...")
                     child.asInstanceOf[SupportsVeColBatch].dataCleanup.cleanup(veColBatch)

--- a/src/main/scala/com/nec/spark/planning/plans/VeFinalAggregate.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VeFinalAggregate.scala
@@ -3,7 +3,7 @@ package com.nec.spark.planning.plans
 import com.nec.colvector.VeColBatch
 import com.nec.spark.SparkCycloneExecutorPlugin.{ImplicitMetrics, source}
 import com.nec.spark.planning.{PlanCallsVeFunction, PlanMetrics, SupportsVeColBatch, VeFunction}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.{Attribute, NamedExpression}
@@ -42,7 +42,7 @@ case class VeFinalAggregate(
             withInvocationMetrics(BATCH){
               import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
               collectBatchMetrics(OUTPUT, VeColBatch({
-                import OriginalCallingContext.Automatic._
+                import com.nec.util.CallContextOps._
                 withInvocationMetrics(VE){
                   try ImplicitMetrics.processMetrics.measureRunningTime(
                     veProcess.execute(

--- a/src/main/scala/com/nec/spark/planning/plans/VeFlattenPartition.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VeFlattenPartition.scala
@@ -3,7 +3,7 @@ package com.nec.spark.planning.plans
 import com.nec.colvector.{VeBatchOfBatches, VeColBatch}
 import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
 import com.nec.spark.planning.{PlanCallsVeFunction, PlanMetrics, SupportsVeColBatch, VeFunction}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -42,7 +42,7 @@ case class VeFlattenPartition(flattenFunction: VeFunction, child: SparkPlan)
                   case one :: Nil => Iterator(one)
                   case Nil        => Iterator.empty
                   case _ =>
-                    import OriginalCallingContext.Automatic._
+                    import com.nec.util.CallContextOps._
                     Iterator {
                       VeColBatch(try {
                         val res = withInvocationMetrics(VE){

--- a/src/main/scala/com/nec/spark/planning/plans/VeOneStageEvaluationPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VeOneStageEvaluationPlan.scala
@@ -22,7 +22,7 @@ package com.nec.spark.planning.plans
 import com.nec.colvector.VeColBatch
 import com.nec.spark.SparkCycloneExecutorPlugin.{ImplicitMetrics, source, veProcess}
 import com.nec.spark.planning.{PlanCallsVeFunction, PlanMetrics, SupportsVeColBatch, VeFunction}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
@@ -59,7 +59,7 @@ final case class VeOneStageEvaluationPlan(
       .mapPartitions { veColBatches =>
         withVeLibrary { libRef =>
           logger.info(s"Will map batches with function ${veFunction}")
-          import OriginalCallingContext.Automatic._
+          import com.nec.util.CallContextOps._
 
           incrementInvocations(PLAN)
           veColBatches.map { inputBatch =>

--- a/src/main/scala/com/nec/spark/planning/plans/VeOneStageEvaluationPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VeOneStageEvaluationPlan.scala
@@ -20,7 +20,7 @@
 package com.nec.spark.planning.plans
 
 import com.nec.colvector.VeColBatch
-import com.nec.spark.SparkCycloneExecutorPlugin.{ImplicitMetrics, source, veProcess}
+import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess, veMetrics}
 import com.nec.spark.planning.{PlanCallsVeFunction, PlanMetrics, SupportsVeColBatch, VeFunction}
 import com.nec.util.CallContext
 import com.typesafe.scalalogging.LazyLogging
@@ -68,7 +68,7 @@ final case class VeOneStageEvaluationPlan(
               try {
                 logger.debug(s"Mapping batch ${inputBatch}")
                 val cols = withInvocationMetrics(VE){
-                  ImplicitMetrics.processMetrics.measureRunningTime(
+                  veMetrics.measureRunningTime(
                     veProcess.execute(
                       libraryReference = libRef,
                       functionName = veFunction.functionName,
@@ -76,7 +76,7 @@ final case class VeOneStageEvaluationPlan(
                       results = veFunction.namedResults
                     )
                   )(
-                    ImplicitMetrics.processMetrics
+                    veMetrics
                       .registerFunctionCallTime(_, veFunction.functionName)
                   )
                 }

--- a/src/main/scala/com/nec/spark/planning/plans/VePartialAggregate.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VePartialAggregate.scala
@@ -3,7 +3,7 @@ package com.nec.spark.planning.plans
 import com.nec.colvector.VeColBatch
 import com.nec.spark.SparkCycloneExecutorPlugin.{ImplicitMetrics, source, veProcess}
 import com.nec.spark.planning.{PlanCallsVeFunction, PlanMetrics, SupportsVeColBatch, VeFunction}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.VeRDDOps.RichKeyedRDDL
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.rdd.RDD
@@ -28,7 +28,7 @@ case class VePartialAggregate(
   override lazy val metrics = invocationMetrics(PLAN) ++ invocationMetrics(BATCH) ++ invocationMetrics(VE) ++ batchMetrics(INPUT) ++ batchMetrics(OUTPUT)
 
   override def executeVeColumnar(): RDD[VeColBatch] = {
-    import OriginalCallingContext.Automatic._
+    import com.nec.util.CallContextOps._
     initializeMetrics()
 
     child

--- a/src/main/scala/com/nec/spark/planning/plans/VePartialAggregate.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VePartialAggregate.scala
@@ -1,7 +1,7 @@
 package com.nec.spark.planning.plans
 
 import com.nec.colvector.VeColBatch
-import com.nec.spark.SparkCycloneExecutorPlugin.{ImplicitMetrics, source, veProcess}
+import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess, veMetrics}
 import com.nec.spark.planning.{PlanCallsVeFunction, PlanMetrics, SupportsVeColBatch, VeFunction}
 import com.nec.util.CallContext
 import com.nec.ve.VeRDDOps.RichKeyedRDDL
@@ -47,7 +47,7 @@ case class VePartialAggregate(
 
               try {
                 val result = withInvocationMetrics(VE) {
-                  ImplicitMetrics.processMetrics.measureRunningTime(
+                  veMetrics.measureRunningTime(
                     veProcess.executeMulti(
                       libraryReference = libRef,
                       functionName = partialFunction.functionName,
@@ -55,7 +55,7 @@ case class VePartialAggregate(
                       results = partialFunction.namedResults
                     )
                   )(
-                    ImplicitMetrics.processMetrics
+                    veMetrics
                       .registerFunctionCallTime(_, veFunction.functionName)
                   )
                 }

--- a/src/main/scala/com/nec/spark/planning/plans/VeProjectEvaluationPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VeProjectEvaluationPlan.scala
@@ -21,7 +21,7 @@ package com.nec.spark.planning.plans
 
 import com.nec.colvector.{VeColBatch, VeColVector}
 import com.nec.spark.SparkCycloneExecutorPlugin
-import com.nec.spark.SparkCycloneExecutorPlugin.{ImplicitMetrics, source, veProcess}
+import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess, veMetrics}
 import com.nec.spark.planning.{PlanCallsVeFunction, PlanMetrics, SupportsVeColBatch, VeFunction}
 import com.nec.util.CallContext
 import com.typesafe.scalalogging.LazyLogging
@@ -79,7 +79,7 @@ final case class VeProjectEvaluationPlan(
                   if (canPassThroughall) Nil
                   else {
                     withInvocationMetrics(VE){
-                      ImplicitMetrics.processMetrics.measureRunningTime(
+                      veMetrics.measureRunningTime(
                         veProcess.execute(
                           libraryReference = libRef,
                           functionName = veFunction.functionName,
@@ -87,7 +87,7 @@ final case class VeProjectEvaluationPlan(
                           results = veFunction.namedResults
                         )
                       )(
-                        ImplicitMetrics.processMetrics
+                        veMetrics
                           .registerFunctionCallTime(_, veFunction.functionName)
                       )
                     }

--- a/src/main/scala/com/nec/spark/planning/plans/VeProjectEvaluationPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VeProjectEvaluationPlan.scala
@@ -23,7 +23,7 @@ import com.nec.colvector.{VeColBatch, VeColVector}
 import com.nec.spark.SparkCycloneExecutorPlugin
 import com.nec.spark.SparkCycloneExecutorPlugin.{ImplicitMetrics, source, veProcess}
 import com.nec.spark.planning.{PlanCallsVeFunction, PlanMetrics, SupportsVeColBatch, VeFunction}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
@@ -70,7 +70,7 @@ final case class VeProjectEvaluationPlan(
           withInvocationMetrics(BATCH){
             veColBatches.map { veColBatch =>
               collectBatchMetrics(INPUT, veColBatch)
-              import OriginalCallingContext.Automatic._
+              import com.nec.util.CallContextOps._
               import SparkCycloneExecutorPlugin.veProcess
               try {
                 val canPassThroughall = columnIndicesToPass.size == outputExpressions.size

--- a/src/main/scala/com/nec/spark/planning/plans/VectorEngineJoinPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VectorEngineJoinPlan.scala
@@ -56,7 +56,7 @@ case class VectorEngineJoinPlan(
               val rightBatchesBatch = VeBatchOfBatches(rightBatches)
 
               withVeLibrary { libRefJoin =>
-                import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+                import com.nec.util.CallContextOps._
                 val outputBatch = try {
                   withInvocationMetrics(VE){
                     ImplicitMetrics.processMetrics.measureRunningTime {

--- a/src/main/scala/com/nec/spark/planning/plans/VectorEngineJoinPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VectorEngineJoinPlan.scala
@@ -1,7 +1,6 @@
 package com.nec.spark.planning.plans
 
 import com.nec.colvector.{VeBatchOfBatches, VeColBatch}
-import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics
 import com.nec.spark.planning._
 import com.nec.ve.VeRDDOps
 import com.typesafe.scalalogging.LazyLogging
@@ -35,7 +34,7 @@ case class VectorEngineJoinPlan(
         cleanUpInput = true
       )
       .mapPartitions { tupleIterator =>
-        import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
+        import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess, veMetrics}
 
         withInvocationMetrics(PLAN){
           val (leftBatchesIter, rightBatchesIter) = tupleIterator.fold((Seq.empty, Seq.empty)){ case ((accLeft, accRight), (left, right)) =>
@@ -59,7 +58,7 @@ case class VectorEngineJoinPlan(
                 import com.nec.util.CallContextOps._
                 val outputBatch = try {
                   withInvocationMetrics(VE){
-                    ImplicitMetrics.processMetrics.measureRunningTime {
+                    veMetrics.measureRunningTime {
                       veProcess.executeJoin(
                         libraryReference = libRefJoin,
                         functionName = joinFunction.functionName,
@@ -67,7 +66,7 @@ case class VectorEngineJoinPlan(
                         right = rightBatchesBatch,
                         results = joinFunction.namedResults
                       )
-                    }(ImplicitMetrics.processMetrics.registerFunctionCallTime(_, veFunction.functionName))
+                    }(veMetrics.registerFunctionCallTime(_, veFunction.functionName))
                   }
                 } finally {
                   leftBatches.foreach(dataCleanup.cleanup(_))

--- a/src/main/scala/com/nec/spark/planning/plans/VectorEngineToSparkPlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VectorEngineToSparkPlan.scala
@@ -3,7 +3,7 @@ package com.nec.spark.planning.plans
 import com.nec.spark.SparkCycloneExecutorPlugin
 import com.nec.spark.planning.ArrowBatchToUnsafeRows.mapBatchToRow
 import com.nec.spark.planning.{PlanMetrics, SupportsVeColBatch}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.spark.rdd.RDD
@@ -45,7 +45,7 @@ case class VectorEngineToSparkPlan(override val child: SparkPlan)
           .newChildAllocator(s"Writer for partial collector", 0, Long.MaxValue)
 
         iterator.map { veColBatch =>
-          import OriginalCallingContext.Automatic._
+          import com.nec.util.CallContextOps._
           collectBatchMetrics(INPUT, veColBatch)
           withInvocationMetrics(BATCH){
             try {

--- a/src/main/scala/com/nec/spark/serialization/ArrowColumnarBatchDeSerializer.scala
+++ b/src/main/scala/com/nec/spark/serialization/ArrowColumnarBatchDeSerializer.scala
@@ -24,7 +24,7 @@ object ArrowColumnarBatchDeSerializer extends Serializable {
 
   def deserializeIterator(
     iterator: Iterator[Array[Byte]]
-  )(implicit bufferAllocator: BufferAllocator): Option[ColBatchWithReader] = {
+  )(implicit allocator: BufferAllocator): Option[ColBatchWithReader] = {
     if (!iterator.hasNext) {
       Option.empty
     } else {
@@ -57,9 +57,9 @@ object ArrowColumnarBatchDeSerializer extends Serializable {
 
   def deserialize(
     arr: Array[Byte]
-  )(implicit bufferAllocator: BufferAllocator): ColBatchWithReader = {
+  )(implicit allocator: BufferAllocator): ColBatchWithReader = {
     val byteArrayInputStream = new ByteArrayInputStream(arr)
-    val arrowStreamReader = new ArrowStreamReader(byteArrayInputStream, bufferAllocator)
+    val arrowStreamReader = new ArrowStreamReader(byteArrayInputStream, allocator)
     arrowStreamReader.loadNextBatch()
     val arrowColumnVectors =
       arrowStreamReader.getVectorSchemaRoot.getFieldVectors.asScala.map(vec =>

--- a/src/main/scala/com/nec/ve/SequenceVeRDD.scala
+++ b/src/main/scala/com/nec/ve/SequenceVeRDD.scala
@@ -3,7 +3,7 @@ package com.nec.ve
 import com.nec.colvector.ArrayTConversions.ArrayTToBPCV
 import com.nec.colvector.VeColBatch
 import com.nec.native.CompiledVeFunction
-import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics.processMetrics
+import com.nec.spark.SparkCycloneExecutorPlugin.veMetrics
 import com.nec.spark.agile.core.CFunction2.CFunctionArgument.PointerPointer
 import com.nec.spark.agile.core.CFunction2.DefaultHeaders
 import com.nec.spark.agile.core.{CFunction2, CVector, VeNullableLong}

--- a/src/main/scala/com/nec/ve/SequenceVeRDD.scala
+++ b/src/main/scala/com/nec/ve/SequenceVeRDD.scala
@@ -56,7 +56,7 @@ object SequenceVeRDD {
 
     new SequenceVeRDD(rdd, rdd.mapPartitions { iter =>
       import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
 
       val part = Array[Long](iter.next)
       val colvec = part.toBytePointerColVector(s"seq-${part(0)}").toVeColVector

--- a/src/main/scala/com/nec/ve/VeAsyncResult.scala
+++ b/src/main/scala/com/nec/ve/VeAsyncResult.scala
@@ -1,13 +1,13 @@
 package com.nec.ve
 
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import org.bytedeco.veoffload.global.veo
 
 class VeAsyncResult[T](
   val process: VeProcess,
   val handles: Seq[Long],
   val fn: () => T)(
-  implicit val originalCallingContext: OriginalCallingContext
+  implicit val context: CallContext
 ) {
   lazy private val result: T = {
     handles.foreach{ handle =>
@@ -37,13 +37,13 @@ class VeAsyncResult[T](
 }
 
 object VeAsyncResult {
-  def apply[T](handle: Long)(fn: () => T)(implicit process: VeProcess, originalCallingContext: OriginalCallingContext): VeAsyncResult[T] = {
+  def apply[T](handle: Long)(fn: () => T)(implicit process: VeProcess, context: CallContext): VeAsyncResult[T] = {
     new VeAsyncResult[T](process, Seq(handle), fn)
   }
 
-  def apply[T](handles: Seq[Long])(fn: () => T)(implicit process: VeProcess, originalCallingContext: OriginalCallingContext): VeAsyncResult[T] = {
+  def apply[T](handles: Seq[Long])(fn: () => T)(implicit process: VeProcess, context: CallContext): VeAsyncResult[T] = {
     new VeAsyncResult[T](process, handles, fn)
   }
 
-  def empty()(implicit process: VeProcess, originalCallingContext: OriginalCallingContext): VeAsyncResult[Unit] = VeAsyncResult(Nil){ () =>}
+  def empty()(implicit process: VeProcess, context: CallContext): VeAsyncResult[Unit] = VeAsyncResult(Nil){ () =>}
 }

--- a/src/main/scala/com/nec/ve/VeConcatGroups.scala
+++ b/src/main/scala/com/nec/ve/VeConcatGroups.scala
@@ -58,7 +58,7 @@ class VeConcatGroups[K: universe.TypeTag, T: universe.TypeTag](
     concatInputs.mapPartitions { batches =>
       batches.map { case (key, veColBatch) =>
         import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
-       import com.nec.util.CallContextOps._
+        import com.nec.util.CallContextOps._
 
         val array = veColBatch.toCPUSeq[T]
         veColBatch.free()

--- a/src/main/scala/com/nec/ve/VeConcatGroups.scala
+++ b/src/main/scala/com/nec/ve/VeConcatGroups.scala
@@ -18,7 +18,7 @@ class VeConcatGroups[K: universe.TypeTag, T: universe.TypeTag](
 
   override def compute(split: Partition, context: TaskContext): Iterator[(K, Iterable[T])] = {
     import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
-    import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+   import com.nec.util.CallContextOps._
 
     val batches = concatInputs.iterator(split, context)
     batches.map { case (key, veColBatch) =>
@@ -40,7 +40,7 @@ class VeConcatGroups[K: universe.TypeTag, T: universe.TypeTag](
     val func = CompiledVeFunction(code.toCFunction, code.toVeFunction.namedResults, null)
 
     shuffled.mapPartitions { batchIter =>
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
       val batches = batchIter.toList
       if (batches.nonEmpty) {
         batches.groupBy(_._1).map { case (key, grouped) =>
@@ -58,7 +58,7 @@ class VeConcatGroups[K: universe.TypeTag, T: universe.TypeTag](
     concatInputs.mapPartitions { batches =>
       batches.map { case (key, veColBatch) =>
         import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
-        import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+       import com.nec.util.CallContextOps._
 
         val array = veColBatch.toCPUSeq[T]
         veColBatch.free()

--- a/src/main/scala/com/nec/ve/VeConcatRDD.scala
+++ b/src/main/scala/com/nec/ve/VeConcatRDD.scala
@@ -15,7 +15,7 @@ class VeConcatRDD[U: TypeTag, T: TypeTag](
 ) extends MappedVeRDD[U, T](rdd, func) {
   override def computeVe(): RDD[VeColBatch] = {
     rdd.inputs.mapPartitions { batches =>
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
       val batchesList = batches.toList
       if (batchesList.isEmpty) {
         Iterator()

--- a/src/main/scala/com/nec/ve/VeGroupByRDD.scala
+++ b/src/main/scala/com/nec/ve/VeGroupByRDD.scala
@@ -25,7 +25,7 @@ class VeGroupByRDD[G, T](
   def computeKeyedVe(): RDD[(G, VeColBatch)] = {
     implicit val g: ClassTag[G] = func.types.output.tag.asInstanceOf[ClassTag[G]]
     verdd.inputs.mapPartitions { batches =>
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
       val batchesList = batches.toList
       if (batchesList.isEmpty) {
         Nil.toIterator

--- a/src/main/scala/com/nec/ve/VeJoinRDD.scala
+++ b/src/main/scala/com/nec/ve/VeJoinRDD.scala
@@ -32,7 +32,7 @@ class VeJoinRDD[IN: TypeTag, OUT: TypeTag, T](
 
   override def compute(split: Partition, context: TaskContext): Iterator[T] = {
     import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
-    import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+   import com.nec.util.CallContextOps._
 
     val batches = joinedInputs.iterator(split, context)
     batches.flatMap { veColBatch =>
@@ -57,7 +57,7 @@ class VeJoinRDD[IN: TypeTag, OUT: TypeTag, T](
     val func = CompiledVeFunction(joiner.toCFunction, joiner.outputs.toList, null)
 
     rdd.mapPartitions { tupleIterator =>
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
 
       val (leftBatchesIter, rightBatchesIter) = tupleIterator.fold((Seq.empty, Seq.empty)){ case ((accLeft, accRight), (left, right)) =>
         (accLeft ++ left, accRight ++ right)
@@ -82,7 +82,7 @@ class VeJoinRDD[IN: TypeTag, OUT: TypeTag, T](
   override def toRDD: RDD[T] = {
     joinedInputs.mapPartitions { batches =>
       import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
 
       batches.flatMap { veColBatch =>
         val res = veColBatch.toCPUSeq[T]

--- a/src/main/scala/com/nec/ve/VeRDD.scala
+++ b/src/main/scala/com/nec/ve/VeRDD.scala
@@ -108,7 +108,7 @@ trait VeRDD[T] extends RDD[T] {
   def toRDD : RDD[T] = {
     inputs.mapPartitions { batches =>
       import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
 
       batches.flatMap { veColBatch =>
         val res = veColBatch.toCPUSeq[T]
@@ -136,7 +136,7 @@ trait VeRDD[T] extends RDD[T] {
 
   override def compute(split: Partition, context: TaskContext): Iterator[T] = {
     import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
-    import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+   import com.nec.util.CallContextOps._
 
     val batches = inputs.iterator(split, context)
     batches.flatMap { veColBatch =>
@@ -171,7 +171,7 @@ abstract class ChainedVeRDD[T](
 
   def computeVe(): RDD[VeColBatch] = {
     verdd.inputs.mapPartitions { batches =>
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
       val res = func.evalFunctionOnBatch(batches)
       res
     }
@@ -181,13 +181,13 @@ abstract class ChainedVeRDD[T](
     val newFunc = CppTranspiler.transpileReduce(expr)
 
     val reduceResults = inputs.mapPartitions { batches =>
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
       newFunc.evalFunctionOnBatch(batches)
     }
 
     val ret = reduceResults.mapPartitions { batches =>
       import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
 
       batches.map { veColBatch =>
         val res = veColBatch.toCPUSeq[T]
@@ -218,7 +218,7 @@ abstract class ChainedVeRDD[T](
 
     val mapped = new VeGroupByRDD[K, T](this, newFunc).toRDD.map { case (idx: K, veColBatch: VeColBatch) =>
       import com.nec.spark.SparkCycloneExecutorPlugin._
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
 
       require(
         veColBatch.nonEmpty,
@@ -241,7 +241,7 @@ abstract class ChainedVeRDD[T](
 
     val mapped = new VeGroupByRDD[K, T](this, newFunc).toRDD.map { case (idx: K, veColBatch: VeColBatch) =>
       import com.nec.spark.SparkCycloneExecutorPlugin._
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
 
       require(
         veColBatch.nonEmpty,
@@ -289,7 +289,7 @@ class BasicVeRDD[T](
     import com.nec.colvector.ArrayTConversions._
     import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics.processMetrics
     import com.nec.spark.SparkCycloneExecutorPlugin._
-    import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+   import com.nec.util.CallContextOps._
 
     val klass = typeTag.mirror.runtimeClass(tpe)
     val klassTag = ClassTag[Any](klass)
@@ -316,14 +316,14 @@ class BasicVeRDD[T](
     val newFunc = CppTranspiler.transpileReduce(expr)
 
     val reduceResults = inputs.mapPartitions { batches =>
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
 
       newFunc.evalFunctionOnBatch(batches)
     }
 
     val ret = reduceResults.mapPartitions { batches =>
       import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess}
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
 
       batches.map { veColBatch =>
         val res = veColBatch.toCPUSeq[T]
@@ -344,7 +344,7 @@ class BasicVeRDD[T](
 
     val mapped = new VeGroupByRDD[K, T](this, newFunc).toRDD.map { case (idx: K, veColBatch: VeColBatch) =>
       import com.nec.spark.SparkCycloneExecutorPlugin._
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
 
       require(
         veColBatch.nonEmpty,
@@ -367,7 +367,7 @@ class BasicVeRDD[T](
 
     val mapped = new VeGroupByRDD[K, T](this, newFunc).toRDD.map { case (idx: K, veColBatch: VeColBatch) =>
       import com.nec.spark.SparkCycloneExecutorPlugin._
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+     import com.nec.util.CallContextOps._
 
       require(
         veColBatch.nonEmpty,

--- a/src/main/scala/com/nec/ve/VeRDD.scala
+++ b/src/main/scala/com/nec/ve/VeRDD.scala
@@ -218,7 +218,7 @@ abstract class ChainedVeRDD[T](
 
     val mapped = new VeGroupByRDD[K, T](this, newFunc).toRDD.map { case (idx: K, veColBatch: VeColBatch) =>
       import com.nec.spark.SparkCycloneExecutorPlugin._
-     import com.nec.util.CallContextOps._
+      import com.nec.util.CallContextOps._
 
       require(
         veColBatch.nonEmpty,
@@ -241,7 +241,7 @@ abstract class ChainedVeRDD[T](
 
     val mapped = new VeGroupByRDD[K, T](this, newFunc).toRDD.map { case (idx: K, veColBatch: VeColBatch) =>
       import com.nec.spark.SparkCycloneExecutorPlugin._
-     import com.nec.util.CallContextOps._
+      import com.nec.util.CallContextOps._
 
       require(
         veColBatch.nonEmpty,
@@ -287,7 +287,7 @@ class BasicVeRDD[T](
 
   def convertToVeVector(valsIter: Iterator[_], index: Int, seriesIndex: Int, tpe: Type): VeColVector = {
     import com.nec.colvector.ArrayTConversions._
-    import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics.processMetrics
+    import com.nec.spark.SparkCycloneExecutorPlugin.veMetrics
     import com.nec.spark.SparkCycloneExecutorPlugin._
    import com.nec.util.CallContextOps._
 
@@ -344,7 +344,7 @@ class BasicVeRDD[T](
 
     val mapped = new VeGroupByRDD[K, T](this, newFunc).toRDD.map { case (idx: K, veColBatch: VeColBatch) =>
       import com.nec.spark.SparkCycloneExecutorPlugin._
-     import com.nec.util.CallContextOps._
+      import com.nec.util.CallContextOps._
 
       require(
         veColBatch.nonEmpty,
@@ -367,7 +367,7 @@ class BasicVeRDD[T](
 
     val mapped = new VeGroupByRDD[K, T](this, newFunc).toRDD.map { case (idx: K, veColBatch: VeColBatch) =>
       import com.nec.spark.SparkCycloneExecutorPlugin._
-     import com.nec.util.CallContextOps._
+      import com.nec.util.CallContextOps._
 
       require(
         veColBatch.nonEmpty,

--- a/src/main/scala/com/nec/ve/VeRDDOps.scala
+++ b/src/main/scala/com/nec/ve/VeRDDOps.scala
@@ -20,8 +20,7 @@ object VeRDDOps extends LazyLogging {
   ): RDD[VeColBatch] =
     rdd
       .map { case (idx, veColBatch) =>
-        import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics._
-        import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
+        import com.nec.spark.SparkCycloneExecutorPlugin.{veProcess, veMetrics}
         logger.debug(s"Preparing to serialize batch ${veColBatch}")
         val r = (idx, veColBatch.toBytes)
         if (cleanUpInput) veColBatch.columns.foreach(_.free())
@@ -31,8 +30,7 @@ object VeRDDOps extends LazyLogging {
       .repartitionByKey(serializer = None /* default **/ )
       .map { case (_, ba) =>
         logger.debug(s"Preparing to deserialize batch of size ${ba.length}...")
-        import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics._
-        import com.nec.spark.SparkCycloneExecutorPlugin.veProcess
+        import com.nec.spark.SparkCycloneExecutorPlugin.{veProcess, veMetrics}
         val res = VeColBatch.fromBytes(ba)
         logger.debug(s"Completed deserializing batch ${ba.length} ==> ${res}")
         res

--- a/src/main/scala/com/nec/ve/serializer/VeDeserializationStream.scala
+++ b/src/main/scala/com/nec/ve/serializer/VeDeserializationStream.scala
@@ -54,12 +54,12 @@ class VeDeserializationStream(in: InputStream)(implicit
         case DoubleTag =>
           dataInputStream.readDouble()
         case CbTag =>
-          import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+          import com.nec.util.CallContextOps._
           VeColBatch.fromStream(dataInputStream)
         case MixedCbTagColBatch =>
           val theSize = dataInputStream.readInt()
           if (DeserStreamed) {
-            import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+            import com.nec.util.CallContextOps._
             cycloneMetrics.measureRunningTime {
               DualBatchOrBytes.ColBatchWrapper(VeColBatch.fromStream(dataInputStream))
             }(cycloneMetrics.registerDeserializationTime)

--- a/src/main/scala/com/nec/ve/serializer/VeSerializerInstance.scala
+++ b/src/main/scala/com/nec/ve/serializer/VeSerializerInstance.scala
@@ -22,14 +22,14 @@ class VeSerializerInstance(cleanUpInput: Boolean) extends SerializerInstance wit
     new VeSerializationStream(s)(
       SparkCycloneExecutorPlugin.veProcess,
       SparkCycloneExecutorPlugin.source,
-      SparkCycloneExecutorPlugin.ImplicitMetrics.processMetrics
+      SparkCycloneExecutorPlugin.veMetrics
     )
 
   override def deserializeStream(s: InputStream): DeserializationStream =
     new VeDeserializationStream(s)(
       SparkCycloneExecutorPlugin.veProcess,
       SparkCycloneExecutorPlugin.source,
-      SparkCycloneExecutorPlugin.ImplicitMetrics.processMetrics
+      SparkCycloneExecutorPlugin.veMetrics
     )
 
 }

--- a/src/test/scala/com/nec/cache/ColumnarBatchToVeColBatchTest.scala
+++ b/src/test/scala/com/nec/cache/ColumnarBatchToVeColBatchTest.scala
@@ -4,7 +4,7 @@ import com.nec.colvector.ArrowVectorConversions._
 import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.SparkAdditions
 import com.nec.ve.WithVeProcess
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
 import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
@@ -26,7 +26,7 @@ object ColumnarBatchToVeColBatchTest {
     ).asJava
   )
 
-  implicit val arrowEncodingSettings: ArrowEncodingSettings =
+  implicit val encoding: ArrowEncodingSettings =
     ArrowEncodingSettings("UTC", 3, 10)
 
   val columnarBatches: List[ColumnarBatch] = {
@@ -46,7 +46,7 @@ final class ColumnarBatchToVeColBatchTest
   extends AnyFreeSpec
   with SparkAdditions
   with WithVeProcess {
-  import OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
   import ColumnarBatchToVeColBatchTest._
 
   implicit val allocator = new RootAllocator(Integer.MAX_VALUE)

--- a/src/test/scala/com/nec/cache/SparkInternalRowsToArrowColumnarBatchesUnitSpec.scala
+++ b/src/test/scala/com/nec/cache/SparkInternalRowsToArrowColumnarBatchesUnitSpec.scala
@@ -18,7 +18,7 @@ final class SparkInternalRowsToArrowColumnarBatchesUnitSpec extends AnyWordSpec 
 
   "SparkInternalRowsToArrowColumnarBatches" should {
     "work" in {
-      import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+      import com.nec.util.CallContextOps._
 
       val result = SparkInternalRowsToArrowColumnarBatches.apply(
         Iterator(

--- a/src/test/scala/com/nec/cache/VeColBatchesCacheUnitSpec.scala
+++ b/src/test/scala/com/nec/cache/VeColBatchesCacheUnitSpec.scala
@@ -1,0 +1,58 @@
+package com.nec.cache
+
+import com.nec.colvector.SeqOptTConversions._
+import com.nec.colvector.{InputSamples, VeColBatch}
+import com.nec.cyclone.annotations.VectorEngineTest
+import com.nec.util.CallContextOps._
+import com.nec.ve.WithVeProcess
+import scala.util.Random
+import java.io._
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
+
+@VectorEngineTest
+final class VeColBatchesCacheUnitSpec extends AnyWordSpec with WithVeProcess {
+  val cache = new VeColBatchesCache
+
+  "VeColBatchesCache" should {
+    "correctly register VeColBatches for cache tracking and free VeColBatches on cleanup" in {
+      val sizeA = Random.nextInt(50) + 10
+      val a1 = InputSamples.seqOpt[Int](sizeA).toBytePointerColVector("_")
+      val a2 = InputSamples.seqOpt[Double](sizeA).toBytePointerColVector("_")
+      val a3 = InputSamples.seqOpt[String](sizeA).toBytePointerColVector("_")
+
+      val sizeB = Random.nextInt(50) + 10
+      val b1 = InputSamples.seqOpt[Int](sizeB).toBytePointerColVector("_")
+      val b2 = InputSamples.seqOpt[Double](sizeB).toBytePointerColVector("_")
+
+      val sizeC = Random.nextInt(50) + 10
+      val c1 = InputSamples.seqOpt[Double](sizeC).toBytePointerColVector("_")
+      val c2 = InputSamples.seqOpt[String](sizeC).toBytePointerColVector("_")
+
+      val batch1 = VeColBatch(Seq(a1, a2, a3).map(_.toVeColVector))
+      val batch2 = VeColBatch(Seq(b1, b2).map(_.toVeColVector))
+      val batch3 = VeColBatch(Seq(c1, c2).map(_.toVeColVector))
+
+      batch1.columns.map(_.isOpen).toSet should be (Set(true))
+      batch2.columns.map(_.isOpen).toSet should be (Set(true))
+      batch3.columns.map(_.isOpen).toSet should be (Set(true))
+
+      cache.register("batch1", batch1)
+      cache.register("batch2", batch2)
+      cache.batches.size should be (2)
+
+      cache.cleanupIfNotCached(batch2)
+      cache.cleanupIfNotCached(batch3)
+      cache.batches.size should be (2)
+      batch1.columns.map(_.isOpen).toSet should be (Set(true))
+      batch2.columns.map(_.isOpen).toSet should be (Set(true))
+      batch3.columns.map(_.isOpen).toSet should be (Set(false))
+
+      cache.cleanup
+      cache.batches.size should be (0)
+      batch1.columns.map(_.isOpen).toSet should be (Set(false))
+      batch2.columns.map(_.isOpen).toSet should be (Set(false))
+      batch3.columns.map(_.isOpen).toSet should be (Set(false))
+    }
+  }
+}

--- a/src/test/scala/com/nec/colvector/BytePointerColVectorUnitSpec.scala
+++ b/src/test/scala/com/nec/colvector/BytePointerColVectorUnitSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.bytedeco.javacpp.BytePointer
 
 final class BytePointerColVectorUnitSpec extends AnyWordSpec {
-  import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
   implicit val source = VeColVectorSource(s"${UUID.randomUUID}")
 
   "BytePointerColVector" should {

--- a/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
+++ b/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
@@ -92,7 +92,7 @@ final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
   }
 
   "handle_transfer" should {
-    import com.nec.ve.VeProcess.OriginalCallingContext.Automatic.originalCallingContext
+   import com.nec.util.CallContextOps._
 
     "correctly unpack a single batch of mixed vector types" in {
       val cols = batch1()

--- a/src/test/scala/com/nec/colvector/UnitColBatchUnitSpec.scala
+++ b/src/test/scala/com/nec/colvector/UnitColBatchUnitSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 @VectorEngineTest
 final class UnitColBatchUnitSpec extends AnyWordSpec with WithVeProcess {
-  import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
 
   "UnitColBatch" should {
     s"correctly construct ${classOf[VeColBatch].getSimpleName} from Seq[Array[Byte]]" in {

--- a/src/test/scala/com/nec/colvector/UnitColVectorUnitSpec.scala
+++ b/src/test/scala/com/nec/colvector/UnitColVectorUnitSpec.scala
@@ -3,6 +3,7 @@ package com.nec.colvector
 import com.nec.colvector.SeqOptTConversions._
 import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.agile.core.{VeNullableInt, VeString}
+import com.nec.util.CallContextOps._
 import com.nec.ve.WithVeProcess
 import scala.util.Random
 import java.io._
@@ -12,8 +13,6 @@ import org.scalatest.wordspec.AnyWordSpec
 
 @VectorEngineTest
 final class UnitColVectorUnitSpec extends AnyWordSpec with WithVeProcess {
-  import com.nec.util.CallContextOps._
-
   def runSerializationTest(input: BytePointerColVector): BytePointerColVector = {
     val colvec1 = input.toVeColVector
     val bytes = colvec1.toBytes

--- a/src/test/scala/com/nec/colvector/UnitColVectorUnitSpec.scala
+++ b/src/test/scala/com/nec/colvector/UnitColVectorUnitSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 @VectorEngineTest
 final class UnitColVectorUnitSpec extends AnyWordSpec with WithVeProcess {
-  import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
 
   def runSerializationTest(input: BytePointerColVector): BytePointerColVector = {
     val colvec1 = input.toVeColVector

--- a/src/test/scala/com/nec/colvector/VeColBatchUnitSpec.scala
+++ b/src/test/scala/com/nec/colvector/VeColBatchUnitSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 @VectorEngineTest
 final class VeColBatchUnitSpec extends AnyWordSpec with WithVeProcess {
-  import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
 
   "VeColBatch" should {
     "correctly serialize and deserialize a batch of 2 columns through Array[Byte]" in {

--- a/src/test/scala/com/nec/colvector/VeColBatchUnitSpec.scala
+++ b/src/test/scala/com/nec/colvector/VeColBatchUnitSpec.scala
@@ -3,14 +3,13 @@ package com.nec.colvector
 import com.nec.colvector.ArrayTConversions._
 import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.ve.WithVeProcess
+import com.nec.util.CallContextOps._
 import java.io._
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 
 @VectorEngineTest
 final class VeColBatchUnitSpec extends AnyWordSpec with WithVeProcess {
-  import com.nec.util.CallContextOps._
-
   "VeColBatch" should {
     "correctly serialize and deserialize a batch of 2 columns through Array[Byte]" in {
       val array1 = Array[Double](1, 2, 3)

--- a/src/test/scala/com/nec/colvector/VeColVectorUnitSpec.scala
+++ b/src/test/scala/com/nec/colvector/VeColVectorUnitSpec.scala
@@ -2,7 +2,7 @@ package com.nec.colvector
 
 import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.colvector.SeqOptTConversions._
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.WithVeProcess
 import com.nec.vectorengine.{WithVeProcess => WithNewVeProcess}
 import scala.reflect.ClassTag
@@ -13,7 +13,7 @@ import org.scalatest.matchers.should.Matchers._
 
 @VectorEngineTest
 final class VeColVectorUnitSpec extends AnyWordSpec with WithVeProcess {
-  import OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
 
   def runTransferTest(input: BytePointerColVector): BytePointerColVector = {
     val colvec = input.toVeColVector
@@ -61,7 +61,7 @@ final class VeColVectorUnitSpec extends AnyWordSpec with WithVeProcess {
 
 @VectorEngineTest
 final class NewVeColVectorUnitSpec extends AnyWordSpec with WithNewVeProcess {
-  import OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
 
   def runTransferTest(input: BytePointerColVector): BytePointerColVector = {
     val colvec = input.toVeColVector2

--- a/src/test/scala/com/nec/spark/serialization/ArrowColumnarBatchDeSerializerSpec.scala
+++ b/src/test/scala/com/nec/spark/serialization/ArrowColumnarBatchDeSerializerSpec.scala
@@ -18,7 +18,7 @@ object ArrowColumnarBatchDeSerializerSpec {
     def take(n: Int): ValueInfo[Value]
     def drop(n: Int): ValueInfo[Value]
     type Vector <: FieldVector
-    def create(name: String)(implicit bufferAllocator: BufferAllocator): Vector
+    def create(name: String)(implicit allocator: BufferAllocator): Vector
     def parse(vector: Vector): List[Option[Value]]
     def parseFV(vector: FieldVector): List[Option[Value]] = parse(vector.asInstanceOf[Vector])
     def values: List[Option[Value]]
@@ -27,8 +27,8 @@ object ArrowColumnarBatchDeSerializerSpec {
   object ValueInfo {
     final case class IntStorage(ints: Option[Int]*) extends ValueInfo[Int] {
       override type Vector = IntVector
-      override def create(name: String)(implicit bufferAllocator: BufferAllocator): IntVector = {
-        val iv = new IntVector(name, bufferAllocator)
+      override def create(name: String)(implicit allocator: BufferAllocator): IntVector = {
+        val iv = new IntVector(name, allocator)
         iv.setValueCount(ints.size)
         values.zipWithIndex.foreach {
           case (None, idx)        => iv.setNull(idx)
@@ -54,8 +54,8 @@ object ArrowColumnarBatchDeSerializerSpec {
       override type Vector = VarCharVector
       override def create(
         name: String
-      )(implicit bufferAllocator: BufferAllocator): VarCharVector = {
-        val iv = new VarCharVector(name, bufferAllocator)
+      )(implicit allocator: BufferAllocator): VarCharVector = {
+        val iv = new VarCharVector(name, allocator)
         iv.setValueCount(strings.size)
         values.zipWithIndex.foreach {
           case (None, idx)        => iv.setNull(idx)
@@ -75,8 +75,8 @@ object ArrowColumnarBatchDeSerializerSpec {
       override def take(n: Int): ValueInfo[Double] = FloatStorage(ints.take(n): _*)
       override def drop(n: Int): ValueInfo[Double] = FloatStorage(ints.drop(n): _*)
       override type Vector = Float8Vector
-      override def create(name: String)(implicit bufferAllocator: BufferAllocator): Float8Vector = {
-        val iv = new Float8Vector(name, bufferAllocator)
+      override def create(name: String)(implicit allocator: BufferAllocator): Float8Vector = {
+        val iv = new Float8Vector(name, allocator)
         iv.setValueCount(ints.size)
         values.zipWithIndex.foreach {
           case (None, idx)        => iv.setNull(idx)

--- a/src/test/scala/com/nec/ve/ArrowTransferCheck.scala
+++ b/src/test/scala/com/nec/ve/ArrowTransferCheck.scala
@@ -9,14 +9,14 @@ import com.nec.spark.agile.merge.MergeFunction
 import com.nec.ve.PureVeFunctions.{DoublingFunction, PartitioningFunction}
 import com.nec.colvector.VeColBatch
 import com.nec.colvector.VeBatchOfBatches
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import scala.util.Random
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.freespec.AnyFreeSpec
 
 @VectorEngineTest
 final class ArrowTransferCheck extends AnyFreeSpec with WithVeProcess with VeKernelInfra {
-  import OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
   "Execute our function" in {
     compiledWithHeaders(DoublingFunction, "f") { path =>
       val lib = veProcess.loadLibrary(path)

--- a/src/test/scala/com/nec/ve/DualModeVESpec.scala
+++ b/src/test/scala/com/nec/ve/DualModeVESpec.scala
@@ -6,7 +6,8 @@ import com.nec.colvector.SparkSqlColumnVectorConversions._
 import com.nec.colvector.{VeColBatch, VeColVectorSource}
 import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.{SparkAdditions, SparkCycloneExecutorPlugin}
-import com.nec.ve.VeProcess.{DeferredVeProcess, OriginalCallingContext, WrappingVeo}
+import com.nec.ve.VeProcess.{DeferredVeProcess, WrappingVeo}
+import com.nec.util.CallContext
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.IntVector
 import org.apache.spark.SparkEnv
@@ -28,7 +29,7 @@ final class DualModeVESpec
   with VeKernelInfra
   with BeforeAndAfterAll {
 
-  import OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
 
   "A dataset from ColumnarBatches can be read via the carrier columnar vector" in withSparkSession2(
     DynamicVeSqlExpressionEvaluationSpec.VeConfiguration
@@ -83,7 +84,7 @@ final class DualModeVESpec
     val result = inputRdd
       .mapPartitions { iteratorRows =>
         implicit val rootAllocator: RootAllocator = new RootAllocator()
-        implicit val arrowEncodingSettings: ArrowEncodingSettings =
+        implicit val encoding: ArrowEncodingSettings =
           ArrowEncodingSettings("UTC", 3, 10)
         import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics._
         unwrapPossiblyDualToVeColBatches(

--- a/src/test/scala/com/nec/ve/DualModeVESpec.scala
+++ b/src/test/scala/com/nec/ve/DualModeVESpec.scala
@@ -74,7 +74,8 @@ final class DualModeVESpec
       .makeRDD(Seq(1, 2))
       .repartition(1)
       .map { int =>
-        import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics._
+        import SparkCycloneExecutorPlugin.veMetrics
+        implicit val source = SparkCycloneExecutorPlugin.source
         VeColBatch.fromArrowColumnarBatch(
           if (int == 1) makeColumnarBatch1()
           else makeColumnarBatch2()
@@ -86,7 +87,7 @@ final class DualModeVESpec
         implicit val rootAllocator: RootAllocator = new RootAllocator()
         implicit val encoding: ArrowEncodingSettings =
           ArrowEncodingSettings("UTC", 3, 10)
-        import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics._
+        import com.nec.spark.SparkCycloneExecutorPlugin.veMetrics
         unwrapPossiblyDualToVeColBatches(
           possiblyDualModeInternalRows = iteratorRows,
           arrowSchema =

--- a/src/test/scala/com/nec/ve/JoinRDDSpec.scala
+++ b/src/test/scala/com/nec/ve/JoinRDDSpec.scala
@@ -6,7 +6,7 @@ import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.{SparkAdditions, SparkCycloneExecutorPlugin}
 import com.nec.ve.DetectVectorEngineSpec.VeClusterConfig
 import com.nec.colvector.{VeColBatch, VeColVector, VeColVectorSource}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import org.apache.spark.sql.SparkSession
 import org.scalatest.freespec.AnyFreeSpec
 
@@ -24,11 +24,11 @@ final class JoinRDDSpec extends AnyFreeSpec with SparkAdditions with VeKernelInf
     VeRDDOps
       .joinExchange(
         sparkSession.sparkContext.makeRDD(partsL).map { case (i, l) =>
-          import OriginalCallingContext.Automatic._
+          import com.nec.util.CallContextOps._
           i -> VeColBatch(List(l.toArray.toBytePointerColVector("left").toVeColVector))
         },
         sparkSession.sparkContext.makeRDD(partsR).map { case (i, l) =>
-          import OriginalCallingContext.Automatic._
+          import com.nec.util.CallContextOps._
           i -> VeColBatch(List(l.toArray.toBytePointerColVector("right").toVeColVector))
         },
         cleanUpInput = true

--- a/src/test/scala/com/nec/ve/JoinRDDSpec.scala
+++ b/src/test/scala/com/nec/ve/JoinRDDSpec.scala
@@ -19,7 +19,6 @@ final class JoinRDDSpec extends AnyFreeSpec with SparkAdditions with VeKernelInf
       Seq(1 -> Seq(5, 6, 7), 2 -> Seq(8, 8, 7), 3 -> Seq(9, 6, 7))
 
     import SparkCycloneExecutorPlugin._
-    import SparkCycloneExecutorPlugin.ImplicitMetrics._
 
     VeRDDOps
       .joinExchange(

--- a/src/test/scala/com/nec/ve/VERDDSpec.scala
+++ b/src/test/scala/com/nec/ve/VERDDSpec.scala
@@ -7,7 +7,7 @@ import com.nec.colvector.{VeColBatch, VeColVectorSource}
 import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.agile.core.VeNullableDouble
 import com.nec.spark.{SparkAdditions, SparkCycloneExecutorPlugin}
-import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics._
+import com.nec.spark.SparkCycloneExecutorPlugin._
 import com.nec.ve.PureVeFunctions.DoublingFunction
 import com.nec.util.CallContext
 import com.nec.ve.VeRDDOps.RichKeyedRDD

--- a/src/test/scala/com/nec/ve/VERDDSpec.scala
+++ b/src/test/scala/com/nec/ve/VERDDSpec.scala
@@ -9,7 +9,7 @@ import com.nec.spark.agile.core.VeNullableDouble
 import com.nec.spark.{SparkAdditions, SparkCycloneExecutorPlugin}
 import com.nec.spark.SparkCycloneExecutorPlugin.ImplicitMetrics._
 import com.nec.ve.PureVeFunctions.DoublingFunction
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve.VeRDDOps.RichKeyedRDD
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
@@ -23,7 +23,7 @@ final class VERDDSpec
   with VeKernelInfra
   with BeforeAndAfterAll {
 
-  import OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
 
   "We can perform a VE call on Arrow things" in withSparkSession2(
     DynamicVeSqlExpressionEvaluationSpec.VeConfiguration
@@ -56,7 +56,7 @@ final class VERDDSpec
 
 object VERDDSpec {
   val MultiFunctionName = "f_multi"
-  import OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
 
   def exchangeBatches(sparkSession: SparkSession, pathStr: String): RDD[Double] = {
     import SparkCycloneExecutorPlugin._

--- a/src/test/scala/com/nec/ve/WithVeProcess.scala
+++ b/src/test/scala/com/nec/ve/WithVeProcess.scala
@@ -1,7 +1,12 @@
 package com.nec.ve
 
+import com.nec.spark.SparkCycloneExecutorPlugin
 import com.nec.colvector.VeColVectorSource
 import org.bytedeco.veoffload.global.veo
+import org.apache.spark.SparkConf
+import org.apache.spark.api.plugin.PluginContext
+import org.apache.spark.resource.ResourceInformation
+import com.codahale.metrics.MetricRegistry
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
 trait WithVeProcess extends BeforeAndAfterAll { this: Suite =>
@@ -29,7 +34,19 @@ trait WithVeProcess extends BeforeAndAfterAll { this: Suite =>
     (proc, ctxt)
   }
 
-  override protected def afterAll(): Unit = {
+  override def beforeAll: Unit = {
+    SparkCycloneExecutorPlugin.pluginContext = new PluginContext {
+      def ask(message: Any): AnyRef = ???
+      def conf: SparkConf = ???
+      def metricRegistry = new MetricRegistry
+      def executorID: String = "executor-id"
+      def hostname: String = "hostname"
+      def resources: java.util.Map[String, ResourceInformation] = ???
+      def send(message: Any): Unit = ???
+    }
+  }
+
+  override def afterAll: Unit = {
     super.afterAll()
     if (initialized) {
       val (proc, thr_ctxt) = proc_and_ctxt

--- a/src/test/scala/com/nec/ve/WithVeProcess.scala
+++ b/src/test/scala/com/nec/ve/WithVeProcess.scala
@@ -11,7 +11,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 
 trait WithVeProcess extends BeforeAndAfterAll { this: Suite =>
   implicit def metrics = VeProcessMetrics.noOp
-  implicit def source = VeColVectorSource(getClass.getName)
+  implicit def source = SparkCycloneExecutorPlugin.source
   implicit def veProcess: VeProcess = VeProcess.WrappingVeo(proc_and_ctxt._1, proc_and_ctxt._2, source, VeProcessMetrics.noOp)
 
   private var initialized = false
@@ -44,6 +44,10 @@ trait WithVeProcess extends BeforeAndAfterAll { this: Suite =>
       def resources: java.util.Map[String, ResourceInformation] = ???
       def send(message: Any): Unit = ???
     }
+
+    val (proc, ctx) = proc_and_ctxt
+    SparkCycloneExecutorPlugin._veo_proc = proc
+    SparkCycloneExecutorPlugin._veo_thr_ctxt = ctx
   }
 
   override def afterAll: Unit = {

--- a/src/test/scala/com/nec/ve/eval/RealExpressionEvaluationUtils.scala
+++ b/src/test/scala/com/nec/ve/eval/RealExpressionEvaluationUtils.scala
@@ -25,7 +25,7 @@ import com.nec.spark.agile.filter.FilterFunction
 import com.nec.spark.agile.join.JoinUtils._
 import com.nec.spark.agile.projection.ProjectionFunction
 import com.nec.spark.agile.sort.{SortFunction, VeSortExpression}
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.ve._
 import com.nec.colvector.{VeColBatch, VeColVectorSource}
 import com.nec.ve.eval.StaticTypingTestAdditions._
@@ -52,7 +52,7 @@ object RealExpressionEvaluationUtils extends LazyLogging {
         )
       ).renderGroupBy
 
-    import OriginalCallingContext.Automatic._
+    import com.nec.util.CallContextOps._
     evalFunction(cFunction, "agg")(input, veRetriever.makeCVectors)
   }
 
@@ -78,7 +78,7 @@ object RealExpressionEvaluationUtils extends LazyLogging {
         )
       )
 
-    import OriginalCallingContext.Automatic._
+    import com.nec.util.CallContextOps._
     evalFunction(cFunction, "project_f")(input, veRetriever.makeCVectors)
   }
 
@@ -98,7 +98,7 @@ object RealExpressionEvaluationUtils extends LazyLogging {
         VeGroupBy(inputs = veAllocator.makeCVectors, groups = groups, outputs = expressions)
       ).renderGroupBy
 
-    import OriginalCallingContext.Automatic._
+    import com.nec.util.CallContextOps._
     evalFunction(cFunction, "project_f")(input, veRetriever.makeCVectors)
 
   }
@@ -121,7 +121,7 @@ object RealExpressionEvaluationUtils extends LazyLogging {
         )
       ).renderGroupBy
 
-    import OriginalCallingContext.Automatic._
+    import com.nec.util.CallContextOps._
     evalFunction(cFunction, "project_f")(input, veRetriever.makeCVectors)
   }
 
@@ -139,7 +139,7 @@ object RealExpressionEvaluationUtils extends LazyLogging {
     }
     val projectionFn = ProjectionFunction("project_f", veAllocator.makeCVectors, outputs.map(Right(_)))
 
-    import OriginalCallingContext.Automatic._
+    import com.nec.util.CallContextOps._
     evalFunction(projectionFn.toCFunction)(input, outputs.map(_.cVector))
   }
 
@@ -151,7 +151,7 @@ object RealExpressionEvaluationUtils extends LazyLogging {
     veRetriever: VeRetriever[Output],
     veProcess: VeProcess,
     veKernelInfra: VeKernelInfra,
-    originalCallingContext: OriginalCallingContext,
+    context: CallContext,
     veColVectorSource: VeColVectorSource
   ): Seq[Output] = {
     implicit val allocator = new RootAllocator(Integer.MAX_VALUE)
@@ -172,7 +172,7 @@ object RealExpressionEvaluationUtils extends LazyLogging {
     veRetriever: VeRetriever[Output],
     veProcess: VeProcess,
     veKernelInfra: VeKernelInfra,
-    originalCallingContext: OriginalCallingContext,
+    context: CallContext,
     veColVectorSource: VeColVectorSource
   ): Seq[Output] = {
     implicit val allocator = new RootAllocator(Integer.MAX_VALUE)
@@ -204,7 +204,7 @@ object RealExpressionEvaluationUtils extends LazyLogging {
       onVe = false
     )
 
-    import OriginalCallingContext.Automatic._
+    import com.nec.util.CallContextOps._
     evalFunction(filterFn.toCFunction)(
       input.toList,
       veRetriever.veTypes.zipWithIndex.map { case (t, i) => t.makeCVector(s"out_${i}") }
@@ -218,7 +218,7 @@ object RealExpressionEvaluationUtils extends LazyLogging {
     veColVectorSource: VeColVectorSource,
     veKernelInfra: VeKernelInfra
   ): Seq[Data] = {
-    import OriginalCallingContext.Automatic._
+    import com.nec.util.CallContextOps._
 
     val sortFn = SortFunction(
       "sort_f",

--- a/src/test/scala/com/nec/ve/eval/StaticTypingTestAdditions.scala
+++ b/src/test/scala/com/nec/ve/eval/StaticTypingTestAdditions.scala
@@ -23,7 +23,7 @@ import com.nec.colvector.SeqOptTConversions._
 import com.nec.colvector.ArrowVectorConversions._
 import com.nec.spark.agile.core._
 import com.nec.spark.agile.join.JoinUtils._
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.colvector.VeColVectorSource
 import com.nec.colvector.VeColVectorSource
 import com.nec.colvector.VeColBatch
@@ -44,7 +44,7 @@ object StaticTypingTestAdditions {
   trait VeAllocator[Input] {
     def allocate(data: Input*)(implicit
       veProcess: VeProcess,
-      originalCallingContext: OriginalCallingContext,
+      context: CallContext,
       veColVectorSource: VeColVectorSource
     ): VeColBatch
     def veTypes: List[VeType]
@@ -56,7 +56,7 @@ object StaticTypingTestAdditions {
   object VeAllocator {
     implicit object DoubleAllocator extends VeAllocator[Double] {
       override def allocate(data: Double*)(implicit process: VeProcess,
-                                           context: OriginalCallingContext,
+                                           context: CallContext,
                                            source: VeColVectorSource): VeColBatch = {
         VeColBatch.from(data.map(Some(_)).toBytePointerColVector("_").toVeColVector)
       }
@@ -66,7 +66,7 @@ object StaticTypingTestAdditions {
 
     implicit object StringAllocator extends VeAllocator[String] {
       override def allocate(data: String*)(implicit process: VeProcess,
-                                           context: OriginalCallingContext,
+                                           context: CallContext,
                                            source: VeColVectorSource): VeColBatch = {
         VeColBatch.from(data.map(Some(_)).toBytePointerColVector("_").toVeColVector)
       }
@@ -76,7 +76,7 @@ object StaticTypingTestAdditions {
 
     implicit object StringDoubleAllocator extends VeAllocator[(String, Double)] {
       override def allocate(data: (String, Double)*)(implicit process: VeProcess,
-                                           context: OriginalCallingContext,
+                                           context: CallContext,
                                            source: VeColVectorSource): VeColBatch = {
         VeColBatch.from(
           data.map(x => Some(x._1)).toBytePointerColVector("_").toVeColVector,
@@ -89,7 +89,7 @@ object StaticTypingTestAdditions {
 
     implicit object DoubleDoubleAllocator extends VeAllocator[(Double, Double)] {
       override def allocate(data: (Double, Double)*)(implicit process: VeProcess,
-                                           context: OriginalCallingContext,
+                                           context: CallContext,
                                            source: VeColVectorSource): VeColBatch = {
         VeColBatch.from(
           data.map(x => Some(x._1)).toBytePointerColVector("_").toVeColVector,
@@ -102,7 +102,7 @@ object StaticTypingTestAdditions {
 
     implicit object DoubleDoubleDoubleAllocator extends VeAllocator[(Double, Double, Double)] {
       override def allocate(data: (Double, Double, Double)*)(implicit process: VeProcess,
-                                           context: OriginalCallingContext,
+                                           context: CallContext,
                                            source: VeColVectorSource): VeColBatch = {
         VeColBatch.from(
           data.map(x => Some(x._1)).toBytePointerColVector("_").toVeColVector,
@@ -118,7 +118,7 @@ object StaticTypingTestAdditions {
     implicit object DoubleDoubleDoubleDoubleAllocator
       extends VeAllocator[(Double, Double, Double, Double)] {
       override def allocate(data: (Double, Double, Double, Double)*)(implicit process: VeProcess,
-                                           context: OriginalCallingContext,
+                                           context: CallContext,
                                            source: VeColVectorSource): VeColBatch = {
         VeColBatch.from(
           data.map(x => Some(x._1)).toBytePointerColVector("_").toVeColVector,
@@ -134,7 +134,7 @@ object StaticTypingTestAdditions {
 
     implicit object OptionDoubleAllocator extends VeAllocator[Option[Double]] {
       override def allocate(data: Option[Double]*)(implicit process: VeProcess,
-                                                   context: OriginalCallingContext,
+                                                   context: CallContext,
                                                    source: VeColVectorSource): VeColBatch = {
         VeColBatch.from(data.toBytePointerColVector("_").toVeColVector)
       }
@@ -145,7 +145,7 @@ object StaticTypingTestAdditions {
     implicit object OptionDoubleDoubleDoubleAllocator
       extends VeAllocator[(Option[Double], Double, Double)] {
       override def allocate(data: (Option[Double], Double, Double)*)(implicit process: VeProcess,
-                                           context: OriginalCallingContext,
+                                           context: CallContext,
                                            source: VeColVectorSource): VeColBatch = {
         VeColBatch.from(
           data.map(x => x._1).toBytePointerColVector("_").toVeColVector,

--- a/src/test/scala/com/nec/ve/eval/StringOpsStringHoleEvaluationSpec.scala
+++ b/src/test/scala/com/nec/ve/eval/StringOpsStringHoleEvaluationSpec.scala
@@ -8,7 +8,7 @@ import com.nec.spark.agile.StringHole
 import com.nec.spark.agile.StringHole.StringHoleEvaluation
 import com.nec.spark.agile.StringHole.StringHoleEvaluation.LikeStringHoleEvaluation
 import com.nec.spark.agile.groupby.GroupByOutline
-import com.nec.ve.VeProcess.OriginalCallingContext
+import com.nec.util.CallContext
 import com.nec.colvector.{VeColBatch, VeColVectorSource}
 import com.nec.ve.eval.StaticTypingTestAdditions.{VeAllocator, VeRetriever}
 import com.nec.ve.{VeKernelInfra, VeProcess, WithVeProcess}
@@ -23,7 +23,7 @@ final class StringOpsStringHoleEvaluationSpec
   with WithVeProcess
   with VeKernelInfra {
 
-  import OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
 
   val list = List("this", "test", "is defi", "nitely", "tested")
 
@@ -91,7 +91,7 @@ object StringOpsStringHoleEvaluationSpec {
     veRetriever: VeRetriever[Int],
     veProcess: VeProcess,
     veKernelInfra: VeKernelInfra,
-    originalCallingContext: OriginalCallingContext,
+    context: CallContext,
     veColVectorSource: VeColVectorSource
   ): Seq[Int] = {
     implicit val allocator = new RootAllocator(Integer.MAX_VALUE)

--- a/src/test/scala/com/nec/ve/serializer/VeSerializerSpec.scala
+++ b/src/test/scala/com/nec/ve/serializer/VeSerializerSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 @VectorEngineTest
 final class VeSerializerSpec extends AnyWordSpec with WithVeProcess with VeKernelInfra {
-  import com.nec.ve.VeProcess.OriginalCallingContext.Automatic._
+  import com.nec.util.CallContextOps._
 
   "VeSerializer" should {
     "check serializer fully" in {


### PR DESCRIPTION
This is part 1 of N fair-sized PRs that will integrate the new `VeProcess` and `VectorEngine` implementations into the existing codebase.  This PR deals with removing the `OriginalCallingContext` and `ImplicitMetrics` to make the next few PRs smaller in size.

Summary:

- Replace usage of `com.nec.ve.VeProcess.OriginalCallingContext` with `com.nec.util.CallContext`
- Simplify the implicit metrics usage in `SparkCycloneExecutorPlugin`
- Move `VeColBatch` cache handling in `SparkCycloneExecutorPlugin` over to the `VeColBatchesCache` class
- Add unit tests for `VeColBatchesCache`