### PR TITLE
Decouple executor count from ve core count

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
@@ -399,3 +399,12 @@ extern "C" int handle_transfer(
     return -1;
   }
 }
+
+extern "C" int cyclone_alloc(size_t size, uintptr_t* out){
+    out[0] = reinterpret_cast<uintptr_t>(std::malloc(size));
+    return 0;
+}
+extern "C" int cyclone_free(uintptr_t address){
+    std::free(reinterpret_cast<void*>(address));
+    return 0;
+}

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.hpp
@@ -25,6 +25,8 @@
 #define VECTOR_ALIGNED(n) ((n + (7UL)) & ~(7UL))
 
 extern "C" int handle_transfer(char** td, uintptr_t* od);
+extern "C" int cyclone_alloc(size_t size, uintptr_t* out);
+extern "C" int cyclone_free(uintptr_t address);
 
 void merge_varchar_transfer(size_t batch_count, size_t total_element_count, char* col_header, char* input_data, char* data, uint64_t* validity_buffer, char* lengths, char* offsets, uintptr_t* od, size_t &output_pos);
 template<typename T> void merge_scalar_transfer(size_t batch_count, size_t total_element_count, char* col_header, char* input_data, char* data, uint64_t* validity_buffer, uintptr_t* od, size_t &output_pos);

--- a/src/main/scala/com/nec/vectorengine/LibCyclone.scala
+++ b/src/main/scala/com/nec/vectorengine/LibCyclone.scala
@@ -10,4 +10,6 @@ object LibCyclone {
   }
 
   final val HandleTransferFn = "handle_transfer"
+  final val FreeFn = "cyclone_free"
+  final val AllocFn = "cyclone_alloc"
 }

--- a/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
+++ b/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
@@ -191,26 +191,24 @@ final case class WrappingVeo private (val node: Int,
     // Explicitly allow registrations of zero-sized allocations
     require(size >= 0L, s"Memory size ${size} is invalid; cannot register allocation!")
 
-    heapRecords.synchronized {
-      heapRecords.get(address) match {
-        case Some(allocation) if allocation.size == size =>
-          logger.warn(s"[${handle.address}] Allocation for ${size} bytes @ ${address} is already registered")
-          allocation
+    heapRecords.get(address) match {
+      case Some(allocation) if allocation.size == size =>
+        logger.warn(s"[${handle.address}] Allocation for ${size} bytes @ ${address} is already registered")
+        allocation
 
-        case Some(allocation) =>
-          throw new IllegalArgumentException(s"Attempted to register allocation @ ${address} (${size} bytes) but it is already registered with a different size (${allocation.size} bytes)!")
+      case Some(allocation) =>
+        throw new IllegalArgumentException(s"Attempted to register allocation @ ${address} (${size} bytes) but it is already registered with a different size (${allocation.size} bytes)!")
 
-        case None =>
-          logger.debug(s"[${handle.address}] Registering externally-created VE memory allocation of ${size} bytes @ ${address}")
+      case None =>
+        logger.debug(s"[${handle.address}] Registering externally-created VE memory allocation of ${size} bytes @ ${address}")
 
-          // Record metrics
-          allocSizesHistogram.update(size)
+        // Record metrics
+        allocSizesHistogram.update(size)
 
-          // Register the allocation
-          val allocation = VeAllocation(address, size, new Exception().getStackTrace)
-          heapRecords.put(address, allocation)
-          allocation
-      }
+        // Register the allocation
+        val allocation = VeAllocation(address, size, new Exception().getStackTrace)
+        heapRecords.put(address, allocation)
+        allocation
     }
   }
 
@@ -218,15 +216,13 @@ final case class WrappingVeo private (val node: Int,
     // Explicitly allow address of 0
     require(address >= 0L, s"Invalid VE memory address ${address}")
 
-    heapRecords.synchronized {
-      heapRecords.get(address) match {
-        case Some(allocation) =>
-          logger.debug(s"[${handle.address}] Unregistering VE memory allocation tracked by ${getClass.getSimpleName} (${allocation.size} bytes @ ${allocation.address})")
-          heapRecords.remove(address)
+    heapRecords.get(address) match {
+      case Some(allocation) =>
+        logger.debug(s"[${handle.address}] Unregistering VE memory allocation tracked by ${getClass.getSimpleName} (${allocation.size} bytes @ ${allocation.address})")
+        heapRecords.remove(address)
 
-        case None =>
-          logger.warn(s"[${handle.address}] VE memory location @ ${address} is not tracked by ${getClass.getSimpleName}; no allocation to unregister")
-      }
+      case None =>
+        logger.warn(s"[${handle.address}] VE memory location @ ${address} is not tracked by ${getClass.getSimpleName}; no allocation to unregister")
     }
   }
 
@@ -235,32 +231,30 @@ final case class WrappingVeo private (val node: Int,
       // Explicitly allow address of 0
       require(address >= 0L, s"Invalid VE memory address ${address}")
 
-      heapRecords.synchronized {
-        heapRecords.get(address) match {
-          case Some(allocation) =>
-            logger.debug(s"[${handle.address}] Deallocating pointer @ ${address} (${allocation.size} bytes)")
-            // veo_free_mem runs in separate context
-            val (result, duration) = measureTime { veo.veo_free_mem(handle, address) }
-            require(result == 0, s"Memory release failed with code: ${result}")
-            // Remove only after the free() was successful
-            heapRecords.remove(address)
-            freeTimer.update(Duration.ofNanos(duration))
+      heapRecords.get(address) match {
+        case Some(allocation) =>
+          logger.debug(s"[${handle.address}] Deallocating pointer @ ${address} (${allocation.size} bytes)")
+          // veo_free_mem runs in separate context
+          val (result, duration) = measureTime { veo.veo_free_mem(handle, address) }
+          require(result == 0, s"Memory release failed with code: ${result}")
+          // Remove only after the free() was successful
+          heapRecords.remove(address)
+          freeTimer.update(Duration.ofNanos(duration))
 
-          case None if unsafe =>
-            logger.warn(s"[${handle.address}] Releasing VE memory @ ${address} without safety checks!")
-            // veo_free_mem runs in separate context
-            val (result, duration) = measureTime { veo.veo_free_mem(handle, address) }
-            require(result == 0, s"Memory release failed with code: ${result}")
-            freeTimer.update(Duration.ofNanos(duration))
+        case None if unsafe =>
+          logger.warn(s"[${handle.address}] Releasing VE memory @ ${address} without safety checks!")
+          // veo_free_mem runs in separate context
+          val (result, duration) = measureTime { veo.veo_free_mem(handle, address) }
+          require(result == 0, s"Memory release failed with code: ${result}")
+          freeTimer.update(Duration.ofNanos(duration))
 
-          case None if address == 0 =>
-            // Do nothing for free(0)
-            ()
+        case None if address == 0 =>
+          // Do nothing for free(0)
+          ()
 
-          case None =>
-            logger.error(s"VE memory address does not correspond to a tracked allocation: ${address}; will not call veo_free_mem()")
-            ()
-        }
+        case None =>
+          logger.error(s"VE memory address does not correspond to a tracked allocation: ${address}; will not call veo_free_mem()")
+          ()
       }
     }
   }

--- a/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
+++ b/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
@@ -109,13 +109,13 @@ final case class WrappingVeo private (val node: Int,
   }
 
   private[vectorengine] def withVeoThreadLock[T](lock: ReentrantReadWriteLock)(thunk: => T): T = {
-    lock.writeLock().lock()
-    try {
-      withVeoProc{
+    withVeoProc {
+      lock.writeLock().lock()
+      try {
         thunk
+      } finally {
+        lock.writeLock().unlock()
       }
-    } finally {
-      lock.writeLock().unlock()
     }
   }
 

--- a/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
+++ b/src/main/scala/com/nec/vectorengine/VeProcessImpl.scala
@@ -28,6 +28,9 @@ final case class WrappingVeo private (val node: Int,
   // thread context locks
   private val contextLocks: Seq[(ReentrantReadWriteLock, veo_thr_ctxt)] = tcontexts.map(new ReentrantReadWriteLock() -> _)
 
+  // reference to libcyclone.so
+  private var libCyclone: LibraryReference = _
+
   // Internal allocation and library records for tracking
   private var heapRecords = MMap.empty[Long, VeAllocation]
   private var stackRecords = MMap.empty[Long, VeCallArgsStack]
@@ -158,14 +161,23 @@ final case class WrappingVeo private (val node: Int,
     loadedLibRecords.toMap
   }
 
+  private def _alloc(out: LongPointer, size: Long): Long = {
+    withVeoProc {
+      val sym = getSymbol(libCyclone, LibCyclone.AllocFn)
+      awaitResult(callAsync(sym, newArgsStack(Seq(
+        U64Arg(size),
+        BuffArg(VeArgIntent.Out, out)
+      )))).get().toInt
+    }
+  }
+
   def allocate(size: Long): VeAllocation = {
     withVeoProc {
       require(size > 0L, s"Requested size ${size} is invalid")
 
       // Value is initialized to 0
       val ptr = new LongPointer(1)
-      // veo_alloc_mem runs in separate context
-      val (result, duration) = measureTime { veo.veo_alloc_mem(handle, ptr, size) }
+      val (result, duration) = measureTime { _alloc(ptr, size) }
 
       // Ensure memory is properly allocated
       val address = ptr.get
@@ -226,6 +238,15 @@ final case class WrappingVeo private (val node: Int,
     }
   }
 
+  private def _free(address: Long): Int = {
+    withVeoProc {
+      val sym = getSymbol(libCyclone, LibCyclone.FreeFn)
+      awaitResult(callAsync(sym, newArgsStack(Seq(
+        U64Arg(address)
+      )))).get().toInt
+    }
+  }
+
   def free(address: Long, unsafe: Boolean): Unit = {
     withVeoProc {
       // Explicitly allow address of 0
@@ -234,8 +255,8 @@ final case class WrappingVeo private (val node: Int,
       heapRecords.get(address) match {
         case Some(allocation) =>
           logger.debug(s"[${handle.address}] Deallocating pointer @ ${address} (${allocation.size} bytes)")
-          // veo_free_mem runs in separate context
-          val (result, duration) = measureTime { veo.veo_free_mem(handle, address) }
+
+          val (result, duration) = measureTime { _free( address) }
           require(result == 0, s"Memory release failed with code: ${result}")
           // Remove only after the free() was successful
           heapRecords.remove(address)
@@ -243,8 +264,8 @@ final case class WrappingVeo private (val node: Int,
 
         case None if unsafe =>
           logger.warn(s"[${handle.address}] Releasing VE memory @ ${address} without safety checks!")
-          // veo_free_mem runs in separate context
-          val (result, duration) = measureTime { veo.veo_free_mem(handle, address) }
+
+          val (result, duration) = measureTime { _free( address) }
           require(result == 0, s"Memory release failed with code: ${result}")
           freeTimer.update(Duration.ofNanos(duration))
 
@@ -343,7 +364,7 @@ final case class WrappingVeo private (val node: Int,
     }
   }
 
-  def load(path: Path): LibraryReference = {
+  private def _load(path: Path): LibraryReference = {
     withVeoProc {
       loadedLibRecords.synchronized {
         val npath = path.normalize
@@ -365,6 +386,15 @@ final case class WrappingVeo private (val node: Int,
         }
       }
     }
+  }
+
+  def load(path: Path): LibraryReference = {
+    if(libCyclone == null){
+      val libCyclonePath = if(path.endsWith("libcyclone.so")) path else path.getParent.resolve("sources").resolve("libcyclone.so")
+      libCyclone = _load(libCyclonePath)
+    }
+
+    _load(path)
   }
 
   def unload(lib: LibraryReference): Unit = {

--- a/src/main/scala/com/nec/vectorengine/VeProcessTraits.scala
+++ b/src/main/scala/com/nec/vectorengine/VeProcessTraits.scala
@@ -1,14 +1,15 @@
 package com.nec.vectorengine
 
-import com.nec.colvector.{VeColVectorSource => VeSource}
-import scala.util.Try
-import java.nio.file.Path
 import com.codahale.metrics.MetricRegistry
+import com.nec.colvector.{VeColVectorSource => VeSource}
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.api.plugin.PluginContext
 import org.bytedeco.javacpp.{LongPointer, Pointer}
 import org.bytedeco.veoffload.global.veo
 import org.bytedeco.veoffload.{veo_args, veo_proc_handle, veo_thr_ctxt}
-import com.typesafe.scalalogging.LazyLogging
+
+import java.nio.file.Path
+import scala.util.Try
 
 final case class VeAllocation private[vectorengine] (address: Long, size: Long, trace: Seq[StackTraceElement]) {
   def toThrowable: Throwable = {
@@ -47,7 +48,7 @@ final case class U64Arg(value: Long) extends CallStackArgument
 
 final case class BuffArg(intent: VeArgIntent, buffer: Pointer) extends CallStackArgument
 
-final case class VeAsyncReqId private[vectorengine] (value: Long)
+final case class VeAsyncReqId private[vectorengine] (value: Long, context: veo_thr_ctxt)
 
 trait VeProcess {
   def node: Int
@@ -128,6 +129,7 @@ trait VeProcess {
 object VeProcess extends LazyLogging {
   final val DefaultVeNodeId = 0
   final val MaxVeNodes = 8
+  final val MaxVeCores = 8
 
   // Gauges
   final val NumTrackedAllocationsMetric   = "ve.gauges.allocations.count"
@@ -143,7 +145,7 @@ object VeProcess extends LazyLogging {
   final val PutSizesHistogramMetric       = "ve.histograms.put.size"
   final val PutThroughputHistogramMetric  = "ve.histograms.put.throughput"
 
-  private def createVeoTuple(venode: Int): Option[(Int, veo_proc_handle, veo_thr_ctxt)] = {
+  private def createVeoTuple(venode: Int): Option[(Int, veo_proc_handle, Seq[veo_thr_ctxt])] = {
     val nnum = if (venode < -1) venode.abs else venode
     logger.info(s"Attemping to allocate VE process on node ${nnum}...")
 
@@ -157,11 +159,17 @@ object VeProcess extends LazyLogging {
 
       // Create asynchronous context
       tcontext <- {
-        val t = veo.veo_context_open(handle)
-        if (t != null && t.address > 0) Some(t) else None
+        Some((0 until MaxVeCores).flatMap { num =>
+          val t = veo.veo_context_open(handle)
+          if (t != null && t.address > 0) {
+            logger.info(s"Successfully allocated VEO asynchronous context ${num} on node ${nnum}")
+            Some(t)
+          } else {
+            logger.error(s"Could not allocate VEO asynchronous context ${num} on node ${nnum}")
+            None
+          }
+        })
       }
-      _ = logger.info(s"Successfully allocated VEO asynchronous context on node ${nnum}")
-
     } yield {
       // Return the tuple
       (nnum, handle, tcontext)
@@ -173,7 +181,7 @@ object VeProcess extends LazyLogging {
   }
 
   def create(identifier: String, metrics: MetricRegistry): VeProcess = {
-    val tupleO = 0.until(MaxVeNodes).foldLeft(Option.empty[(Int, veo_proc_handle, veo_thr_ctxt)]) {
+    val tupleO = 0.until(MaxVeNodes).foldLeft(Option.empty[(Int, veo_proc_handle, Seq[veo_thr_ctxt])]) {
       case (Some(tuple), venode)  => Some(tuple)
       case (None, venode)         => createVeoTuple(venode)
     }
@@ -232,7 +240,7 @@ object VeProcess extends LazyLogging {
 
     logger.info(s"Attemping to use VE node = ${selectedNodeId}")
 
-    val tupleO = selectedNodeId.until(MaxVeNodes).foldLeft(Option.empty[(Int, veo_proc_handle, veo_thr_ctxt)]) {
+    val tupleO = selectedNodeId.until(MaxVeNodes).foldLeft(Option.empty[(Int, veo_proc_handle, Seq[veo_thr_ctxt])]) {
       case (Some(tuple), venode)  => Some(tuple)
       case (None, venode)         => createVeoTuple(venode)
     }

--- a/src/main/scala/com/nec/vectorengine/VeProcessTraits.scala
+++ b/src/main/scala/com/nec/vectorengine/VeProcessTraits.scala
@@ -229,7 +229,7 @@ object VeProcess extends LazyLogging {
 
       // Executor IDs start at 1
       val executorId = Try { context.executorID.toInt - 1 }.getOrElse(0)
-      val veMultiple = executorId / MaxVeNodes
+      val veMultiple = executorId
 
       if (veMultiple > veResources.addresses.size) {
         logger.warn("Not enough VE resources allocated for the number of executors specified.")


### PR DESCRIPTION
With this PR it is now possible (and necessary!) to use just 1 Executor for every VE in the system.