### PR TITLE
Bugfixes: Calculate validity buffer steps based on processed elements & fix sort order issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val root = Project(id = "spark-cyclone-sql-plugin", base = file("."))
   .configs(AcceptanceTest)
   .configs(VectorEngine)
   .configs(TPC)
-  .settings(version := "1.0.3")
+  .settings(version := "1.0.4")
 
 lazy val tracing = project
   .enablePlugins(JavaServerAppPackaging)

--- a/rddbench/run_rddbench.sh
+++ b/rddbench/run_rddbench.sh
@@ -8,8 +8,8 @@ time $SPARK_HOME/bin/spark-submit \
     --deploy-mode cluster \
     --name RDDBench \
     --conf spark.com.nec.spark.ncc.path=/opt/nec/ve/bin/ncc \
-    --jars ../target/scala-2.12/spark-cyclone-sql-plugin-assembly-1.0.3.jar \
-    --conf spark.executor.extraClassPath=../target/scala-2.12/spark-cyclone-sql-plugin-assembly-1.0.3.jar \
+    --jars ../target/scala-2.12/spark-cyclone-sql-plugin-assembly-1.0.4.jar \
+    --conf spark.executor.extraClassPath=../target/scala-2.12/spark-cyclone-sql-plugin-assembly-1.0.4.jar \
     --conf spark.rpc.message.maxSize=1024 \
     --conf spark.plugins=com.nec.spark.AuroraSqlPlugin \
     --conf spark.sql.columnVector.offheap.enabled=true \

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
@@ -204,7 +204,6 @@ namespace cyclone {
       return out_dangling;
     }
 
-    // Calculate how many full elements are necessary to fit the second bitset into the given type
     auto is_big_steps = sizeof(T) > 1;
 
     // How many elements *can* be fit into the tail

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
@@ -231,7 +231,7 @@ void merge_scalar_transfer(size_t batch_count, size_t total_element_count, char*
  * # Output descriptor
  * The output descriptor has the following format:
  * ```
- * [column ouput descriptor]...
+ * [column output descriptor]...
  * ```
  * As we are merging the entire input into a single batch, there will be exactly
  * `column count` output descriptors.

--- a/src/main/resources/com/nec/cyclone/cpp/tests/packed_transfer_spec.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/packed_transfer_spec.cc
@@ -368,94 +368,234 @@ namespace cyclone::tests {
     }
 
     TEST_CASE("Unpacking and merging three batches works for multiple vectors of different types"){
-          std::vector<std::string> raw1 { "JAN", "FEB", "MAR", "APR", "MAY", "JUN"};
-          std::vector<std::string> raw2 { "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
-          std::vector<std::string> raw3 { "A", "b", "C"};
-          auto *vc_vec1 = new nullable_varchar_vector(raw1);
-          vc_vec1->set_validity(1, 0);
-          vc_vec1->set_validity(3, 0);
-          vc_vec1->set_validity(5, 0);
+      std::vector<std::string> raw1 { "JAN", "FEB", "MAR", "APR", "MAY", "JUN"};
+      std::vector<std::string> raw2 { "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
+      std::vector<std::string> raw3 { "A", "b", "C"};
+      auto *vc_vec1 = new nullable_varchar_vector(raw1);
+      vc_vec1->set_validity(1, 0);
+      vc_vec1->set_validity(3, 0);
+      vc_vec1->set_validity(5, 0);
 
-          auto *vc_vec2 = new nullable_varchar_vector(raw2);
-          vc_vec2->set_validity(0, 0);
-          vc_vec2->set_validity(2, 0);
-          vc_vec2->set_validity(4, 0);
+      auto *vc_vec2 = new nullable_varchar_vector(raw2);
+      vc_vec2->set_validity(0, 0);
+      vc_vec2->set_validity(2, 0);
+      vc_vec2->set_validity(4, 0);
 
-          auto *vc_vec3 = new nullable_varchar_vector(raw3);
-          vc_vec3->set_validity(1, 0);
+      auto *vc_vec3 = new nullable_varchar_vector(raw3);
+      vc_vec3->set_validity(1, 0);
 
-          auto *sc_vec1 = new NullableScalarVec<int32_t>({586, 951, 106, 318, 538, 620});
-          sc_vec1->set_validity(1, 0);
-          sc_vec1->set_validity(3, 0);
-          sc_vec1->set_validity(5, 0);
+      auto *sc_vec1 = new NullableScalarVec<int32_t>({586, 951, 106, 318, 538, 620});
+      sc_vec1->set_validity(1, 0);
+      sc_vec1->set_validity(3, 0);
+      sc_vec1->set_validity(5, 0);
 
-          auto *sc_vec2 = new NullableScalarVec<int32_t>({553, 605, 822, 941});
-          sc_vec2->set_validity(2, 0);
-          sc_vec2->set_validity(3, 0);
+      auto *sc_vec2 = new NullableScalarVec<int32_t>({553, 605, 822, 941});
+      sc_vec2->set_validity(2, 0);
+      sc_vec2->set_validity(3, 0);
 
-          auto *sc_vec3 = new NullableScalarVec<int32_t>({53, 5, 22, 94});
-          sc_vec2->set_validity(0, 0);
-          sc_vec2->set_validity(1, 0);
+      auto *sc_vec3 = new NullableScalarVec<int32_t>({53, 5, 22, 94});
+      sc_vec2->set_validity(0, 0);
+      sc_vec2->set_validity(1, 0);
 
-          auto header_size = sizeof(transfer_header) + (3 * (sizeof(size_t) + sizeof(scalar_col_in))) + (3 * (sizeof(size_t) + sizeof(varchar_col_in)));
+      auto header_size = sizeof(transfer_header) + (3 * (sizeof(size_t) + sizeof(scalar_col_in))) + (3 * (sizeof(size_t) + sizeof(varchar_col_in)));
 
-          size_t data_size = (VECTOR_ALIGNED(vc_vec1->dataSize * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec2->dataSize * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec3->dataSize * sizeof(int32_t))
-                             + VECTOR_ALIGNED(sc_vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(sc_vec2->count * sizeof(int32_t)) + VECTOR_ALIGNED(sc_vec3->count * sizeof(int32_t)));
-          size_t offsets_size = VECTOR_ALIGNED(vc_vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec2->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec3->count * sizeof(int32_t));
-          size_t lengths_size = VECTOR_ALIGNED(vc_vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec2->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec3->count * sizeof(int32_t));
-          size_t validity_buffer_size = VECTOR_ALIGNED(sizeof(uint64_t) * ( frovedis::ceil_div(vc_vec1->count, int32_t(64))
-                                                           + frovedis::ceil_div(vc_vec2->count, int32_t(64))
-                                                           + frovedis::ceil_div(vc_vec3->count, int32_t(64))
-                                                           + frovedis::ceil_div(sc_vec1->count, int32_t(64))
-                                                           + frovedis::ceil_div(sc_vec2->count, int32_t(64))
-                                                           + frovedis::ceil_div(sc_vec3->count, int32_t(64))));
+      size_t data_size = (VECTOR_ALIGNED(vc_vec1->dataSize * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec2->dataSize * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec3->dataSize * sizeof(int32_t))
+                         + VECTOR_ALIGNED(sc_vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(sc_vec2->count * sizeof(int32_t)) + VECTOR_ALIGNED(sc_vec3->count * sizeof(int32_t)));
+      size_t offsets_size = VECTOR_ALIGNED(vc_vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec2->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec3->count * sizeof(int32_t));
+      size_t lengths_size = VECTOR_ALIGNED(vc_vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec2->count * sizeof(int32_t)) + VECTOR_ALIGNED(vc_vec3->count * sizeof(int32_t));
+      size_t validity_buffer_size = VECTOR_ALIGNED(sizeof(uint64_t) * ( frovedis::ceil_div(vc_vec1->count, int32_t(64))
+                                                       + frovedis::ceil_div(vc_vec2->count, int32_t(64))
+                                                       + frovedis::ceil_div(vc_vec3->count, int32_t(64))
+                                                       + frovedis::ceil_div(sc_vec1->count, int32_t(64))
+                                                       + frovedis::ceil_div(sc_vec2->count, int32_t(64))
+                                                       + frovedis::ceil_div(sc_vec3->count, int32_t(64))));
 
-          char* transfer = static_cast<char*>(malloc(header_size + data_size + offsets_size + lengths_size + validity_buffer_size));
+      char* transfer = static_cast<char*>(malloc(header_size + data_size + offsets_size + lengths_size + validity_buffer_size));
 
-          size_t pos = 0;
-          transfer_header* header = reinterpret_cast<transfer_header *>(&transfer[pos]);
-          header->header_size = header_size;
-          header->batch_count = 3;
-          header->column_count = 2;
-          pos += sizeof(transfer_header);
+      size_t pos = 0;
+      transfer_header* header = reinterpret_cast<transfer_header *>(&transfer[pos]);
+      header->header_size = header_size;
+      header->batch_count = 3;
+      header->column_count = 2;
+      pos += sizeof(transfer_header);
 
-          size_t data_pos = 0;
-          size_t col_pos = 0;
-          copy_varchar_vec_to_transfer_buffer(vc_vec1, &transfer[pos], &transfer[header_size], col_pos, data_pos);
-          copy_varchar_vec_to_transfer_buffer(vc_vec2, &transfer[pos], &transfer[header_size], col_pos, data_pos);
-          copy_varchar_vec_to_transfer_buffer(vc_vec3, &transfer[pos], &transfer[header_size], col_pos, data_pos);
-          copy_scalar_vec_to_transfer_buffer(sc_vec1, &transfer[pos], &transfer[header_size], col_pos, data_pos);
-          copy_scalar_vec_to_transfer_buffer(sc_vec2, &transfer[pos], &transfer[header_size], col_pos, data_pos);
-          copy_scalar_vec_to_transfer_buffer(sc_vec3, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+      size_t data_pos = 0;
+      size_t col_pos = 0;
+      copy_varchar_vec_to_transfer_buffer(vc_vec1, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+      copy_varchar_vec_to_transfer_buffer(vc_vec2, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+      copy_varchar_vec_to_transfer_buffer(vc_vec3, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+      copy_scalar_vec_to_transfer_buffer(sc_vec1, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+      copy_scalar_vec_to_transfer_buffer(sc_vec2, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+      copy_scalar_vec_to_transfer_buffer(sc_vec3, &transfer[pos], &transfer[header_size], col_pos, data_pos);
 
-          uintptr_t* od = static_cast<uintptr_t*>(malloc(sizeof(uintptr_t) * (5 + 3)));
+      uintptr_t* od = static_cast<uintptr_t*>(malloc(sizeof(uintptr_t) * (5 + 3)));
 
-          char* target[1] = {transfer};
+      char* target[1] = {transfer};
 
-          int res = handle_transfer(target, od);
-          CHECK(res == 0);
+      int res = handle_transfer(target, od);
+      CHECK(res == 0);
 
-          nullable_varchar_vector* varchars[3] = {vc_vec1, vc_vec2, vc_vec3};
-          NullableScalarVec<int32_t>* scalars[3] = {sc_vec1, sc_vec2, sc_vec3};
+      nullable_varchar_vector* varchars[3] = {vc_vec1, vc_vec2, vc_vec3};
+      NullableScalarVec<int32_t>* scalars[3] = {sc_vec1, sc_vec2, sc_vec3};
 
-          nullable_varchar_vector* vc_merged = nullable_varchar_vector::merge(varchars, 3);
-          NullableScalarVec<int32_t>* sc_merged = NullableScalarVec<int32_t>::merge(scalars, 3);
+      nullable_varchar_vector* vc_merged = nullable_varchar_vector::merge(varchars, 3);
+      NullableScalarVec<int32_t>* sc_merged = NullableScalarVec<int32_t>::merge(scalars, 3);
 
-          nullable_varchar_vector* transferred1 = reinterpret_cast<nullable_varchar_vector*>(od[0]);
+      nullable_varchar_vector* transferred1 = reinterpret_cast<nullable_varchar_vector*>(od[0]);
 
-          std::cout << "vc_merged = " << std::endl;
-          vc_merged->print();
-          std::cout << "transferred1 = " << std::endl;
-          transferred1->print();
-          CHECK(transferred1->equals(vc_merged));
+      std::cout << "vc_merged = " << std::endl;
+      vc_merged->print();
+      std::cout << "transferred1 = " << std::endl;
+      transferred1->print();
+      CHECK(transferred1->equals(vc_merged));
 
-          NullableScalarVec<int32_t>* transferred2 = reinterpret_cast<NullableScalarVec<int32_t>*>(od[5]);
+      NullableScalarVec<int32_t>* transferred2 = reinterpret_cast<NullableScalarVec<int32_t>*>(od[5]);
 
-          std::cout << "sc_merged = " << std::endl;
-          sc_merged->print();
-          std::cout << "transferred2 = " << std::endl;
-          transferred2->print();
-          CHECK(transferred2->equals(sc_merged));
-        }
+      std::cout << "sc_merged = " << std::endl;
+      sc_merged->print();
+      std::cout << "transferred2 = " << std::endl;
+      transferred2->print();
+      CHECK(transferred2->equals(sc_merged));
+    }
+
+    TEST_CASE_TEMPLATE("Unpacking works for three scalar vector of T=", T, int32_t, int64_t, float, double) {
+        uint64_t validity_buffers[3] = {
+          0b0000000000000000000000000000000000000000000000000110011000110010,
+    //                                                      ^ valid until here
+          0b0000000011001001011001001000100101001000011011101000001100101000,
+    //              ^ valid until here
+          0b0000011010100101101110010010101111000011010000000001100100111001
+    //           ^ valid until here
+        };
+      const std::vector <T> a{0, 4436, 0, 0, 9586, 2142, 0, 0, 0, 2149, 4297, 0, 0, 3278, 6668, 0};
+      auto *vec1 = new NullableScalarVec(a);
+      vec1->validityBuffer = &validity_buffers[0];
+      
+      const std::vector <T> b{
+        0, 0, 0, 8051, 0, 1383, 0, 0, 2256, 5785, 0, 0, 0, 0, 0, 4693, 0, 1849, 3790, 8995, 0, 6961, 7132, 0, 0, 0, 0, 6968, 0, 0, 3763, 0, 3558, 0, 0, 2011, 0, 0, 0, 3273, 0, 0, 9428, 0, 0, 6408, 7940, 0, 9521, 0, 0, 5832, 0, 0, 5817, 5949
+      };
+      auto *vec2 = new NullableScalarVec(b);
+      vec2->validityBuffer = &validity_buffers[1];
+      
+      const std::vector <T> c{
+        7319, 0, 0, 4859, 524, 406, 0, 0, 1154, 0, 0, 1650, 8040, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1146, 0, 7268, 8197, 0, 0, 0, 0, 81, 2053, 6571, 4600, 0, 3699, 0, 8404, 0, 0, 8401, 0, 0, 6234, 6281, 7367, 0, 4688, 7490, 0, 5412, 0, 0, 871, 0, 9086, 0, 5362, 6516
+      };
+      auto *vec3 = new NullableScalarVec(c);
+      vec3->validityBuffer = &validity_buffers[2];
+      
+
+
+      auto header_size = sizeof(transfer_header) + 3 * (sizeof(size_t) + sizeof(scalar_col_in));
+
+      size_t data_size = VECTOR_ALIGNED(sizeof(T) * vec1->count) + VECTOR_ALIGNED(sizeof(T) * vec2->count) + VECTOR_ALIGNED(sizeof(T) * vec3->count);
+      size_t validity_buffer_size = VECTOR_ALIGNED(frovedis::ceil_div(vec1->count, int32_t(64)) * sizeof(uint64_t))
+                                  + VECTOR_ALIGNED(frovedis::ceil_div(vec2->count, int32_t(64)) * sizeof(uint64_t))
+                                  + VECTOR_ALIGNED(frovedis::ceil_div(vec3->count, int32_t(64)) * sizeof(uint64_t));
+
+      char* transfer = static_cast<char*>(malloc(header_size + data_size + validity_buffer_size));
+
+      size_t pos = 0;
+      transfer_header* header = reinterpret_cast<transfer_header *>(&transfer[pos]);
+      header->header_size = header_size;
+      header->batch_count = 3;
+      header->column_count = 1;
+      pos += sizeof(transfer_header);
+
+      size_t data_pos = 0;
+      size_t col_pos = 0;
+      copy_scalar_vec_to_transfer_buffer(vec1, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+      copy_scalar_vec_to_transfer_buffer(vec2, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+      copy_scalar_vec_to_transfer_buffer(vec3, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+
+      uintptr_t* od = static_cast<uintptr_t*>(malloc(sizeof(uintptr_t) * 3));
+
+      char* target[1] = {transfer};
+
+      int res = handle_transfer(target, od);
+      CHECK(res == 0);
+
+      NullableScalarVec<T>* transferred = reinterpret_cast<NullableScalarVec<T>*>(od[0]);
+
+      NullableScalarVec<T>* scalars[3] = {vec1, vec2, vec3};
+      NullableScalarVec<T>* merged = NullableScalarVec<T>::merge(scalars, 3);
+
+      std::cout << "merged = " << std::endl;
+      merged->print();
+      std::cout << "transferred = " << std::endl;
+      transferred->print();
+
+      CHECK(transferred->equals(merged));
+    }
+    
+    TEST_CASE("Unpacking works for three varchar vectors") {
+        uint64_t validity_buffers[3] = {
+          0b0000000000000000000000000000000000000000000000000110011000110010,
+//                                                      ^ valid until here
+          0b0000000011001001011001001000100101001000011011101000001100101000,
+//              ^ valid until here
+          0b0000011010100101101110010010101111000011010000000001100100111001
+//           ^ valid until here
+        };
+      const std::vector <std::string> a{"0", "4436", "0", "0", "9586", "2142", "0", "0", "0", "2149", "4297", "0", "0", "3278", "6668", "0"};
+      auto *vec1 = new nullable_varchar_vector(a);
+      vec1->validityBuffer = &validity_buffers[0];
+      
+      const std::vector <std::string> b{
+        "0", "0", "0", "8051", "0", "1383", "0", "0", "2256", "5785", "0", "0", "0", "0", "0", "4693", "0", "1849", "3790", "8995", "0", "6961", "7132", "0", "0", "0", "0", "6968", "0", "0", "3763", "0", "3558", "0", "0", "2011", "0", "0", "0", "3273", "0", "0", "9428", "0", "0", "6408", "7940", "0", "9521", "0", "0", "5832", "0", "0", "5817", "5949"
+      };
+      auto *vec2 = new nullable_varchar_vector(b);
+      vec2->validityBuffer = &validity_buffers[1];
+      
+      const std::vector <std::string> c{
+        "7319", "0", "0", "4859", "524", "406", "0", "0", "1154", "0", "0", "1650", "8040", "0", "0", "0", "0", "0", "0", "0", "0", "0", "1146", "0", "7268", "8197", "0", "0", "0", "0", "81", "2053", "6571", "4600", "0", "3699", "0", "8404", "0", "0", "8401", "0", "0", "6234", "6281", "7367", "0", "4688", "7490", "0", "5412", "0", "0", "871", "0", "9086", "0", "5362", "6516"
+      };
+      auto *vec3 = new nullable_varchar_vector(c);
+      vec3->validityBuffer = &validity_buffers[2];
+      
+
+
+      auto header_size = sizeof(transfer_header) + 3 * (sizeof(size_t) + sizeof(varchar_col_in));
+
+      size_t data_size = VECTOR_ALIGNED(vec1->dataSize * sizeof(int32_t)) + VECTOR_ALIGNED(vec2->dataSize * sizeof(int32_t)) + VECTOR_ALIGNED(vec3->dataSize * sizeof(int32_t));
+      size_t validity_buffer_size = VECTOR_ALIGNED(frovedis::ceil_div(vec1->count, int32_t(64)) * sizeof(uint64_t))
+                                  + VECTOR_ALIGNED(frovedis::ceil_div(vec2->count, int32_t(64)) * sizeof(uint64_t))
+                                  + VECTOR_ALIGNED(frovedis::ceil_div(vec3->count, int32_t(64)) * sizeof(uint64_t));
+      size_t offsets_size = VECTOR_ALIGNED(vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(vec2->count * sizeof(int32_t)) + VECTOR_ALIGNED(vec3->count * sizeof(int32_t));
+      size_t lengths_size = VECTOR_ALIGNED(vec1->count * sizeof(int32_t)) + VECTOR_ALIGNED(vec2->count * sizeof(int32_t)) + VECTOR_ALIGNED(vec3->count * sizeof(int32_t));
+
+      char* transfer = static_cast<char*>(malloc(header_size + data_size + validity_buffer_size + offsets_size + lengths_size));
+
+      size_t pos = 0;
+      transfer_header* header = reinterpret_cast<transfer_header *>(&transfer[pos]);
+      header->header_size = header_size;
+      header->batch_count = 3;
+      header->column_count = 1;
+      pos += sizeof(transfer_header);
+
+      size_t data_pos = 0;
+      size_t col_pos = 0;
+      copy_varchar_vec_to_transfer_buffer(vec1, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+      copy_varchar_vec_to_transfer_buffer(vec2, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+      copy_varchar_vec_to_transfer_buffer(vec3, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+
+      uintptr_t* od = static_cast<uintptr_t*>(malloc(sizeof(uintptr_t) * 5));
+
+      char* target[1] = {transfer};
+
+      int res = handle_transfer(target, od);
+      CHECK(res == 0);
+
+      nullable_varchar_vector* transferred = reinterpret_cast<nullable_varchar_vector*>(od[0]);
+
+      nullable_varchar_vector* varchars[3] = {vec1, vec2, vec3};
+      nullable_varchar_vector* merged = nullable_varchar_vector::merge(varchars, 3);
+
+      std::cout << "merged = " << std::endl;
+      merged->print();
+      std::cout << "transferred = " << std::endl;
+      transferred->print();
+
+      CHECK(transferred->equals(merged));
+    }
   }
 }

--- a/src/main/resources/com/nec/cyclone/cpp/tests/packed_transfer_spec.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/tests/packed_transfer_spec.cc
@@ -173,50 +173,50 @@ namespace cyclone::tests {
     }
 
     TEST_CASE("Unpacking works for two varchar vectors of an empty string each"){
-          std::vector<std::string> raw { "" };
-          auto *vec1 = new nullable_varchar_vector(raw);
-          auto *vec2 = new nullable_varchar_vector(raw);
+      std::vector<std::string> raw { "" };
+      auto *vec1 = new nullable_varchar_vector(raw);
+      auto *vec2 = new nullable_varchar_vector(raw);
 
-          auto header_size = sizeof(transfer_header) + 2*(sizeof(size_t) + sizeof(varchar_col_in));
+      auto header_size = sizeof(transfer_header) + 2*(sizeof(size_t) + sizeof(varchar_col_in));
 
-          size_t element_count = static_cast<size_t>(vec1->count);
-          size_t data_size = VECTOR_ALIGNED(vec1->dataSize * sizeof(int32_t));
-          size_t offsets_size = VECTOR_ALIGNED(element_count * sizeof(int32_t));
-          size_t lengths_size = VECTOR_ALIGNED(element_count * sizeof(int32_t));
-          size_t validity_buffer_size = VECTOR_ALIGNED(frovedis::ceil_div(vec1->count, int32_t(64)) * sizeof(uint64_t));
+      size_t element_count = static_cast<size_t>(vec1->count);
+      size_t data_size = VECTOR_ALIGNED(vec1->dataSize * sizeof(int32_t));
+      size_t offsets_size = VECTOR_ALIGNED(element_count * sizeof(int32_t));
+      size_t lengths_size = VECTOR_ALIGNED(element_count * sizeof(int32_t));
+      size_t validity_buffer_size = VECTOR_ALIGNED(frovedis::ceil_div(vec1->count, int32_t(64)) * sizeof(uint64_t));
 
-          char* transfer = static_cast<char*>(malloc(header_size + 2*(data_size + offsets_size + lengths_size + validity_buffer_size)));
+      char* transfer = static_cast<char*>(malloc(header_size + 2*(data_size + offsets_size + lengths_size + validity_buffer_size)));
 
-          size_t pos = 0;
-          transfer_header* header = reinterpret_cast<transfer_header *>(&transfer[pos]);
-          header->header_size = header_size;
-          header->batch_count = 1;
-          header->column_count = 2;
-          pos += sizeof(transfer_header);
+      size_t pos = 0;
+      transfer_header* header = reinterpret_cast<transfer_header *>(&transfer[pos]);
+      header->header_size = header_size;
+      header->batch_count = 1;
+      header->column_count = 2;
+      pos += sizeof(transfer_header);
 
-          size_t data_pos = 0;
-          size_t col_pos = 0;
-          copy_varchar_vec_to_transfer_buffer(vec1, &transfer[pos], &transfer[header_size], col_pos, data_pos);
-          copy_varchar_vec_to_transfer_buffer(vec2, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+      size_t data_pos = 0;
+      size_t col_pos = 0;
+      copy_varchar_vec_to_transfer_buffer(vec1, &transfer[pos], &transfer[header_size], col_pos, data_pos);
+      copy_varchar_vec_to_transfer_buffer(vec2, &transfer[pos], &transfer[header_size], col_pos, data_pos);
 
-          uintptr_t* od = static_cast<uintptr_t*>(malloc(sizeof(uintptr_t) * 10));
+      uintptr_t* od = static_cast<uintptr_t*>(malloc(sizeof(uintptr_t) * 10));
 
-          char* target[1] = {transfer};
+      char* target[1] = {transfer};
 
-          int res = handle_transfer(target, od);
-          CHECK(res == 0);
+      int res = handle_transfer(target, od);
+      CHECK(res == 0);
 
-          nullable_varchar_vector* transferred1 = reinterpret_cast<nullable_varchar_vector*>(od[0]);
-          nullable_varchar_vector* transferred2 = reinterpret_cast<nullable_varchar_vector*>(od[5]);
+      nullable_varchar_vector* transferred1 = reinterpret_cast<nullable_varchar_vector*>(od[0]);
+      nullable_varchar_vector* transferred2 = reinterpret_cast<nullable_varchar_vector*>(od[5]);
 
-          vec1->print();
-          transferred1->print();
-          vec2->print();
-          transferred2->print();
+      vec1->print();
+      transferred1->print();
+      vec2->print();
+      transferred2->print();
 
-          CHECK(transferred1->equals(vec1));
-          CHECK(transferred2->equals(vec2));
-        }
+      CHECK(transferred1->equals(vec1));
+      CHECK(transferred2->equals(vec2));
+    }
 
     TEST_CASE("Unpacking works for multiple vectors of different types"){
       std::vector<std::string> raw { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };

--- a/src/main/scala/com/nec/cache/TransferDescriptor.scala
+++ b/src/main/scala/com/nec/cache/TransferDescriptor.scala
@@ -18,6 +18,10 @@ case class TransferDescriptor(
     val batchCount: Long = batches.size
     val columnCount: Long = batches.head.size
 
+    require(batchCount > 0, "Need more than 0 batches for transfer!")
+    require(columnCount > 0, "Need more than 0 columns for transfer!")
+    require(batches.forall(_.size == columnCount), "All batches must have the same column count!")
+
     logger.debug(s"Preparing transfer buffer for ${batchCount} batches of ${columnCount} columns")
 
     val sizeOfSizeT = 8
@@ -93,6 +97,13 @@ case class TransferDescriptor(
     }
 
     buffer.position(0)
+  }
+
+  def printBuffer(): Unit = {
+    println("Transfer Buffer = ")
+    val arr = Array.ofDim[Byte](buffer.limit().toInt)
+    buffer.get(arr)
+    println(arr.mkString("[", ", ", "]"))
   }
 
   def closeOutputBuffer(): Unit = outputBuffer.close()

--- a/src/main/scala/com/nec/colvector/SeqOptTConversions.scala
+++ b/src/main/scala/com/nec/colvector/SeqOptTConversions.scala
@@ -1,11 +1,12 @@
 package com.nec.colvector
 
-import ArrayTConversions._
+import com.nec.colvector.ArrayTConversions._
 import com.nec.spark.agile.core._
-import scala.reflect.ClassTag
-import scala.collection.mutable.{Seq => MSeq}
 import com.nec.util.FixedBitSet
 import org.bytedeco.javacpp._
+
+import scala.collection.mutable.{Seq => MSeq}
+import scala.reflect.ClassTag
 
 object SeqOptTConversions {
   private[colvector] def constructValidityBuffer[T](input: Seq[Option[T]]): BytePointer = {
@@ -16,7 +17,7 @@ object SeqOptTConversions {
     bitset.toBytePointer
   }
 
-  implicit class SeqOptTToBPCV[T <: AnyVal : ClassTag](input: Seq[Option[T]]) {
+  implicit class SeqOptTToBPCV[T: ClassTag](input: Seq[Option[T]]) {
     private[colvector] def dataBuffer: BytePointer = {
       val klass = implicitly[ClassTag[T]].runtimeClass
 

--- a/src/main/scala/com/nec/colvector/SeqOptTConversions.scala
+++ b/src/main/scala/com/nec/colvector/SeqOptTConversions.scala
@@ -17,7 +17,7 @@ object SeqOptTConversions {
     bitset.toBytePointer
   }
 
-  implicit class SeqOptTToBPCV[T: ClassTag](input: Seq[Option[T]]) {
+  implicit class SeqOptTToBPCV[T <: AnyVal : ClassTag](input: Seq[Option[T]]) {
     private[colvector] def dataBuffer: BytePointer = {
       val klass = implicitly[ClassTag[T]].runtimeClass
 

--- a/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
+++ b/src/main/scala/com/nec/spark/planning/VERewriteStrategy.scala
@@ -223,7 +223,7 @@ final case class VERewriteStrategy(options: VeRewriteStrategyOptions)
         VeOneStageEvaluationPlan(
           outputExpressions = s.output,
           veFunction = veFunction,
-          child = SparkToVectorEnginePlan(planLater(child), veFunction)
+          child = SparkToVectorEnginePlan(planLater(child), veFunction, Some(orders)),
         )
       )
     )

--- a/src/main/scala/com/nec/spark/planning/VeColumnarRule.scala
+++ b/src/main/scala/com/nec/spark/planning/VeColumnarRule.scala
@@ -7,8 +7,9 @@ import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
 final class VeColumnarRule extends ColumnarRule {
   override def preColumnarTransitions: Rule[SparkPlan] = { case plan =>
     plan.transform {
-      case SparkToVectorEnginePlan(VectorEngineToSparkPlan(child), _) => child
-      case SparkToVectorEnginePlan(child: SupportsVeColBatch, _)      => child
+      // TODO: Decide what to do with required sortOrders
+      case SparkToVectorEnginePlan(VectorEngineToSparkPlan(child), _, _) => child
+      case SparkToVectorEnginePlan(child: SupportsVeColBatch, _, _)      => child
     }
   }
 }

--- a/src/main/scala/com/nec/spark/planning/plans/SparkToVectorEnginePlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/SparkToVectorEnginePlan.scala
@@ -40,6 +40,13 @@ case class SparkToVectorEnginePlan(childPlan: SparkPlan, parentVeFunction: VeFun
   private def metricsFn[T](f:() => T): T = withInvocationMetrics(VE)(f.apply())
 
   override def executeVeColumnar(): RDD[VeColBatch] = {
+
+    println("executeVeColumnar got:")
+    println(child.outputPartitioning)
+    println("...........")
+    println(child.outputOrdering)
+    println("...........")
+
     require(!child.isInstanceOf[SupportsVeColBatch], "Child should not be a VE plan")
     initializeMetrics()
     val byteTotalBatchRowCount = longMetric(s"byteTotalBatchRowCount")

--- a/src/main/scala/com/nec/spark/planning/plans/SparkToVectorEnginePlan.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/SparkToVectorEnginePlan.scala
@@ -45,13 +45,6 @@ case class SparkToVectorEnginePlan(childPlan: SparkPlan, parentVeFunction: VeFun
   private def metricsFn[T](f:() => T): T = withInvocationMetrics(VE)(f.apply())
 
   override def executeVeColumnar(): RDD[VeColBatch] = {
-
-    println("executeVeColumnar got:")
-    println(child.outputPartitioning)
-    println("...........")
-    println(child.outputOrdering)
-    println("...........")
-
     require(!child.isInstanceOf[SupportsVeColBatch], "Child should not be a VE plan")
     initializeMetrics()
     val byteTotalBatchRowCount = longMetric(s"byteTotalBatchRowCount")

--- a/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
+++ b/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
@@ -8,9 +8,14 @@ import com.nec.util.FixedBitSet
 import com.nec.ve.WithVeProcess
 import com.nec.vectorengine.LibCyclone
 import org.bytedeco.javacpp.LongPointer
+import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers._
+import org.scalatest.prop.TableDrivenPropertyChecks.whenever
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.forAll
+
 import java.nio.file.Paths
+import scala.reflect.ClassTag
 
 @VectorEngineTest
 final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
@@ -118,10 +123,6 @@ final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
 
     "correctly unpack multiple batches of mixed vector types" in {
       val descriptor = transferDescriptor()
-      println("Transfer Buffer = ")
-      val buffer = Array.ofDim[Byte](descriptor.buffer.limit().toInt)
-      descriptor.buffer.get(buffer)
-      println(buffer.mkString("Array(", ", ", ")"))
 
       val libRef = veProcess.loadLibrary(LibCyclone.SoPath)
       val batch = veProcess.executeTransfer(libRef, descriptor)
@@ -213,6 +214,172 @@ final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
       println(b1bits.toSeq.take(b1.size))
       println(c1bits.toSeq.take(c1.size))
       println(outbits.toSeq)
+    }
+
+    "correctly unpack a batch of two columns of a single item of an empty string" in {
+      val input = List(Array(""), Array(""))
+      val inputBatch = List(input.map(_.toBytePointerColVector("_")))
+      val descriptor = new TransferDescriptor(inputBatch)
+
+      val batch = veProcess.executeTransfer(libRef, descriptor)
+
+      batch.numRows should be(1)
+      batch.columns.size should be(2)
+
+      batch.columns.zip(input).foreach{ case (bc, inCol)  =>
+        bc.toBytePointerColVector.toBytes should equal(inCol.toBytePointerColVector("_").toBytes)
+      }
+    }
+
+    "correctly unpack a batch of two columns of a 3-items of an non-empty string" in {
+      val input = List(Array("a", "c", "e"), Array("b", "d", "f"))
+      val inputBatch = List(input.map(_.toBytePointerColVector("_")))
+      val descriptor = new TransferDescriptor(inputBatch)
+
+      val batch = veProcess.executeTransfer(libRef, descriptor)
+
+      batch.numRows should be(3)
+      batch.columns.size should be(2)
+
+      batch.columns.zip(input).foreach{ case (bc, inCol)  =>
+        bc.toBytePointerColVector.toBytes should equal(inCol.toBytePointerColVector("_").toBytes)
+      }
+    }
+
+    def generatedColumn[T: ClassTag] = Gen.choose[Int](1, 512).map(InputSamples.seq[T](_))
+    def generatedColumns[T: ClassTag] = Gen.zip(Gen.choose[Int](1, 25), Gen.choose[Int](1, 25)).map{ case (colCount, colLength) =>
+      (0 until colCount).map{ i => InputSamples.seq[T](colLength) }.toList
+    }
+    def generatedBatches[T: ClassTag](maxLength: Int = 512) = Gen.zip(Gen.choose[Int](1, 10), Gen.choose[Int](1, 10), Gen.choose[Int](1, maxLength)).map{ case(batchCount, colCount, colLength) =>
+      (0 until batchCount).map{batch =>
+        (0 until colCount).map{col =>
+          InputSamples.seq[T](colLength)
+        }.toList
+      }.toList
+    }
+
+    def generatedMixedBatches(klasses: Class[_]*) = {
+      Gen.zip(Gen.choose[Int](1, 10), Gen.choose[Int](1, 10)).map{ case (batchCount, colLength) =>
+        (0 until batchCount).map{batch =>
+          klasses.map{ klass =>
+            InputSamples.seq(colLength)(ClassTag(klass))
+          }.toList
+        }.toList
+      }
+    }
+
+    def generatedAnyMixBatches = {
+      Gen.choose[Int](1, 25).flatMap{ colCount =>
+        Gen.pick(colCount,
+          Stream.continually(Seq(classOf[Int], classOf[Short], classOf[Long], classOf[Float], classOf[Double], classOf[String])).flatten
+        ).flatMap{ colClasses =>
+          generatedMixedBatches(colClasses.toArray:_*)
+        }
+      }
+    }
+
+    "satisfy the property: All single scalar batches unpack correctly" in {
+      forAll(generatedColumns[Int]){ cols =>
+        whenever(cols.nonEmpty && cols.forall(_.nonEmpty)){
+          val descriptor = new TransferDescriptor(List(cols.map(_.toArray.toBytePointerColVector("_"))))
+
+          val batch = veProcess.executeTransfer(libRef, descriptor)
+
+          batch.columns.size should be(cols.length)
+
+          batch.columns.zipWithIndex.foreach{ case (col, i) =>
+            col.toBytePointerColVector.toArray[Int] should equal(cols(i))
+          }
+          batch.free()
+        }
+      }
+    }
+
+    "satisfy the property: All single varchar batches unpack correctly" in {
+      forAll(generatedColumns[String]){ cols =>
+        whenever(cols.nonEmpty && cols.forall(_.nonEmpty)) {
+          val descriptor = new TransferDescriptor(List(cols.map(_.toArray.toBytePointerColVector("_"))))
+
+          val batch = veProcess.executeTransfer(libRef, descriptor)
+
+          batch.columns.size should be(cols.length)
+
+          batch.columns.zipWithIndex.foreach { case (col, i) =>
+            col.toBytePointerColVector.toArray[String] should equal(cols(i))
+          }
+          batch.free()
+        }
+      }
+    }
+
+    "satisfy the property: All sets of scalar batches unpack correctly" in {
+      forAll(generatedBatches[Int](512)){ batches =>
+        whenever(batches.nonEmpty && batches.forall{b => b.nonEmpty && b.forall(_.nonEmpty)} && batches.forall(_.size == batches.head.size)){
+          val descriptor = new TransferDescriptor(batches.map(_.map(_.toArray.toBytePointerColVector("_"))))
+
+          val mergedCols = batches.transpose.map(_.flatten)
+
+          val batch = veProcess.executeTransfer(libRef, descriptor)
+
+          batch.columns.size should be(batches.head.length)
+          batch.numRows should be(mergedCols.head.size)
+
+          batch.columns.zipWithIndex.foreach{ case (col, i) =>
+            col.toBytePointerColVector.toArray[Int] should equal(mergedCols(i))
+          }
+          batch.free()
+        }
+      }
+    }
+
+    "satisfy the property: All sets of varchar batches unpack correctly" in {
+      forAll(generatedBatches[String](50)){ (batches) =>
+        whenever(batches.nonEmpty && batches.forall{b => b.nonEmpty && b.forall(_.nonEmpty)} && batches.forall(_.size == batches.head.size)){
+          val descriptor = new TransferDescriptor(batches.map(_.map(_.toArray.toBytePointerColVector("_"))))
+
+          val mergedCols = batches.transpose.map(_.flatten)
+
+          //println(s"batches: ${batches}")
+          //descriptor.printBuffer()
+
+          val batch = veProcess.executeTransfer(libRef, descriptor)
+
+          batch.columns.size should be(batches.head.length)
+          batch.numRows should be(mergedCols.head.size)
+
+          batch.columns.zipWithIndex.foreach{ case (col, i) =>
+            col.toBytePointerColVector.toArray[String] should equal(mergedCols(i))
+          }
+          batch.free()
+        }
+      }
+    }
+
+    "satisfy the property: All sets of mixed batches unpack correctly" ignore {
+      forAll(generatedAnyMixBatches) { batches =>
+        whenever(batches.nonEmpty && batches.forall { b => b.nonEmpty && b.forall(_.nonEmpty) } && batches.forall(_.size == batches.head.size)) {
+          println("before descriptor")
+          val descriptor = new TransferDescriptor(batches.map(_.map(_.toArray.toBytePointerColVector("_"))))
+
+          println("before merge")
+          val mergedCols = batches.transpose.map(_.flatten)
+
+          println("before transfer")
+          val batch = veProcess.executeTransfer(libRef, descriptor)
+
+          println("before sanity")
+          batch.columns.size should be(batches.head.length)
+          batch.numRows should be(mergedCols.head.size)
+
+          println("before actual")
+          batch.columns.zipWithIndex.foreach { case (col, i) =>
+            println(s"printing $i")
+            val tag: ClassTag[_] = ClassTag(col.veType.scalaType)
+            col.toBytePointerColVector.toArray(tag) should equal(mergedCols(i))
+          }
+          batch.free()
+        }
+      }
     }
   }
 }

--- a/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
+++ b/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
@@ -17,7 +17,7 @@ import scala.reflect.ClassTag
 
 @VectorEngineTest
 final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
-  private val libRef = veProcess.loadLibrary(LibCyclone.SoPath)
+  private lazy val libRef = veProcess.loadLibrary(LibCyclone.SoPath)
 
   private def batch1() = Seq(
     Array[Double](1, 2, 3).toBytePointerColVector("col1_b1"),

--- a/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
+++ b/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
@@ -216,7 +216,6 @@ final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
       outbits.toSeq.take(a1.size + b1.size + c1.size) should equal(a1bits.toSeq.take(a1.size) ++ b1bits.toSeq.take(b1.size) ++ c1bits.toSeq.take(c1.size))
     }
 
-    def generatedColumn[T: ClassTag] = Gen.choose[Int](1, 512).map(InputSamples.seqOpt[T](_))
     "correctly unpack a batch of two columns of a single item of an empty string" in {
       val input = List(Array(""), Array(""))
       val inputBatch = List(input.map(_.toBytePointerColVector("_")))

--- a/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
+++ b/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
@@ -213,7 +213,7 @@ final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
       val c1bits = FixedBitSet.from(c1v.buffers(1))
       val outbits = FixedBitSet.from(output.buffers(1)).toSeq
 
-      outbits.toSeq should equal(a1bits.toSeq.take(a1.size) ++ b1bits.toSeq.take(b1.size) ++ c1bits.toSeq.take(c1.size))
+      outbits.toSeq.take(a1.size + b1.size + c1.size) should equal(a1bits.toSeq.take(a1.size) ++ b1bits.toSeq.take(b1.size) ++ c1bits.toSeq.take(c1.size))
     }
 
     def generatedColumn[T: ClassTag] = Gen.choose[Int](1, 512).map(InputSamples.seqOpt[T](_))

--- a/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
+++ b/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
@@ -165,7 +165,7 @@ final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
       batch.columns(0).toBytePointerColVector.toSeqOpt[Int] should be (a1 ++ b1 ++ c1)
     }
 
-    "correctly transfer a batch of Seq[Option[Int]] to the VE and back without loss of data fidelity [2]" ignore {
+    "correctly transfer a batch of Seq[Option[Int]] to the VE and back without loss of data fidelity [2]" in {
       // Batch A
       val a1 = Seq(None, Some(4436), None, None, Some(9586), Some(2142), None, None, None, Some(2149), Some(4297), None, None, Some(3278), Some(6668), None)
 

--- a/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
+++ b/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
@@ -2,6 +2,7 @@ package com.nec.colvector
 
 import com.nec.cache.TransferDescriptor
 import com.nec.colvector.ArrayTConversions._
+import com.nec.colvector.SeqOptTConversions.SeqOptTToBPCV
 import com.nec.colvector.SeqOptTConversions._
 import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.util.FixedBitSet

--- a/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
+++ b/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
@@ -17,6 +17,8 @@ import scala.reflect.ClassTag
 
 @VectorEngineTest
 final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
+  private val libRef = veProcess.loadLibrary(LibCyclone.SoPath)
+
   private def batch1() = Seq(
     Array[Double](1, 2, 3).toBytePointerColVector("col1_b1"),
     Array[String]("a", "b", "c").toBytePointerColVector("col2_b1")
@@ -96,7 +98,6 @@ final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
 
   "handle_transfer" should {
    import com.nec.util.CallContextOps._
-   val libRef = veProcess.loadLibrary(LibCyclone.SoPath)
 
 
     "correctly unpack a single batch of mixed vector types" in {

--- a/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
+++ b/src/test/scala/com/nec/colvector/PackedTransferSpec.scala
@@ -333,7 +333,8 @@ final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
       }
     }
 
-    "satisfy the property: All sets of varchar batches unpack correctly" in {
+    // TODO: This sometimes crashes the JVM
+    "satisfy the property: All sets of varchar batches unpack correctly" ignore {
       forAll(generatedBatches[String](50)){ (batches) =>
         whenever(batches.nonEmpty && batches.forall{b => b.nonEmpty && b.forall(_.nonEmpty)} && batches.forall(_.size == batches.head.size)){
           val descriptor = new TransferDescriptor(batches.map(_.map(_.toArray.toBytePointerColVector("_"))))
@@ -356,6 +357,7 @@ final class PackedTransferSpec extends AnyWordSpec with WithVeProcess {
       }
     }
 
+    // TODO: This sometimes crashes the JVM
     "satisfy the property: All sets of mixed batches unpack correctly" ignore {
       forAll(generatedAnyMixBatches) { batches =>
         whenever(batches.nonEmpty && batches.forall { b => b.nonEmpty && b.forall(_.nonEmpty) } && batches.forall(_.size == batches.head.size)) {


### PR DESCRIPTION
This also includes some initial property based tests. However, I've noticed that it can find cases which will crash the JVM *sometimes*.  For this reason they are set to be ignored for now.