### PR TITLE
[NS-44] Vectorize Merge

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
@@ -221,3 +221,52 @@ namespace cyclone {
     }
   }
 }
+
+template<typename T>
+void fast_validity_merge(uint64_t *outbuf, T * const * const inputs, const size_t batches) {
+  auto dangling_bits = 0;
+  auto ox = 0;
+  outbuf[0] = 0;
+
+  for (auto b=0; b<batches; b++) {
+
+    size_t wordcnt = inputs[b]->count / 64;
+    size_t restcnt = inputs[b]->count  % 64;
+
+    // if there is any rest bits to copy in wordcnt+1,
+    // we copy the whole 64 bit as if they were fully used
+    wordcnt += restcnt ? 1 : 0;
+
+    uint64_t mask =  UINT64_MAX >> dangling_bits;
+    uint64_t vmask = UINT64_MAX >> (64-restcnt);
+
+
+    // copy whole words from source batch
+    // since we might need to shift the bits by "dangling_bits" in the output
+    // to not overwrite the odd bits at the end of the last merged input,
+    // one source word might need to be split and written to 2 destination words
+    for (auto i=0; i<wordcnt; i++) {
+
+      uint64_t validity_bits = inputs[b]->validityBuffer[i];
+
+      if (i == wordcnt - 1) validity_bits &= vmask;
+
+      uint64_t lower_half = (validity_bits & mask) << dangling_bits;
+      uint64_t upper_half = (validity_bits & ~mask) >> (64 - dangling_bits);
+
+      outbuf[ox++] |= lower_half;
+      outbuf[ox] = upper_half;
+
+    }
+
+    // now it might be, that the last word has not been used,
+    // i.e. the upper_half above wasn't used at all and there are
+    // a few bits left in the second to last word.
+    // So, if there is at least one bit left, we need to
+    // set back the output index ox to point to that location:
+    ox = ox - 1 + (restcnt + dangling_bits) / 64;
+
+    // update dangling_bits
+    dangling_bits = (dangling_bits + restcnt) % 64;
+   }
+}

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
@@ -224,49 +224,21 @@ namespace cyclone {
 
 template<typename T>
 void fast_validity_merge(uint64_t *outbuf, T * const * const inputs, const size_t batches) {
-  auto dangling_bits = 0;
-  auto ox = 0;
-  outbuf[0] = 0;
+  size_t dangling_bits = 0;
+  auto bit_output_cnt = 0;
 
   for (auto b=0; b<batches; b++) {
 
-    size_t wordcnt = inputs[b]->count / 64;
-    size_t restcnt = inputs[b]->count  % 64;
+      auto current_output_pos = bit_output_cnt / 64;
 
-    // if there is any rest bits to copy in wordcnt+1,
-    // we copy the whole 64 bit as if they were fully used
-    wordcnt += restcnt ? 1 : 0;
+      dangling_bits = cyclone::append_bitsets(
+        &outbuf[current_output_pos],
+        dangling_bits,
+        inputs[b]->validityBuffer,
+        inputs[b]->count
+       );
 
-    uint64_t mask =  UINT64_MAX >> dangling_bits;
-    uint64_t vmask = UINT64_MAX >> (64-restcnt);
-
-
-    // copy whole words from source batch
-    // since we might need to shift the bits by "dangling_bits" in the output
-    // to not overwrite the odd bits at the end of the last merged input,
-    // one source word might need to be split and written to 2 destination words
-    for (auto i=0; i<wordcnt; i++) {
-
-      uint64_t validity_bits = inputs[b]->validityBuffer[i];
-
-      if (i == wordcnt - 1) validity_bits &= vmask;
-
-      uint64_t lower_half = (validity_bits & mask) << dangling_bits;
-      uint64_t upper_half = (validity_bits & ~mask) >> (64 - dangling_bits);
-
-      outbuf[ox++] |= lower_half;
-      if (ox < wordcnt) outbuf[ox] = upper_half;
-
-    }
-
-    // now it might be, that the last word has not been used,
-    // i.e. the upper_half above wasn't used at all and there are
-    // a few bits left in the second to last word.
-    // So, if there is at least one bit left, we need to
-    // set back the output index ox to point to that location:
-    ox = ox - 1 + (restcnt + dangling_bits) / 64;
-
-    // update dangling_bits
-    dangling_bits = (dangling_bits + restcnt) % 64;
+      bit_output_cnt += inputs[b]->count;
    }
 }
+

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
@@ -224,21 +224,20 @@ namespace cyclone {
 
 template<typename T>
 void fast_validity_merge(uint64_t *outbuf, T * const * const inputs, const size_t batches) {
-  size_t dangling_bits = 0;
-  auto bit_output_cnt = 0;
+  size_t bit_output_cnt = 0;
 
   for (auto b=0; b<batches; b++) {
 
-      auto current_output_pos = bit_output_cnt / 64;
+      size_t inputs_cnt = inputs[b]->count;
 
-      dangling_bits = cyclone::append_bitsets(
-        &outbuf[current_output_pos],
-        dangling_bits,
+      cyclone::append_bitsets(
+        outbuf,
+        bit_output_cnt,
         inputs[b]->validityBuffer,
-        inputs[b]->count
+        inputs_cnt
        );
 
-      bit_output_cnt += inputs[b]->count;
+      bit_output_cnt += inputs_cnt;
    }
 }
 

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/cyclone_utils.hpp
@@ -255,7 +255,7 @@ void fast_validity_merge(uint64_t *outbuf, T * const * const inputs, const size_
       uint64_t upper_half = (validity_bits & ~mask) >> (64 - dangling_bits);
 
       outbuf[ox++] |= lower_half;
-      outbuf[ox] = upper_half;
+      if (ox < wordcnt) outbuf[ox] = upper_half;
 
     }
 

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
@@ -21,7 +21,6 @@
 #include "frovedis/core/utility.hpp"
 #include "frovedis/core/radix_sort.hpp"
 #include "frovedis/core/set_operations.hpp"
-#include "cyclone_utils.hpp"
 #include <stdlib.h>
 #include <iostream>
 
@@ -356,7 +355,14 @@ NullableScalarVec<T> * NullableScalarVec<T>::merge(const NullableScalarVec<T> * 
   }
 
   // Copy the data and preserve the validityBuffer across the merge
-  fast_validity_merge(output->validityBuffer, inputs, batches);
+  auto o = 0;
+  #pragma _NEC ivdep
+  for (auto b = 0; b < batches; b++) {
+    for (auto i = 0; i < inputs[b]->count; i++) {
+      output->data[o] = inputs[b]->data[i];
+      output->set_validity(o++, inputs[b]->get_validity(i));
+    }
+  }
 
   return output;
 }

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
@@ -21,6 +21,7 @@
 #include "frovedis/core/utility.hpp"
 #include "frovedis/core/radix_sort.hpp"
 #include "frovedis/core/set_operations.hpp"
+#include "cyclone_utils.hpp"
 #include <stdlib.h>
 #include <iostream>
 
@@ -354,15 +355,17 @@ NullableScalarVec<T> * NullableScalarVec<T>::merge(const NullableScalarVec<T> * 
     std::cerr << "NullableScalarVec<T>::merge() (validity) failed." << std::endl;
   }
 
-  // Copy the data and preserve the validityBuffer across the merge
+  // Copy the data
   auto o = 0;
   #pragma _NEC ivdep
   for (auto b = 0; b < batches; b++) {
     for (auto i = 0; i < inputs[b]->count; i++) {
       output->data[o] = inputs[b]->data[i];
-      output->set_validity(o++, inputs[b]->get_validity(i));
     }
   }
+
+  // Preserve the validityBuffer across the merge
+  fast_validity_merge(output->validityBuffer, inputs, batches);
 
   return output;
 }

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
@@ -360,7 +360,7 @@ NullableScalarVec<T> * NullableScalarVec<T>::merge(const NullableScalarVec<T> * 
   #pragma _NEC ivdep
   for (auto b = 0; b < batches; b++) {
     for (auto i = 0; i < inputs[b]->count; i++) {
-      output->data[o] = inputs[b]->data[i];
+      output->data[o++] = inputs[b]->data[i];
     }
   }
 

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_scalar_vector.cc
@@ -21,6 +21,7 @@
 #include "frovedis/core/utility.hpp"
 #include "frovedis/core/radix_sort.hpp"
 #include "frovedis/core/set_operations.hpp"
+#include "cyclone_utils.hpp"
 #include <stdlib.h>
 #include <iostream>
 
@@ -355,14 +356,7 @@ NullableScalarVec<T> * NullableScalarVec<T>::merge(const NullableScalarVec<T> * 
   }
 
   // Copy the data and preserve the validityBuffer across the merge
-  auto o = 0;
-  #pragma _NEC ivdep
-  for (auto b = 0; b < batches; b++) {
-    for (auto i = 0; i < inputs[b]->count; i++) {
-      output->data[o] = inputs[b]->data[i];
-      output->set_validity(o++, inputs[b]->get_validity(i));
-    }
-  }
+  fast_validity_merge(output->validityBuffer, inputs, batches);
 
   return output;
 }

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -484,16 +484,6 @@ nullable_varchar_vector * nullable_varchar_vector::merge(const nullable_varchar_
   auto *output = from_words(frovedis::merge_multi_words(multi_words));
 
   // Preserve the validityBuffer across the merge
-  /*
-  auto o = 0;
-  #pragma _NEC ivdep
-  for (auto b = 0; b < batches; b++) {
-    for (auto i = 0; i < inputs[b]->count; i++) {
-      output->set_validity(o++, inputs[b]->get_validity(i));
-    }
-  }
-  */
-
   auto dangling_bits = 0;
   auto ox = 0;
   uint64_t* outbuf = output->validityBuffer;

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -511,14 +511,6 @@ nullable_varchar_vector * nullable_varchar_vector::merge(const nullable_varchar_
     uint64_t mask =  UINT64_MAX >> dangling_bits;
     uint64_t vmask = UINT64_MAX >> (64-restcnt);
 
-    // debug
-    printf("======================\nBatch: %d\n", b);
-    printf("ox: %d\n", ox);
-    printf("dangling: %d\n", dangling_bits);
-    printf("mask: %016llx\n", mask);
-    printf("wordcnt:  %d\n", wordcnt);
-    printf("restcnt:  %d\n", restcnt);
-
 
     // copy whole words from source batch
     // since we might need to shift the bits by "dangling_bits" in the output
@@ -533,15 +525,8 @@ nullable_varchar_vector * nullable_varchar_vector::merge(const nullable_varchar_
       uint64_t lower_half = (validity_bits & mask) << dangling_bits;
       uint64_t upper_half = (validity_bits & ~mask) >> (64 - dangling_bits);
 
-      printf("validity: %016llx\n", validity_bits);
-      printf("lower   : %016llx\n", lower_half);
-      printf("upper   : %016llx\n", upper_half);
-     
       outbuf[ox++] |= lower_half;
       outbuf[ox] = upper_half;
-
-      printf("out[ox] : %016llx\n", outbuf[ox-1]);
-      printf("out[ox+1] %016llx\n", outbuf[ox]);
 
     }
 

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -514,8 +514,10 @@ nullable_varchar_vector * nullable_varchar_vector::merge(const nullable_varchar_
     // debug
     printf("======================\nBatch: %d\n", b);
     printf("ox: %d\n", ox);
-    printf("dangling: %d\n=================\n", dangling_bits);
+    printf("dangling: %d\n", dangling_bits);
     printf("mask: %016llx\n", mask);
+    printf("wordcnt:  %d\n", wordcnt);
+    printf("restcnt:  %d\n", restcnt);
 
 
     // copy whole words from source batch
@@ -524,7 +526,7 @@ nullable_varchar_vector * nullable_varchar_vector::merge(const nullable_varchar_
     // one source word might need to be split and written to 2 destination words
     for (auto i=0; i<wordcnt; i++) {
 
-      uint64_t validity_bits = inputs[b]->validityBuffer[i] & mask;
+      uint64_t validity_bits = inputs[b]->validityBuffer[i];
 
       if (i == wordcnt - 1) validity_bits &= vmask;
 

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -24,6 +24,7 @@
 #include "frovedis/text/dict.hpp"
 #include <stdlib.h>
 #include <iostream>
+#include <cstring>
 
 nullable_varchar_vector * nullable_varchar_vector::allocate() {
   // Allocate

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -22,6 +22,7 @@
 #include "frovedis/text/char_int_conv.hpp"
 #include "frovedis/text/datetime_utility.hpp"
 #include "frovedis/text/dict.hpp"
+#include "cyclone_utils.hpp"
 #include <stdlib.h>
 #include <iostream>
 #include <cstring>
@@ -468,55 +469,6 @@ const std::vector<int32_t> nullable_varchar_vector::validity_vec() const {
   }
 
   return bitmask;
-}
-
-template<typename T>
-void fast_validity_merge(uint64_t *outbuf, T * const * const inputs, const size_t batches) {
-  auto dangling_bits = 0;
-  auto ox = 0;
-  outbuf[0] = 0;
-
-  for (auto b=0; b<batches; b++) {
-
-    size_t wordcnt = inputs[b]->count / 64;
-    size_t restcnt = inputs[b]->count  % 64;
-
-    // if there is any rest bits to copy in wordcnt+1,
-    // we copy the whole 64 bit as if they were fully used
-    wordcnt += restcnt ? 1 : 0;
-
-    uint64_t mask =  UINT64_MAX >> dangling_bits;
-    uint64_t vmask = UINT64_MAX >> (64-restcnt);
-
-
-    // copy whole words from source batch
-    // since we might need to shift the bits by "dangling_bits" in the output
-    // to not overwrite the odd bits at the end of the last merged input,
-    // one source word might need to be split and written to 2 destination words
-    for (auto i=0; i<wordcnt; i++) {
-
-      uint64_t validity_bits = inputs[b]->validityBuffer[i];
-
-      if (i == wordcnt - 1) validity_bits &= vmask;
-
-      uint64_t lower_half = (validity_bits & mask) << dangling_bits;
-      uint64_t upper_half = (validity_bits & ~mask) >> (64 - dangling_bits);
-
-      outbuf[ox++] |= lower_half;
-      outbuf[ox] = upper_half;
-
-    }
-
-    // now it might be, that the last word has not been used,
-    // i.e. the upper_half above wasn't used at all and there are
-    // a few bits left in the second to last word.
-    // So, if there is at least one bit left, we need to
-    // set back the output index ox to point to that location:
-    ox = ox - 1 + (restcnt + dangling_bits) / 64;
-
-    // update dangling_bits
-    dangling_bits = (dangling_bits + restcnt) % 64;
-   }
 }
 
 nullable_varchar_vector * nullable_varchar_vector::merge(const nullable_varchar_vector * const * const inputs,

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <type_traits>
 #include <iostream>
+#include <cstring>
 
 void merge_varchar_transfer(size_t batch_count, char* col_header, char* input_data, char* out_data, uint64_t* out_validity_buffer, char* out_lengths, char* out_offsets, uintptr_t* od, size_t &output_pos){
   //std::cout << "merge_varchar_transfer" << std::endl;


### PR DESCRIPTION
From #584, which unfortunately started from an unclean state:

Fix for NS-44 (Replace bitwise merge with vectorized merge):

nullable_scalar_vector and nullable_varchar_vector now use cyclone_utils::fast_validity_merge for vectorized merge of validity bits.

I'd love to know, if it's any faster now...