### PR TITLE
[NS-50] Re-enable Aggregation Support for rows with String columns

### DIFF
--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -729,6 +729,15 @@ void nullable_varchar_vector::group_indexes_on_subset(const size_t  * input_inde
                                                       size_t        * output_index_arr,
                                                       size_t        * output_group_delims_arr,
                                                       size_t        & output_group_delims_len) const {
+  std::cout << "group_indexes_on_subset(): size                     = " << this->count << std::endl;
+  std::cout << "group_indexes_on_subset(): input_index_arr0         = " << input_index_arr0 << std::endl;
+  std::cout << "group_indexes_on_subset(): input_group_delims_arr   = " << input_group_delims_arr << std::endl;
+  std::cout << "group_indexes_on_subset(): input_group_delims_len   = " << input_group_delims_len << std::endl;
+  std::cout << "group_indexes_on_subset(): output_index_arr         = " << output_index_arr << std::endl;
+  std::cout << "group_indexes_on_subset(): output_group_delims_arr  = " << output_group_delims_arr << std::endl;
+  std::cout << "group_indexes_on_subset(): output_group_delims_len  = " << output_group_delims_len << std::endl;
+  std::cout << "START 0" << std::endl;
+
   // For compatibility purposes, we allow input_index_arr0 to be nullptr.  If it
   // is indeed nullptr, then we generate the index array from 0 to this->count.
   std::vector<size_t> _input_index(this->count);
@@ -742,10 +751,14 @@ void nullable_varchar_vector::group_indexes_on_subset(const size_t  * input_inde
     }
   }
 
+  std::cout << "REACHED 1" << std::endl;
+
   // Fetch the full range start and end
   auto range_start = input_group_delims_arr[0];
   auto range_end   = input_group_delims_arr[input_group_delims_len - 1];
   auto range_size  = range_end - range_start;
+
+  std::cout << "range_size = " << range_size << std::endl;
 
   {
     // If there are more group positions than elements in the vector, it means
@@ -758,6 +771,8 @@ void nullable_varchar_vector::group_indexes_on_subset(const size_t  * input_inde
     }
   }
 
+  std::cout << "REACHED 2" << std::endl;
+
   // Initialize the output group delims
   output_group_delims_len = 0;
   output_group_delims_arr[output_group_delims_len++] = input_group_delims_arr[0];
@@ -767,8 +782,8 @@ void nullable_varchar_vector::group_indexes_on_subset(const size_t  * input_inde
   auto sorted_data = sort_buffer.data();
 
   // Initialize temporary buffers using std::vector for RAII cleanup
-  std::vector<size_t> grp_buffer1(range_size);
-  std::vector<size_t> grp_buffer2(range_size);
+  std::vector<size_t> grp_buffer1(range_size + 1);
+  std::vector<size_t> grp_buffer2(range_size + 1);
   auto * grp_data1 = grp_buffer1.data();
   auto * grp_data2 = grp_buffer2.data();
 
@@ -872,6 +887,9 @@ void nullable_varchar_vector::group_indexes_on_subset(const size_t  * input_inde
             grp_data2,
             grp_len2
           );
+
+          std::cout << "grp_len1 = " << grp_len1 << std::endl;
+          std::cout << "grp_len2 = " << grp_len2 << std::endl;
 
           // Swap grp_data1 and grp_data2
           auto *tmpd = grp_data2;

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -729,15 +729,6 @@ void nullable_varchar_vector::group_indexes_on_subset(const size_t  * input_inde
                                                       size_t        * output_index_arr,
                                                       size_t        * output_group_delims_arr,
                                                       size_t        & output_group_delims_len) const {
-  std::cout << "group_indexes_on_subset(): size                     = " << this->count << std::endl;
-  std::cout << "group_indexes_on_subset(): input_index_arr0         = " << input_index_arr0 << std::endl;
-  std::cout << "group_indexes_on_subset(): input_group_delims_arr   = " << input_group_delims_arr << std::endl;
-  std::cout << "group_indexes_on_subset(): input_group_delims_len   = " << input_group_delims_len << std::endl;
-  std::cout << "group_indexes_on_subset(): output_index_arr         = " << output_index_arr << std::endl;
-  std::cout << "group_indexes_on_subset(): output_group_delims_arr  = " << output_group_delims_arr << std::endl;
-  std::cout << "group_indexes_on_subset(): output_group_delims_len  = " << output_group_delims_len << std::endl;
-  std::cout << "START 0" << std::endl;
-
   // For compatibility purposes, we allow input_index_arr0 to be nullptr.  If it
   // is indeed nullptr, then we generate the index array from 0 to this->count.
   std::vector<size_t> _input_index(this->count);
@@ -751,14 +742,10 @@ void nullable_varchar_vector::group_indexes_on_subset(const size_t  * input_inde
     }
   }
 
-  std::cout << "REACHED 1" << std::endl;
-
   // Fetch the full range start and end
   auto range_start = input_group_delims_arr[0];
   auto range_end   = input_group_delims_arr[input_group_delims_len - 1];
   auto range_size  = range_end - range_start;
-
-  std::cout << "range_size = " << range_size << std::endl;
 
   {
     // If there are more group positions than elements in the vector, it means
@@ -771,8 +758,6 @@ void nullable_varchar_vector::group_indexes_on_subset(const size_t  * input_inde
     }
   }
 
-  std::cout << "REACHED 2" << std::endl;
-
   // Initialize the output group delims
   output_group_delims_len = 0;
   output_group_delims_arr[output_group_delims_len++] = input_group_delims_arr[0];
@@ -781,7 +766,9 @@ void nullable_varchar_vector::group_indexes_on_subset(const size_t  * input_inde
   std::vector<int32_t> sort_buffer(range_size);
   auto sorted_data = sort_buffer.data();
 
-  // Initialize temporary buffers using std::vector for RAII cleanup
+  // Initialize temporary buffers using std::vector for RAII cleanup.  This
+  // buffer needs to be range_size + 1 to account for the case where the function
+  // is given only one subset as input and every element is its own group.
   std::vector<size_t> grp_buffer1(range_size + 1);
   std::vector<size_t> grp_buffer2(range_size + 1);
   auto * grp_data1 = grp_buffer1.data();
@@ -887,9 +874,6 @@ void nullable_varchar_vector::group_indexes_on_subset(const size_t  * input_inde
             grp_data2,
             grp_len2
           );
-
-          std::cout << "grp_len1 = " << grp_len1 << std::endl;
-          std::cout << "grp_len2 = " << grp_len2 << std::endl;
 
           // Swap grp_data1 and grp_data2
           auto *tmpd = grp_data2;

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
@@ -156,12 +156,12 @@ struct NullableScalarVec {
   // out_group_pos will be in the same format as group_pos and delineate the
   // found groups
   // out_group_pos_size will contain the number of elements in out_group_group_pos
-  void group_indexes_on_subset(const size_t * iter_order_arr,
-                               const size_t * group_pos,
-                               const size_t group_pos_size,
-                               size_t * idx_arr,
-                               size_t * out_group_pos,
-                               size_t & out_group_pos_size) const;
+  void group_indexes_on_subset(const size_t * input_index_arr0,
+                               const size_t * input_group_delims_arr,
+                               const size_t   input_group_delims_len,
+                               size_t       * output_index_arr,
+                               size_t       * output_group_delims_arr,
+                               size_t       & output_group_delims_len) const;
 };
 
 // Explicitly instantiate struct template for int32_t
@@ -340,17 +340,25 @@ struct nullable_varchar_vector {
     The delimiters of the groups are given by the indices relative to the input array:
       [ 0, 2, 3, 4, 5, 6, 7, 8, 9, 19, 12, 13, 14, 15, 17 ]
 
-
     group_indexes_on_subset() applies the sort + grouping algorithm onto on
     multiple contiguous ranges of the nullable_varchar_vector.
 
     Function Arguments:
-      input_index_arr0        : An array of indices of the elements (sort values).  If set to nullptr, the regular iteration order is used.
-      input_group_delims_arr  : Indices that denote the subset ranges to be sorted.  Index values are relative to this->data.
+      input_index_arr0        : An array of indices of the elements (sort values).
+                                If set to nullptr, the regular iteration order is used.
+      input_group_delims_arr  : Indices that denote the subset ranges to be sorted.
+                                Index values are relative to `this->data`.
       input_group_delims_len  : Length of the input indices.
-      output_index_arr        : An array of indices that reflect input_index_arr0 after sort + grouping (pre-allocated and to be written).
-      output_group_delims_arr : Combined indices where the values change after sort + grouping (pre-allocated and to be written).  Index values are relative to this->data.
-      output_group_delims_len : Length of output_group_delims_arr (to be written).  Index values are relative to this->data.
+      output_index_arr        : An array of indices that reflect input_index_arr0
+                                after sort + grouping (pre-allocated and to be written).
+      output_group_delims_arr : Combined indices where the values change after
+                                sort + grouping (pre-allocated and to be written).
+                                Index values are relative to `this->data`.  The
+                                pre-allocated size should be at least `range_size + 1`
+                                where `range_size` refers to the range from the
+                                0th to last delimiter in input_group_delims_arr.
+      output_group_delims_len : Length of output_group_delims_arr (to be written).
+                                Index values are relative to `this->data`.
   */
   void group_indexes_on_subset(const size_t * input_index_arr0,
                                const size_t * input_group_delims_arr,

--- a/src/main/resources/io/sparkcyclone/cpp/examples.cpp
+++ b/src/main/resources/io/sparkcyclone/cpp/examples.cpp
@@ -278,6 +278,43 @@ void test_string_grouping2() {
   std::cout << output_group_delims << std::endl;
 }
 
+void foo() {
+      // Set up input
+      auto input1 = std::vector<std::string> { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
+      auto vec1 = new nullable_varchar_vector(input1);
+
+      // Expected output - because the group delims are in [3, 17), index values
+      // at positions [0, 1, 2, 17, 18] are set to 0, so will point to `JAN`
+      auto input2 = std::vector<std::string> { "APR", "AUG", "DEC" , "FEB", "JAN", "JUL", "JUN", "MAR", "MAY", "NOV", "OCT", "SEP" };
+      auto vec2 = new nullable_varchar_vector(input2);
+      auto expected_group_delims = std::vector<size_t> { 3, 4, 5, 6, 7, 8, 9, 11, 12, 14, 15, 16, 17 };
+
+      auto input_group_delims = std::vector<size_t> { 0, 12 };
+
+      // Set up output
+      std::vector<size_t> output_index(vec1->count);
+      std::vector<size_t> output_group_delims(vec1->count + 1);
+      size_t output_group_delims_len;
+
+      // Group indices
+      vec1->group_indexes_on_subset(
+        nullptr,
+        input_group_delims.data(),
+        input_group_delims.size(),
+        output_index.data(),
+        output_group_delims.data(),
+        output_group_delims_len
+      );
+
+      // Adjust the output
+      output_group_delims.resize(output_group_delims_len);
+
+      // CHECK(vec1->select(output_index)->equivalent_to(vec2));
+      // CHECK(output_group_delims == expected_group_delims);
+      std::cout << "output_group_delims: " << output_group_delims << std::endl;
+}
+
+
 int main() {
   // projection_test();
   // filter_test();
@@ -287,5 +324,6 @@ int main() {
   // test_statement_expressions();
 
   // test_multiple_grouping();
-  test_string_grouping();
+  // test_string_grouping();
+  foo();
 }

--- a/src/main/resources/io/sparkcyclone/cpp/examples.cpp
+++ b/src/main/resources/io/sparkcyclone/cpp/examples.cpp
@@ -218,34 +218,13 @@ void test_multiple_grouping() {
   std::cout << "================================================================================" << std::endl;
 }
 
-void test_string_grouping() {
-  auto input = std::vector<std::string> { "JAN", "JANU", "FEBU", "FEB", "MARCH", "MARCG", "APR", "APR", "JANU", "SEP", "OCT", "NOV", "DEC2", "DEC1", "DEC0" };
-  std::cout << input << std::endl;
-  auto vec1 = nullable_varchar_vector(input);
-  vec1.set_validity(3, 0);
-  vec1.set_validity(10, 0);
-
-  auto groups = vec1.group_indexes();
-
-  std::cout << groups << std::endl;
-  std::cout << "[ ";
-  for (auto group : groups) {
-    for (auto i : group) {
-      std::cout << input[i] << ", ";
-    }
-  }
-  std::cout << " ]" << std::endl;
-}
-
-void test_string_grouping2() {
-  auto input = std::vector<std::string> { "JAN", "JANU", "FEBU", "FEB", "MARCH", "MARCG", "APR", "NOV", "MARCG", "SEPT", "SEPT", "APR", "JANU", "SEP", "OCT", "NOV", "DEC2", "DEC1", "DEC0" };
-  std::cout << input << std::endl;
-  auto vec1 = new nullable_varchar_vector(input);
+void test_scalar_grouping() {
+  auto input = std::vector<int32_t> { 77, 1, 2, 2, 3, 3, 4, 11, 3, 9, 9, 4, 1, 9, 10, 11, 12, 42, -8 };
+  auto vec1 = new NullableScalarVec<int32_t>(input);
   vec1->set_validity(7, 0);
   vec1->set_validity(11, 0);
   vec1->set_validity(13, 0);
 
-  vec1->print();
 
   // Sort 3 subsets separately
   auto input_group_delims = std::vector<size_t> { 3, 8, 14, 17 };
@@ -268,52 +247,46 @@ void test_string_grouping2() {
   // Adjust the output
   output_group_delims.resize(output_group_delims_len);
 
-  std::cout << std::endl;
-  // vec1->print();
-  // std::cout << "data = " << vec1->data[0] << std::endl;
+  std::cout << input << std::endl;
   std::cout << input_group_delims << std::endl;
-  // std::cout << output_group_delims << std::endl;
+  vec1->print();
   vec1->select(output_index)->print();
-
   std::cout << output_group_delims << std::endl;
 }
+void test_varchar_grouping() {
+  auto input = std::vector<std::string> { "JAN", "JANU", "FEBU", "FEB", "MARCH", "MARCG", "APR", "NOV", "MARCG", "SEPT", "SEPT", "APR", "JANU", "SEP", "OCT", "NOV", "DEC2", "DEC1", "DEC0" };
+  auto vec1 = new nullable_varchar_vector(input);
+  vec1->set_validity(7, 0);
+  vec1->set_validity(11, 0);
+  vec1->set_validity(13, 0);
 
-void foo() {
-      // Set up input
-      auto input1 = std::vector<std::string> { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
-      auto vec1 = new nullable_varchar_vector(input1);
+  // Sort 3 subsets separately
+  auto input_group_delims = std::vector<size_t> { 3, 8, 14, 17 };
 
-      // Expected output - because the group delims are in [3, 17), index values
-      // at positions [0, 1, 2, 17, 18] are set to 0, so will point to `JAN`
-      auto input2 = std::vector<std::string> { "APR", "AUG", "DEC" , "FEB", "JAN", "JUL", "JUN", "MAR", "MAY", "NOV", "OCT", "SEP" };
-      auto vec2 = new nullable_varchar_vector(input2);
-      auto expected_group_delims = std::vector<size_t> { 3, 4, 5, 6, 7, 8, 9, 11, 12, 14, 15, 16, 17 };
+  // Set up output
+  std::vector<size_t> output_index(vec1->count);
+  std::vector<size_t> output_group_delims(vec1->count + 1);
+  size_t output_group_delims_len;
 
-      auto input_group_delims = std::vector<size_t> { 0, 12 };
+  // Group indices
+  vec1->group_indexes_on_subset(
+    nullptr,
+    input_group_delims.data(),
+    input_group_delims.size(),
+    output_index.data(),
+    output_group_delims.data(),
+    output_group_delims_len
+  );
 
-      // Set up output
-      std::vector<size_t> output_index(vec1->count);
-      std::vector<size_t> output_group_delims(vec1->count + 1);
-      size_t output_group_delims_len;
+  // Adjust the output
+  output_group_delims.resize(output_group_delims_len);
 
-      // Group indices
-      vec1->group_indexes_on_subset(
-        nullptr,
-        input_group_delims.data(),
-        input_group_delims.size(),
-        output_index.data(),
-        output_group_delims.data(),
-        output_group_delims_len
-      );
-
-      // Adjust the output
-      output_group_delims.resize(output_group_delims_len);
-
-      // CHECK(vec1->select(output_index)->equivalent_to(vec2));
-      // CHECK(output_group_delims == expected_group_delims);
-      std::cout << "output_group_delims: " << output_group_delims << std::endl;
+  std::cout << input << std::endl;
+  std::cout << input_group_delims << std::endl;
+  vec1->print();
+  vec1->select(output_index)->print();
+  std::cout << output_group_delims << std::endl;
 }
-
 
 int main() {
   // projection_test();
@@ -324,6 +297,6 @@ int main() {
   // test_statement_expressions();
 
   // test_multiple_grouping();
-  // test_string_grouping();
-  foo();
+  test_scalar_grouping();
+  test_varchar_grouping();
 }

--- a/src/main/resources/io/sparkcyclone/cpp/tests/nullable_varchar_vector_spec.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/tests/nullable_varchar_vector_spec.cc
@@ -364,7 +364,7 @@ namespace cyclone::tests {
       CHECK(result == expected);
     }
 
-    TEST_CASE("group_indexes_on_subset works [2] (having every element end up in its own group should not cause crash)") {
+    TEST_CASE("group_indexes_on_subset works [2] (grouping the full range and having every element end up in its own group should not cause crash)") {
       // Set up input
       auto input1 = std::vector<std::string> { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
       auto vec1 = new nullable_varchar_vector(input1);
@@ -399,7 +399,7 @@ namespace cyclone::tests {
       CHECK(output_group_delims == expected_group_delims);
     }
 
-    TEST_CASE("group_indexes_on_subset works [3] (some groups have multiple elements)") {
+    TEST_CASE("group_indexes_on_subset works [3] (grouping multiple subsets of a range, where some groups have multiple elements)") {
       // Set up input
       auto input1 = std::vector<std::string> { "JAN", "JANU", "FEBU", "FEB", "MARCH", "MARCG", "APR", "NOV", "MARCG", "SEPT", "SEPT", "APR", "JANU", "SEP", "OCT", "NOV", "DEC2", "DEC1", "DEC0" };
       auto vec1 = new nullable_varchar_vector(input1);

--- a/src/main/resources/io/sparkcyclone/cpp/tests/nullable_varchar_vector_spec.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/tests/nullable_varchar_vector_spec.cc
@@ -364,7 +364,42 @@ namespace cyclone::tests {
       CHECK(result == expected);
     }
 
-    TEST_CASE("group_indexes_on_subset works [2]") {
+    TEST_CASE("group_indexes_on_subset works [2] (having every element end up in its own group should not cause crash)") {
+      // Set up input
+      auto input1 = std::vector<std::string> { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
+      auto vec1 = new nullable_varchar_vector(input1);
+
+      // Expected output - because the group delims are in [3, 17), index values
+      // at positions [0, 1, 2, 17, 18] are set to 0, so will point to `JAN`
+      auto input2 = std::vector<std::string> { "APR", "AUG", "DEC" , "FEB", "JAN", "JUL", "JUN", "MAR", "MAY", "NOV", "OCT", "SEP" };
+      auto vec2 = new nullable_varchar_vector(input2);
+      auto expected_group_delims = std::vector<size_t> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+
+      auto input_group_delims = std::vector<size_t> { 0, 12 };
+
+      // Set up output
+      std::vector<size_t> output_index(vec1->count);
+      std::vector<size_t> output_group_delims(vec1->count + 1);
+      size_t output_group_delims_len;
+
+      // Group indices
+      vec1->group_indexes_on_subset(
+        nullptr,
+        input_group_delims.data(),
+        input_group_delims.size(),
+        output_index.data(),
+        output_group_delims.data(),
+        output_group_delims_len
+      );
+
+      // Adjust the output
+      output_group_delims.resize(output_group_delims_len);
+
+      CHECK(vec1->select(output_index)->equivalent_to(vec2));
+      CHECK(output_group_delims == expected_group_delims);
+    }
+
+    TEST_CASE("group_indexes_on_subset works [3] (some groups have multiple elements)") {
       // Set up input
       auto input1 = std::vector<std::string> { "JAN", "JANU", "FEBU", "FEB", "MARCH", "MARCG", "APR", "NOV", "MARCG", "SEPT", "SEPT", "APR", "JANU", "SEP", "OCT", "NOV", "DEC2", "DEC1", "DEC0" };
       auto vec1 = new nullable_varchar_vector(input1);

--- a/src/main/scala/io/sparkcyclone/spark/codegen/groupby/GroupByPartialGenerator.scala
+++ b/src/main/scala/io/sparkcyclone/spark/codegen/groupby/GroupByPartialGenerator.scala
@@ -127,9 +127,7 @@ final case class GroupByPartialGenerator(
                 case (_, Right(TypedCExpression2(_, cExp))) =>
                   s"hash = 31 * hash + (${cExp.cCode});"
                 case (_, Left(StringReference(name))) =>
-                  CodeLines.forLoop("j", s"${name}->count") {
-                    s"hash = ${name}->hash_at(j, hash);"
-                  }.cCode
+                  s"hash = ${name}->hash_at(i, hash);"
               },
               // Assign the bucket based on the hash
               s"${BatchAssignmentsId}[g] = __builtin_abs(hash % ${nBuckets});"
@@ -144,6 +142,7 @@ final case class GroupByPartialGenerator(
     CodeLines.from(
       s"std::vector<size_t> ${BatchCountsId}(${nBuckets});",
       s"std::vector<size_t> ${BatchGroupPositionsId}(${groupingCodeGenerator.groupsCountOutName});",
+      s"std::vector<std::vector<size_t>> batch_group_indexes;",
       CodeLines.scoped("Compute the value counts for each batch") {
         CodeLines.from(
           "#pragma _NEC vector",
@@ -160,10 +159,25 @@ final case class GroupByPartialGenerator(
                 }
               },
               // Assign to the counts table
-              s"${BatchCountsId}[b] = count;"
+              s"${BatchCountsId}[b] = count;",
+              s"std::vector<size_t> group_indexes(count);",
+              s"batch_group_indexes.push_back(groups_indexes);"
             )
-          }
-        )
+          },
+          "",
+          CodeLines.forLoop("b", s"${nBuckets}") {
+            CodeLines.from(
+              s"size_t* group_indexes = batch_group_indexes[b].data();",
+              s"size_t i=0;",
+              CodeLines.forLoop("g", groupingCodeGenerator.groupsCountOutName) {
+                CodeLines.ifStatement("${BatchAssignmentsId}[g] == b") {
+                  CodeLines.from(
+                    s"group_indexes = sorted_idx[groups_indices[g]];"
+                  )
+                  }
+              }
+            )
+          })
       },
       ""
     )
@@ -189,23 +203,33 @@ final case class GroupByPartialGenerator(
 
   def computeGroupingKeysPerGroup: CodeLines = {
     final case class ProductionTriplet(forEach: CodeLines, complete: CodeLines)
+
     val initVars = computedGroupingKeys.map {
       case (groupingKey, Right(TypedCExpression2(_, cExp))) =>
         ProductionTriplet(
           forEach = storeTo(s"partial_${groupingKey.name}[${BatchAssignmentsId}[g]]", cExp, s"${BatchGroupPositionsId}[g]"),
           complete = CodeLines.empty
         )
+    }
+    val initVars2 = computedGroupingKeys.map {
       case (groupingKey, Left(StringReference(sr))) =>
         ProductionTriplet(
           forEach = CodeLines.from(
-            s"partial_str_${groupingKey.name}[${BatchAssignmentsId}[g]]->move_assign_from(${sr}->select(matching_ids));"
+            s"partial_str_${groupingKey.name}[b]->move_assign_from(${sr}->select(batch_group_indexes[b]);"
+            //s"partial_str_${groupingKey.name}[${BatchAssignmentsId}[g]]->move_assign_from(${sr}->select(matching_ids));"
           ),
           complete = CodeLines.empty
         )
     }
 
     CodeLines.scoped("Compute grouping keys per group") {
+
       CodeLines.from(
+        "#pragma _NEC vector",
+        CodeLines.forLoop("b", s"${nBuckets}") {
+            initVars2.map(_.forEach)
+        },
+        "",
         groupingCodeGenerator.forHeadOfEachGroup(initVars.map(_.forEach)),
         initVars.map(_.complete)
       )
@@ -217,7 +241,12 @@ final case class GroupByPartialGenerator(
     r: Either[StringReference, TypedCExpression2]
   ): CodeLines = r match {
     case Left(StringReference(sr)) =>
-      CodeLines.from(s"partial_str_${stagedProjection.name}->move_assign_from(${sr}->select(matching_ids));")
+      groupingCodeGenerator.forHeadOfEachGroup(
+        CodeLines.from(
+          s"partial_str_${stagedProjection.name}[b]->move_assign_from(${sr}->select(batch_group_indexes[b]);"
+        )
+        //CodeLines.from(s"partial_str_${stagedProjection.name}[${BatchAssignmentsId}[g]]->move_assign_from(${sr}->select(matching_ids));")
+      )
     case Right(TypedCExpression2(veType, cExpression)) =>
       CodeLines.from(
         groupingCodeGenerator.forHeadOfEachGroup(

--- a/src/test/scala/io/sparkcyclone/spark/codegen/groupby/GroupByPartialSpec.scala
+++ b/src/test/scala/io/sparkcyclone/spark/codegen/groupby/GroupByPartialSpec.scala
@@ -19,8 +19,9 @@ class GroupByPartialSpec extends AnyFreeSpec {
     val computedGroupingKeys = List(
       GroupingKey(agg, VeNullableInt) -> Right(TypedCExpression2(VeNullableInt, CExpression("foo", None))),
       GroupingKey(agg+"2", VeNullableInt) -> Right(TypedCExpression2(VeNullableInt, CExpression("foo2", None))),
+
       //TODO: String references are just not supported at the moment
-      //GroupingKey("str_key", VeNullableInt) -> Left(StringReference("some_str_col"))
+      GroupingKey("str_key", VeNullableInt) -> Left(StringReference("some_str_col"))
     )
 
     val computedProjections = List(
@@ -29,7 +30,7 @@ class GroupByPartialSpec extends AnyFreeSpec {
 
     val stringVectorComputations = List(
       //TODO: StringHole seems to not be fully supported in aggregation yet
-      //LikeStringHoleEvaluation("spam", "eggs")
+      LikeStringHoleEvaluation("spam", "eggs")
     )
 
     val finalOutputs: List[Either[GroupByOutline.StagedProjection, GroupByOutline.StagedAggregation]] = List(


### PR DESCRIPTION
Summary:

- Re-enable string vector aggregations
- Implement computing batch placement per group for strings
- Fix implementation of group indices assignment for batching
- Fix some broken code and add missing index
- Fix wrong index variable in projections
- Fix temporary buffer size to be `range_size + 1` to account for scenario where `nullable_varchar_vector::group_indexes_on_subset()` is invoked with a single subset and where every element ends up in its own group
- Add more unit tests for `nullable_varchar_vector::group_indexes_on_subset()` to cover the case where only one subset is passed in for grouping and each element ends up being in its own group
- Add better documentation for `NullableScalarVec<T>::group_indexes_on_subset()`
- Add unit test for `NullableScalarVec<T>::group_indexes_on_subset()` for the case where only one subset is specified for grouping and every element ends up in its own group