### PR TITLE
Implement custom replacement for Spark's RowToColumnar

### DIFF
--- a/src/main/scala/com/nec/cache/BpcvTransferDescriptor.scala
+++ b/src/main/scala/com/nec/cache/BpcvTransferDescriptor.scala
@@ -1,0 +1,215 @@
+package com.nec.cache
+
+import com.nec.colvector.{BytePointerColVector, VeColBatch, VeColVector, VeColVectorSource}
+import com.nec.spark.agile.core.{VeScalarType, VeString}
+import com.typesafe.scalalogging.LazyLogging
+import org.bytedeco.javacpp.{BytePointer, LongPointer, Pointer}
+
+import scala.collection.mutable.ListBuffer
+
+case class BpcvTransferDescriptor(batches: Seq[Seq[BytePointerColVector]])
+  extends TransferDescriptor with LazyLogging {
+  lazy val isEmpty: Boolean = {
+    batches.flatten.isEmpty
+  }
+
+  lazy val nonEmpty: Boolean = {
+    !isEmpty
+  }
+
+  private[cache] lazy val nbatches: Long = {
+    batches.size.toLong
+  }
+
+  private[cache] lazy val ncolumns: Long = {
+    batches.headOption.map(_.size.toLong).getOrElse(0L)
+  }
+
+  private[cache] lazy val batchwiseColumns: Seq[Seq[BytePointerColVector]] = {
+    batches.transpose
+  }
+
+  private[cache] lazy val columns: Seq[BytePointerColVector] = {
+    // Transpose the columns such that the first column of each batch comes first, followed by the second column of each batch, etc.
+    batchwiseColumns.flatten
+  }
+
+  private[cache] lazy val headerOffsets: Seq[Long] = {
+    columns.map(_.veType)
+      .map {
+        case _: VeScalarType =>
+          // The header info for a scalar column contains 4 uint64_t values:
+          // [column_type][element_count][data_size][validity_buffer_size]
+          4L
+
+        case VeString =>
+          // The header info for a scalar column contains 6 uint64_t values:
+          // [column_type][element_count][data_size][offsets_size][lengths_size][validity_buffer_size]
+          6L
+      }
+      // The transfer descriptor header contains 3 uint64_t values:
+      // [header_size, batch_count, column_count]
+      // Offsets are in uint64_t
+      .scanLeft(3L)(_ + _)
+  }
+
+  private[cache] lazy val dataOffsets: Seq[Long] = {
+    columns.flatMap(_.buffers)
+      // Get the size of each buffer in bytes
+      .map { buf => vectorAlignedSize(buf.limit) }
+      // Start the accumulation from header total size
+      // Offsets are in bytes
+      .scanLeft(headerOffsets.last * 8)(_ + _)
+  }
+
+  private[cache] lazy val resultOffsets: Seq[Long] = {
+    batches.head.map(_.veType)
+      .map {
+        case _: VeScalarType =>
+          // scalar vectors prodduce 3 pointers (struct, data buffer, validity buffer)
+          3L
+
+        case VeString =>
+          // nullable_varchar_vector produce 5 pointers (struct, data buffer, offsets, lengths, validity buffer)
+          5L
+      }
+      // Accumulate the offsets (offsets are in uint64_t)
+      .scanLeft(0L)(_ + _)
+  }
+
+  private[cache] def vectorAlignedSize(size: Long): Long = {
+    val dangling = size % 8
+    if (dangling > 0) {
+      // If the size is not aligned on 8 bytes, add some padding
+      size + (8 - dangling)
+    } else {
+      size
+    }
+  }
+
+  lazy val buffer: BytePointer = {
+    require(nbatches > 0, "Need more than 0 batches for transfer!")
+    require(ncolumns > 0, "Need more than 0 columns for transfer!")
+    require(batches.forall(_.size == ncolumns), "All batches must have the same column count!")
+    logger.debug(s"Preparing transfer buffer for ${nbatches} batches of ${ncolumns} columns")
+
+    // Total size of the buffer is computed from scan-left of the header and data sizes
+    val tsize = (headerOffsets.last * 8) + dataOffsets.last
+
+    logger.debug(s"Allocating transfer buffer of ${tsize} bytes")
+    val outbuffer = new BytePointer(tsize)
+    val header = new LongPointer(outbuffer)
+
+    // Zero out the memory for consistency
+    Pointer.memset(outbuffer, 0, outbuffer.limit)
+
+    // Write the descriptor header
+    // Total header size is in bytes
+    header.put(0, headerOffsets.last * 8)
+    header.put(1, nbatches)
+    header.put(2, ncolumns)
+
+    // Write the column headers
+    columns.zipWithIndex.foreach { case (column, i) =>
+      val buffers = column.buffers.toList
+      val start = headerOffsets(i)
+
+      header.put(start, column.veType.cEnumValue)
+      header.put(start + 1, column.numItems)
+      header.put(start + 2, buffers(0).limit())
+      header.put(start + 3, buffers(1).limit())
+
+      if (column.veType.isString) {
+        header.put(start + 4, buffers(2).limit())
+        header.put(start + 5, buffers(3).limit())
+      }
+    }
+
+    // Write the data from the individual column buffers
+    columns.flatMap(_.buffers).zipWithIndex.foreach { case (buf, i) =>
+      val start = dataOffsets(i)
+      Pointer.memcpy(outbuffer.position(start), buf, buf.limit)
+    }
+
+    outbuffer.position(0)
+  }
+
+  lazy val resultBuffer: LongPointer = {
+    require(nbatches > 0, "Need more than 0 batches for creating a result buffer!")
+    require(ncolumns > 0, "Need more than 0 columns for creating a result buffer!")
+
+    // Total size of the buffer is computed from scan-left of the result sizes
+    logger.debug(s"Allocating transfer output pointer of ${resultOffsets.last} bytes")
+    new LongPointer(resultOffsets.last)
+  }
+
+  def resultToColBatch(implicit source: VeColVectorSource): VeColBatch = {
+    val vcolumns = batches.head.zipWithIndex.map { case (column, i) =>
+      logger.debug(s"Reading output pointers for column ${i}")
+
+      val batch = batchwiseColumns(i)
+      val cbuf = resultBuffer.position(resultOffsets(i))
+
+      // Fetch the pointers to the nullable_t_vector
+      val buffers = (if (column.veType.isString) 1.to(4) else 1.to(2))
+        .toSeq
+        .map(cbuf.get(_))
+
+      // Compute the dataSize
+      val dataSizeO = column.veType match {
+        case _: VeScalarType =>
+          None
+        case VeString =>
+          Some(batch.map(_.dataSize).flatten.foldLeft(0)(_ + _))
+      }
+
+      VeColVector(
+        source,
+        column.name,
+        column.veType,
+        // Compute the total size of the column
+        batch.map(_.numItems).sum,
+        buffers,
+        dataSizeO,
+        cbuf.get(0)
+      )
+    }
+
+    VeColBatch(vcolumns)
+  }
+
+  def close: Unit = {
+    buffer.close
+    resultBuffer.close
+  }
+}
+
+object BpcvTransferDescriptor {
+  class Builder {
+    val batches: ListBuffer[ListBuffer[BytePointerColVector]] = ListBuffer()
+    var curBatch: Option[ListBuffer[BytePointerColVector]] = None
+
+    def newBatch(): Builder = {
+      val empty = ListBuffer[BytePointerColVector]()
+      curBatch = Some(empty)
+      batches += empty
+      this
+    }
+
+    def addColumns(columns: Seq[BytePointerColVector]): Builder = {
+      if(curBatch.isEmpty) newBatch()
+      curBatch.get ++= columns
+      this
+    }
+
+    def build(): BpcvTransferDescriptor = {
+      val batchesList = batches.map(_.toList).toList
+      if(batchesList.nonEmpty){
+        val size = batchesList.head.size
+        require(batchesList.forall(_.size == size), "All batches must have the same column count!")
+      }
+
+      BpcvTransferDescriptor(batchesList)
+    }
+  }
+}

--- a/src/main/scala/com/nec/cache/RowCollectingTransferDescriptor.scala
+++ b/src/main/scala/com/nec/cache/RowCollectingTransferDescriptor.scala
@@ -1,0 +1,273 @@
+package com.nec.cache
+
+import com.nec.colvector.{VeColBatch, VeColVector, VeColVectorSource}
+import com.nec.spark.agile.SparkExpressionToCExpression
+import com.nec.spark.agile.core._
+import com.nec.util.FixedBitSet
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.unsafe.types.UTF8String
+import org.bytedeco.javacpp.indexer.ByteIndexer
+import org.bytedeco.javacpp.{BytePointer, LongPointer, Pointer}
+
+import scala.collection.mutable.ListBuffer
+
+trait VeTransferCol {
+  def veType: VeType
+  def append(row: InternalRow): Unit
+  def close(): Unit
+  def headerSize: Int
+  def totalDataSize: Long
+  def resultSize: Int
+
+  def writeHeader(target: LongPointer, targetPosition: Long): Long
+  def writeData(target: BytePointer, targetPosition: Long): Long
+
+  private[cache] def vectorAlignedSize(size: Long): Long = {
+    val dangling = size % 8
+    if (dangling > 0) {
+      // If the size is not aligned on 8 bytes, add some padding
+      size + (8 - dangling)
+    } else {
+      size
+    }
+  }
+}
+
+case class VeScalarTransferCol(veType: VeScalarType, capacity: Int, idx: Int) extends VeTransferCol {
+  private val pointer = new BytePointer(Pointer.calloc(capacity, veType.cSize)).capacity(capacity * veType.cSize)
+  private val indexer = ByteIndexer.create(pointer)
+
+  private val validityBuffer = FixedBitSet.ones(capacity)
+
+  private var pos = 0
+  private val appender = veType match {
+    case VeNullableDouble => writer{ (row, pos) => indexer.putDouble(pos, row.getDouble(idx)) }
+    case VeNullableFloat => writer{ (row, pos) => indexer.putFloat(pos, row.getFloat(idx)) }
+    case VeNullableShort => writer{ (row, pos) => indexer.putInt(pos, row.getShort(idx)) }
+    case VeNullableInt => writer{ (row, pos) => indexer.putInt(pos, row.getInt(idx)) }
+    case VeNullableLong => writer{ (row, pos) => indexer.putLong(pos, row.getLong(idx)) }
+  }
+
+  def append(row: InternalRow): Unit = appender(row)
+
+  private def writer(thunk: (InternalRow, Long) => Unit) = { row: InternalRow =>
+    if(row.isNullAt(idx)){
+      validityBuffer.clear(pos)
+    }else{
+      thunk(row, pos * veType.cSize)
+    }
+    pos += 1
+  }
+
+  def close(): Unit = {
+    indexer.close()
+    pointer.close()
+  }
+
+  private def count = pos
+  private def dataSize = count * veType.cSize
+  private def validityBufferSize = (count / 64f).ceil.toInt * 8
+
+  def headerSize: Int = 4 * 8
+  def writeHeader(target: LongPointer, targetPosition: Long): Long = {
+    target.put(targetPosition, veType.cEnumValue)
+    target.put(targetPosition + 1, count)
+    target.put(targetPosition + 2, dataSize)
+    target.put(targetPosition + 3, validityBufferSize)
+
+    targetPosition + 4
+  }
+
+  def totalDataSize: Long = Seq(dataSize, validityBufferSize).map(vectorAlignedSize(_)).sum
+  def writeData(target: BytePointer, targetPosition: Long): Long = {
+    val curDataBytes = dataSize
+    val curValidityBytes = validityBufferSize
+
+    var pos = targetPosition
+
+    val origPosition = target.position()
+    target.position(targetPosition)
+    Pointer.memcpy(target, pointer, curDataBytes)
+    target.position(origPosition)
+
+    pos += curDataBytes
+    pos = vectorAlignedSize(pos)
+
+    target.position(pos).put(validityBuffer.toByteArray, 0, curValidityBytes).position(origPosition)
+
+    vectorAlignedSize(pos + curValidityBytes)
+  }
+
+  // scalar vectors produce 3 pointers (struct, data buffer, validity buffer)
+  override def resultSize: Int = 3
+}
+
+case class VeStringTransferCol(idx: Int) extends VeTransferCol {
+  val veType: VeType = VeString
+  private val listBuffer: ListBuffer[UTF8String] = ListBuffer()
+  private lazy val converted = {
+    listBuffer.map{ utf8String =>
+      if(utf8String == null){
+        null
+      }else{
+        utf8String.toString.getBytes("UTF-32LE")
+      }
+    }.toArray
+  }
+
+  override def append(row: InternalRow): Unit = listBuffer.append(row.getUTF8String(idx))
+
+  override def close(): Unit = {}
+
+  override def headerSize: Int = 6 * 8
+
+  private def count = converted.length
+  def dataSize: Int = converted.map{s => if(s == null) {0}else{s.length}}.sum
+  private def offsetsSize = count * 4
+  private def lengthsSize = count * 4
+  private def validityBufferSize = (count / 64f).ceil.toInt * 8
+
+  override def totalDataSize: Long = {
+    Seq(dataSize, offsetsSize, lengthsSize, validityBufferSize).map(vectorAlignedSize(_)).sum
+  }
+
+  override def writeHeader(target: LongPointer, targetPosition: Long): Long = {
+    target.put(targetPosition, veType.cEnumValue)
+    target.put(targetPosition + 1, count)
+    target.put(targetPosition + 2, dataSize)
+    target.put(targetPosition + 3, offsetsSize)
+    target.put(targetPosition + 4, lengthsSize)
+    target.put(targetPosition + 5, validityBufferSize)
+
+    targetPosition + 6
+  }
+
+  override def writeData(target: BytePointer, targetPosition: Long): Long = {
+    val lengths = converted.map{s => if(s == null){ 0 }else{ s.length / 4 }}
+    val offsets = lengths.scanLeft(0)(_+_).dropRight(1)
+
+    val validityBuffer = FixedBitSet.ones(count)
+    converted.zipWithIndex.filter(_._1 == null).foreach(t => validityBuffer.clear(t._2))
+
+    var origPos = target.position()
+    var pos = targetPosition
+    converted.foreach{ str =>
+      if(str != null){
+        target.position(pos).put(str, 0, str.length)
+        pos += str.length
+      }
+    }
+    target.position(origPos)
+
+    pos = vectorAlignedSize(pos)
+    offsets.foreach{ o =>
+      target.putInt(pos, o)
+      pos += 4
+    }
+
+    pos = vectorAlignedSize(pos)
+    lengths.foreach{ l =>
+      target.putInt(pos, l)
+      pos += 4
+    }
+
+    pos = vectorAlignedSize(pos)
+    val validityBufferArr = validityBuffer.toByteArray
+    target.position(pos).put(validityBufferArr, 0, validityBufferArr.length).position(origPos)
+
+    vectorAlignedSize(pos + validityBufferArr.length)
+  }
+
+  // nullable_varchar_vector produce 5 pointers (struct, data buffer, offsets, lengths, validity buffer)
+  override def resultSize: Int = 5
+}
+
+case class RowCollectingTransferDescriptor(schema: Seq[Attribute], capacity: Int) extends TransferDescriptor with LazyLogging {
+  private var level = 0
+  def nonFull: Boolean = level < capacity
+  def isFull: Boolean = !nonFull
+  override def nonEmpty: Boolean = level > 0
+
+  private[cache] val transferCols = schema.map(att => SparkExpressionToCExpression.sparkTypeToVeType(att.dataType)).zipWithIndex.map {
+    case (t: VeScalarType, idx) => VeScalarTransferCol(t, capacity, idx)
+    case (VeString, idx) => VeStringTransferCol(idx)
+  }
+
+  def append(row: InternalRow): Unit = {
+    transferCols.foreach(_.append(row))
+    level += 1
+  }
+
+  lazy val resultOffsets = transferCols.map(_.resultSize).scanLeft(0)(_+_)
+  lazy val resultBuffer: LongPointer = {
+    require(nonEmpty, "Need more than 0 rows for creating a result buffer!")
+
+    // Total size of the buffer is computed from scan-left of the result sizes
+    logger.debug(s"Allocating transfer output pointer of ${resultOffsets.last} bytes")
+    new LongPointer(resultOffsets.last)
+  }
+
+  lazy val buffer: BytePointer = {
+    val headerSize = 3 * 8 + transferCols.map(_.headerSize).sum
+    val size = headerSize + transferCols.map(tCol => tCol.totalDataSize).sum
+
+    val buffer = new BytePointer(Pointer.calloc(size, 1)).capacity(size)
+
+    val header = new LongPointer(buffer)
+
+    header.put(0, headerSize)
+    header.put(1, 1)
+    header.put(2, transferCols.size)
+
+    var headerPos = 3L
+    var dataPos = headerSize.toLong
+    transferCols.foreach{ tCol =>
+      headerPos = tCol.writeHeader(header, headerPos)
+      dataPos = tCol.writeData(buffer, dataPos)
+      tCol.close()
+    }
+
+    buffer
+  }
+
+  override def close: Unit = {
+    resultBuffer.close()
+    buffer.close()
+  }
+
+  override def resultToColBatch(implicit source: VeColVectorSource): VeColBatch = {
+    val vcolumns = schema.zip(transferCols).zipWithIndex.map { case ((column, tCol), i) =>
+      logger.debug(s"Reading output pointers for column ${i}")
+
+      val veType = tCol.veType
+      val cbuf = resultBuffer.position(resultOffsets(i))
+
+      // Fetch the pointers to the nullable_t_vector
+      val buffers = (if (veType.isString) 1.to(4) else 1.to(2))
+        .toSeq
+        .map(cbuf.get(_))
+
+      // Compute the dataSize
+      val dataSizeO = tCol match {
+        case _: VeScalarTransferCol =>
+          None
+        case col: VeStringTransferCol =>
+          Some(col.dataSize)
+      }
+
+      VeColVector(
+        source,
+        column.name,
+        veType,
+        level,
+        buffers,
+        dataSizeO,
+        cbuf.get(0)
+      )
+    }
+
+    VeColBatch(vcolumns)
+  }
+}

--- a/src/main/scala/com/nec/cache/TransferDescriptor.scala
+++ b/src/main/scala/com/nec/cache/TransferDescriptor.scala
@@ -1,185 +1,18 @@
 package com.nec.cache
 
-import com.nec.colvector.{BytePointerColVector, VeColBatch, VeColVector}
-import com.nec.spark.agile.core.{VeScalarType, VeString}
-import com.nec.util.PointerOps._
-import scala.collection.mutable.ListBuffer
-import org.bytedeco.javacpp.{BytePointer, LongPointer, Pointer}
-import com.typesafe.scalalogging.LazyLogging
+import com.nec.colvector.{VeColBatch, VeColVectorSource}
+import com.nec.util.PointerOps.ExtendedPointer
+import org.bytedeco.javacpp.{BytePointer, LongPointer}
 
-case class TransferDescriptor(batches: Seq[Seq[BytePointerColVector]]) extends LazyLogging {
-  lazy val isEmpty: Boolean = {
-    batches.flatten.isEmpty
-  }
+trait TransferDescriptor {
+  def buffer: BytePointer
+  def resultBuffer: LongPointer
+  def resultToColBatch(implicit source: VeColVectorSource): VeColBatch
+  def close: Unit
+  def nonEmpty: Boolean
 
-  lazy val nonEmpty: Boolean = {
-    !isEmpty
-  }
-
-  private[cache] lazy val nbatches: Long = {
-    batches.size.toLong
-  }
-
-  private[cache] lazy val ncolumns: Long = {
-    batches.headOption.map(_.size.toLong).getOrElse(0L)
-  }
-
-  private[cache] lazy val batchwiseColumns: Seq[Seq[BytePointerColVector]] = {
-    batches.transpose
-  }
-
-  private[cache] lazy val columns: Seq[BytePointerColVector] = {
-    // Transpose the columns such that the first column of each batch comes first, followed by the second column of each batch, etc.
-    batchwiseColumns.flatten
-  }
-
-  private[cache] lazy val headerOffsets: Seq[Long] = {
-    columns.map(_.veType)
-      .map {
-        case _: VeScalarType =>
-          // The header info for a scalar column contains 4 uint64_t values:
-          // [column_type][element_count][data_size][validity_buffer_size]
-          4L
-
-        case VeString =>
-          // The header info for a scalar column contains 6 uint64_t values:
-          // [column_type][element_count][data_size][offsets_size][lengths_size][validity_buffer_size]
-          6L
-      }
-      // The transfer descriptor header contains 3 uint64_t values:
-      // [header_size, batch_count, column_count]
-      // Offsets are in uint64_t
-      .scanLeft(3L)(_ + _)
-  }
-
-  private[cache] lazy val dataOffsets: Seq[Long] = {
-    columns.flatMap(_.buffers)
-      // Get the size of each buffer in bytes
-      .map { buf => vectorAlignedSize(buf.limit) }
-      // Start the accumulation from header total size
-      // Offsets are in bytes
-      .scanLeft(headerOffsets.last * 8)(_ + _)
-  }
-
-  private[cache] lazy val resultOffsets: Seq[Long] = {
-    batches.head.map(_.veType)
-      .map {
-        case _: VeScalarType =>
-          // scalar vectors prodduce 3 pointers (struct, data buffer, validity buffer)
-          3L
-
-        case VeString =>
-          // nullable_varchar_vector produce 5 pointers (struct, data buffer, offsets, lengths, validity buffer)
-          5L
-      }
-      // Accumulate the offsets (offsets are in uint64_t)
-      .scanLeft(0L)(_ + _)
-  }
-
-  private[cache] def vectorAlignedSize(size: Long): Long = {
-    val dangling = size % 8
-    if (dangling > 0) {
-      // If the size is not aligned on 8 bytes, add some padding
-      size + (8 - dangling)
-    } else {
-      size
-    }
-  }
-
-  lazy val buffer: BytePointer = {
-    require(nbatches > 0, "Need more than 0 batches for transfer!")
-    require(ncolumns > 0, "Need more than 0 columns for transfer!")
-    require(batches.forall(_.size == ncolumns), "All batches must have the same column count!")
-    logger.debug(s"Preparing transfer buffer for ${nbatches} batches of ${ncolumns} columns")
-
-    // Total size of the buffer is computed from scan-left of the header and data sizes
-    val tsize = (headerOffsets.last * 8) + dataOffsets.last
-
-    logger.debug(s"Allocating transfer buffer of ${tsize} bytes")
-    val outbuffer = new BytePointer(tsize)
-    val header = new LongPointer(outbuffer)
-
-    // Zero out the memory for consistency
-    Pointer.memset(outbuffer, 0, outbuffer.limit)
-
-    // Write the descriptor header
-    // Total header size is in bytes
-    header.put(0, headerOffsets.last * 8)
-    header.put(1, nbatches)
-    header.put(2, ncolumns)
-
-    // Write the column headers
-    columns.zipWithIndex.foreach { case (column, i) =>
-      val buffers = column.buffers.toList
-      val start = headerOffsets(i)
-
-      header.put(start, column.veType.cEnumValue)
-      header.put(start + 1, column.numItems)
-      header.put(start + 2, buffers(0).limit())
-      header.put(start + 3, buffers(1).limit())
-
-      if (column.veType.isString) {
-        header.put(start + 4, buffers(2).limit())
-        header.put(start + 5, buffers(3).limit())
-      }
-    }
-
-    // Write the data from the individual column buffers
-    columns.flatMap(_.buffers).zipWithIndex.foreach { case (buf, i) =>
-      val start = dataOffsets(i)
-      Pointer.memcpy(outbuffer.position(start), buf, buf.limit)
-    }
-
-    outbuffer.position(0)
-  }
-
-  lazy val resultBuffer: LongPointer = {
-    require(nbatches > 0, "Need more than 0 batches for creating a result buffer!")
-    require(ncolumns > 0, "Need more than 0 columns for creating a result buffer!")
-
-    // Total size of the buffer is computed from scan-left of the result sizes
-    logger.debug(s"Allocating transfer output pointer of ${resultOffsets.last} bytes")
-    new LongPointer(resultOffsets.last)
-  }
-
-  def resultToColBatch: VeColBatch = {
-    val vcolumns = batches.head.zipWithIndex.map { case (column, i) =>
-      logger.debug(s"Reading output pointers for column ${i}")
-
-      val batch = batchwiseColumns(i)
-      val cbuf = resultBuffer.position(resultOffsets(i))
-
-      // Fetch the pointers to the nullable_t_vector
-      val buffers = (if (column.veType.isString) 1.to(4) else 1.to(2))
-        .toSeq
-        .map(cbuf.get(_))
-
-      // Compute the dataSize
-      val dataSizeO = column.veType match {
-        case _: VeScalarType =>
-          None
-        case VeString =>
-          Some(batch.map(_.dataSize).flatten.foldLeft(0)(_ + _))
-      }
-
-      VeColVector(
-        column.source,
-        column.name,
-        column.veType,
-        // Compute the total size of the column
-        batch.map(_.numItems).sum,
-        buffers,
-        dataSizeO,
-        cbuf.get(0)
-      )
-    }
-
-    VeColBatch(vcolumns)
-  }
-
-  def close: Unit = {
-    buffer.close
-    resultBuffer.close
+  def print: Unit = {
+    println(s"Transfer Buffer = \n${buffer.hexdump}\n")
   }
 
   def toSeq: Seq[Byte] = {
@@ -187,39 +20,5 @@ case class TransferDescriptor(batches: Seq[Seq[BytePointerColVector]]) extends L
     val array = Array.ofDim[Byte](buffer.limit().toInt)
     buf.get(array)
     array.toSeq
-  }
-
-  def print: Unit = {
-    println(s"Transfer Buffer = \n${buffer.hexdump}\n")
-  }
-}
-
-object TransferDescriptor {
-  class Builder {
-    val batches: ListBuffer[ListBuffer[BytePointerColVector]] = ListBuffer()
-    var curBatch: Option[ListBuffer[BytePointerColVector]] = None
-
-    def newBatch(): Builder = {
-      val empty = ListBuffer[BytePointerColVector]()
-      curBatch = Some(empty)
-      batches += empty
-      this
-    }
-
-    def addColumns(columns: Seq[BytePointerColVector]): Builder = {
-      if(curBatch.isEmpty) newBatch()
-      curBatch.get ++= columns
-      this
-    }
-
-    def build(): TransferDescriptor = {
-      val batchesList = batches.map(_.toList).toList
-      if(batchesList.nonEmpty){
-        val size = batchesList.head.size
-        require(batchesList.forall(_.size == size), "All batches must have the same column count!")
-      }
-
-      TransferDescriptor(batchesList)
-    }
   }
 }

--- a/src/main/scala/com/nec/util/FixedBitSet.scala
+++ b/src/main/scala/com/nec/util/FixedBitSet.scala
@@ -1,15 +1,13 @@
 package com.nec.util
 
-import java.util.BitSet
 import org.bytedeco.javacpp.BytePointer
+
+import java.util.BitSet
 
 object FixedBitSet {
   def ones(size: Int): FixedBitSet = {
     val bitset = FixedBitSet(size)
-    for (i <- 0 until size) {
-      bitset.set(i, true)
-    }
-    bitset
+    bitset.setAll()
   }
 
   def from(buffer: BytePointer): FixedBitSet = {
@@ -28,6 +26,16 @@ case class FixedBitSet(size: Int) {
 
   def set(position: Int, value: Boolean): FixedBitSet = {
     underlying.set(position, value)
+    this
+  }
+
+  def setAll(): FixedBitSet = {
+    underlying.set(0, size)
+    this
+  }
+
+  def clear(position: Int): FixedBitSet = {
+    underlying.clear(position)
     this
   }
 

--- a/src/main/scala/com/nec/vectorengine/VectorEngineImpl.scala
+++ b/src/main/scala/com/nec/vectorengine/VectorEngineImpl.scala
@@ -1,15 +1,16 @@
 package com.nec.vectorengine
 
+import com.codahale.metrics._
 import com.nec.cache.TransferDescriptor
 import com.nec.colvector._
-import com.nec.spark.agile.core.{CScalarVector, CVarChar, CVector, VeString}
+import com.nec.spark.agile.core.CVector
 import com.nec.util.CallContext
-import scala.reflect.ClassTag
-import scala.util.Try
-import java.time.Duration
-import com.codahale.metrics._
 import com.typesafe.scalalogging.LazyLogging
 import org.bytedeco.javacpp.{BytePointer, IntPointer, LongPointer, PointerScope}
+
+import java.time.Duration
+import scala.reflect.ClassTag
+import scala.util.Try
 
 class VectorEngineImpl(val process: VeProcess,
                        val metrics: MetricRegistry)
@@ -340,6 +341,7 @@ class VectorEngineImpl(val process: VeProcess,
   def executeTransfer(lib: LibraryReference,
                       descriptor: TransferDescriptor)
                      (implicit context: CallContext): VeColBatch = {
+    import com.nec.spark.SparkCycloneExecutorPlugin.source
     require(descriptor.nonEmpty, "TransferDescriptor is empty")
 
     // Allocate the buffer in VE and transfer the data over
@@ -371,6 +373,7 @@ class VectorEngineImpl(val process: VeProcess,
     require(descriptor.nonEmpty, "TransferDescriptor is empty")
 
     // Load libcyclone if not already loaded
+    // *_ONLY WORKS IN TESTS_*
     val lib = process.load(LibCyclone.SoPath)
 
     executeTransfer(lib, descriptor)

--- a/src/main/scala/com/nec/vectorengine/VectorEngineTraits.scala
+++ b/src/main/scala/com/nec/vectorengine/VectorEngineTraits.scala
@@ -1,12 +1,12 @@
 package com.nec.vectorengine
 
+import com.codahale.metrics.MetricRegistry
 import com.nec.cache.TransferDescriptor
 import com.nec.colvector._
 import com.nec.spark.agile.core.CVector
 import com.nec.util.CallContext
-import scala.concurrent.duration._
+
 import scala.reflect.ClassTag
-import com.codahale.metrics.MetricRegistry
 
 trait VectorEngine {
   /** The VE process handle that the VectorEngine has access to */

--- a/src/test/scala/com/nec/cache/RowCollectingTransferDescriptorUnitSpec.scala
+++ b/src/test/scala/com/nec/cache/RowCollectingTransferDescriptorUnitSpec.scala
@@ -55,21 +55,13 @@ final class RowCollectingTransferDescriptorUnitSpec extends AnyWordSpec with Wit
     Seq("applebananacarrotdurianeggplantfiggrapehawthornichigo".length * 4, 9 * 4, 9 * 4, 8)
   )
 
-  def vectorAlignedSize(size: Int): Long = {
-    val dangling = size % 8
-    if (dangling > 0) {
-      // If the size is not aligned on 8 bytes, add some padding
-      size + (8 - dangling)
-    } else {
-      size
-    }
-  }
-
-  val dataOffsets = colSizes.map { cs => cs.map(vectorAlignedSize) }
-    .map { cs => cs.scanLeft(0L)(_ + _)}
-    .scanLeft(Seq(headerSize.toLong * 8)){ (prev, cur) =>
-      cur.map(_ + prev.last)
-    }.tail
+  val dataOffsets = Seq(
+    // 168 = Data start offset
+    List(168, 208, 216),
+    List(216, 256, 264),
+    List(264, 336, 344),
+    List(344, 560, 600, 640, 648)
+  )
 
   val expectedRows = 9
 

--- a/src/test/scala/com/nec/cache/RowCollectingTransferDescriptorUnitSpec.scala
+++ b/src/test/scala/com/nec/cache/RowCollectingTransferDescriptorUnitSpec.scala
@@ -1,0 +1,199 @@
+package com.nec.cache
+
+import com.nec.colvector.VeColVectorSource
+import com.nec.cyclone.annotations.VectorEngineTest
+import com.nec.util.FixedBitSet
+import com.nec.util.PointerOps._
+import com.nec.vectorengine.WithVeProcess
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, GenericInternalRow, PrettyAttribute}
+import org.apache.spark.sql.types.{DoubleType, FloatType, ShortType, StringType}
+import org.apache.spark.unsafe.types.UTF8String
+import org.bytedeco.javacpp._
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
+
+@VectorEngineTest
+final class RowCollectingTransferDescriptorUnitSpec extends AnyWordSpec with WithVeProcess {
+  private def batch: (Seq[Attribute], List[InternalRow]) = {
+    val schema = Seq(
+      PrettyAttribute("short", ShortType),
+      PrettyAttribute("float", FloatType),
+      PrettyAttribute("double", DoubleType),
+      PrettyAttribute("string", StringType)
+    )
+
+    val data = List(
+      new GenericInternalRow(Seq(1.toShort, 10.toFloat, 100.toDouble, UTF8String.fromString("apple")).toArray),
+      new GenericInternalRow(Seq(2.toShort, 20.toFloat, 200.toDouble, UTF8String.fromString("banana")).toArray),
+      new GenericInternalRow(Seq(3.toShort, 30.toFloat, 300.toDouble, UTF8String.fromString("carrot")).toArray),
+      new GenericInternalRow(Seq(4.toShort, 40.toFloat, 400.toDouble, UTF8String.fromString("durian")).toArray),
+      new GenericInternalRow(Seq(5.toShort, 50.toFloat, 500.toDouble, UTF8String.fromString("eggplant")).toArray),
+      new GenericInternalRow(Seq(6.toShort, 60.toFloat, 600.toDouble, UTF8String.fromString("fig")).toArray),
+      new GenericInternalRow(Seq(7.toShort, 70.toFloat, 700.toDouble, UTF8String.fromString("grape")).toArray),
+      new GenericInternalRow(Seq(8.toShort, 80.toFloat, 800.toDouble, UTF8String.fromString("hawthorn")).toArray),
+      new GenericInternalRow(Seq(9.toShort, 90.toFloat, 900.toDouble, UTF8String.fromString("ichigo")).toArray),
+    )
+
+    (schema, data)
+  }
+
+  private def sampleDescriptor: RowCollectingTransferDescriptor = {
+    val (schema, rows) = batch
+    val descriptor = RowCollectingTransferDescriptor(schema, 9)
+    rows.foreach(row => descriptor.append(row))
+    descriptor
+  }
+
+  // 3 for the top level header, and 4 + 4 + 4 + 6 for the sum of all the column descriptors
+  val headerSize = (3 + 4 + 4 + 4 + 6)
+
+  val colSizes = Seq(
+    Seq(9 * 4, 8),
+    Seq(9 * 4, 8),
+    Seq(9 * 8, 8),
+    Seq("applebananacarrotdurianeggplantfiggrapehawthornichigo".length * 4, 9 * 4, 9 * 4, 8)
+  )
+
+  def vectorAlignedSize(size: Int): Long = {
+    val dangling = size % 8
+    if (dangling > 0) {
+      // If the size is not aligned on 8 bytes, add some padding
+      size + (8 - dangling)
+    } else {
+      size
+    }
+  }
+
+  val dataOffsets = colSizes.map { cs => cs.map(vectorAlignedSize) }
+    .map { cs => cs.scanLeft(0L)(_ + _)}
+    .scanLeft(Seq(headerSize.toLong * 8)){ (prev, cur) =>
+      cur.map(_ + prev.last)
+    }.tail
+
+  val expectedRows = 9
+
+  "RowCollectingTransferDescriptor" should {
+    "correctly allocates buffer" in {
+      val descriptor = sampleDescriptor
+      val expectedSize = dataOffsets.last.last
+      descriptor.buffer.limit() should be(expectedSize)
+    }
+
+    "correctly write the transfer header into the buffer" in {
+      val descriptor = sampleDescriptor
+      val types = descriptor.transferCols.map(_.veType)
+
+      val header = descriptor.buffer.as[LongPointer].toArray.take(headerSize)
+
+      header should be (Array[Long](
+        // Descriptor header
+        headerSize * 8, 1, 4,
+        // Column headers for the first column of each batch
+        types(0).cEnumValue, expectedRows, colSizes(0)(0), colSizes(0)(1),
+        // Column headers for the second column of each batch
+        types(1).cEnumValue, expectedRows, colSizes(1)(0), colSizes(1)(1),
+        // Column headers for the third column of each batch
+        types(2).cEnumValue, expectedRows, colSizes(2)(0), colSizes(2)(1),
+        // Column headers for the fourth column of each batch
+        types(3).cEnumValue, expectedRows, colSizes(3)(0), colSizes(3)(1), colSizes(3)(2), colSizes(3)(3)
+      ))
+    }
+
+    "correctly write scalar columns into the data buffers" in {
+      val descriptor = sampleDescriptor
+      val buffer = descriptor.buffer
+      val offsets = dataOffsets
+
+      // Column A data should be correctly written
+      buffer.slice(offsets(0)(0), offsets(0)(1) - offsets(0)(0)).as[IntPointer].toArray.map(_.toShort) should be (Array[Short](1, 2, 3, 4, 5, 6, 7, 8, 9, 0))
+      // Column A validity buffers should be correctly written
+      buffer.slice(offsets(0)(1), offsets(0)(2) - offsets(0)(1)).toArray should be (FixedBitSet.ones(9).toByteArray)
+
+      // Column B data should be correctly written
+      buffer.slice(offsets(1)(0), offsets(1)(1) - offsets(1)(0)).as[FloatPointer].toArray should be (Array[Float](10, 20, 30, 40, 50, 60, 70, 80, 90, 0))
+      // Column B validity buffers should be correctly written
+      buffer.slice(offsets(1)(1), offsets(1)(2) - offsets(1)(1)).toArray should be (FixedBitSet.ones(9).toByteArray)
+
+      // Column C data should be correctly written
+      buffer.slice(offsets(2)(0), offsets(2)(1) - offsets(2)(0)).as[DoublePointer].toArray should be (Array[Double](100, 200, 300, 400, 500, 600, 700, 800, 900))
+      // Column C validity buffers should be correctly written
+      buffer.slice(offsets(2)(1), offsets(2)(2) - offsets(2)(1)).toArray should be (FixedBitSet.ones(9).toByteArray)
+    }
+
+    "correctly write varchar columns into the data buffers" in {
+      val descriptor = sampleDescriptor
+      val buffer = descriptor.buffer
+      val offsets = dataOffsets
+
+      val expectedStrings = Array("apple", "banana", "carrot", "durian", "eggplant", "fig", "grape", "hawthorn", "ichigo")
+      val expectedStringBytes = expectedStrings.map(_.getBytes("UTF-32LE")).flatten ++ Array[Byte](0, 0, 0, 0)
+
+      // Column D data should be correctly written
+      buffer.slice(offsets(3)(0), offsets(3)(1) - offsets(3)(0)).toArray should be (expectedStringBytes)
+
+      // Column D offsets should be correctly written
+      buffer.slice(offsets(3)(1), offsets(3)(2) - offsets(3)(1)).as[IntPointer].toArray should be (Array(0, 5, 11, 17, 23, 31, 34, 39, 47, 0))
+
+      // Column D lens should be correctly written
+      buffer.slice(offsets(3)(2), offsets(3)(3) - offsets(3)(2)).as[IntPointer].toArray should be ((expectedStrings.map(_.length) ++ Array(0)))
+
+      // Column D validity buffers should be correctly written
+      buffer.slice(offsets(3)(3), offsets(3)(4) - offsets(3)(3)).toArray should be (FixedBitSet.ones(9).toByteArray)
+    }
+
+    "correctly read the result buffer" in {
+      val descriptor = sampleDescriptor
+      val buffer = descriptor.resultBuffer
+
+      buffer.limit() should be (3 + 3 + 3 + 5)
+
+      // put up some imaginary values
+      buffer
+        // Col A
+        .put(0, 1)
+        .put(1, 2)
+        .put(2, 3)
+        // Col B
+        .put(3, 4)
+        .put(4, 5)
+        .put(5, 6)
+        // Col C
+        .put(6, 7)
+        .put(7, 8)
+        .put(8, 9)
+        // Col D
+        .put(9, 10)
+        .put(10, 11)
+        .put(11, 12)
+        .put(12, 13)
+        .put(13, 14)
+
+      val batch = descriptor.resultToColBatch(VeColVectorSource("test"))
+      batch.numRows should be (9)
+      batch.columns.size should be (4)
+
+      val col1 = batch.columns(0)
+      val col2 = batch.columns(1)
+      val col3 = batch.columns(2)
+      val col4 = batch.columns(3)
+
+      col1.numItems should be (9)
+      col2.numItems should be (9)
+      col3.numItems should be (9)
+      col4.numItems should be (9)
+
+      col1.container should be (1)
+      col1.buffers should be (Seq(2, 3))
+
+      col2.container should be (4)
+      col2.buffers should be (Seq(5, 6))
+
+      col3.container should be (7)
+      col3.buffers should be (Seq(8, 9))
+
+      col4.container should be (10)
+      col4.buffers should be (Seq(11, 12, 13, 14))
+    }
+  }
+}

--- a/src/test/scala/com/nec/cache/TransferDescriptorUnitSpec.scala
+++ b/src/test/scala/com/nec/cache/TransferDescriptorUnitSpec.scala
@@ -1,20 +1,15 @@
 package com.nec.cache
 
-import com.nec.colvector.BytePointerColVector
 import com.nec.colvector.ArrayTConversions._
-import com.nec.colvector.SeqOptTConversions._
+import com.nec.colvector.BytePointerColVector
+import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.util.CallContextOps._
 import com.nec.util.FixedBitSet
 import com.nec.util.PointerOps._
-import com.nec.cyclone.annotations.VectorEngineTest
-import com.nec.vectorengine.{LibCyclone, WithVeProcess}
+import com.nec.vectorengine.WithVeProcess
 import org.bytedeco.javacpp._
-import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers._
-import org.scalatest.prop.TableDrivenPropertyChecks.whenever
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.forAll
-import scala.reflect.ClassTag
 
 @VectorEngineTest
 final class TransferDescriptorUnitSpec extends AnyWordSpec with WithVeProcess {
@@ -45,8 +40,8 @@ final class TransferDescriptorUnitSpec extends AnyWordSpec with WithVeProcess {
     )
   }
 
-  private def sampleDescriptor: TransferDescriptor = {
-    TransferDescriptor(Seq(batch1, batch2, batch3))
+  private def sampleDescriptor: BpcvTransferDescriptor = {
+    BpcvTransferDescriptor(Seq(batch1, batch2, batch3))
   }
 
   "TransferDescriptor" should {

--- a/src/test/scala/com/nec/vectorengine/VectorEngineFunSpec.scala
+++ b/src/test/scala/com/nec/vectorengine/VectorEngineFunSpec.scala
@@ -1,9 +1,9 @@
 package com.nec.vectorengine
 
-import com.nec.cache.TransferDescriptor
-import com.nec.colvector._
+import com.nec.cache.BpcvTransferDescriptor
 import com.nec.colvector.ArrayTConversions._
 import com.nec.colvector.SeqOptTConversions._
+import com.nec.colvector._
 import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.native.CppTranspiler
 import com.nec.spark.agile.core._
@@ -12,10 +12,11 @@ import com.nec.spark.agile.join.SimpleEquiJoinFunction
 import com.nec.spark.agile.merge.MergeFunction
 import com.nec.util.CallContextOps._
 import com.nec.ve.VeKernelInfra
-import scala.reflect.runtime.universe._
-import scala.util.Random
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.reflect.runtime.universe._
+import scala.util.Random
 
 @VectorEngineTest
 final class VectorEngineFunSpec extends AnyWordSpec with WithVeProcess with VeKernelInfra {
@@ -340,7 +341,7 @@ final class VectorEngineFunSpec extends AnyWordSpec with WithVeProcess with VeKe
       }
     }
 
-    s"correctly execute bulk data transfer to the VE using ${classOf[TransferDescriptor].getSimpleName}" in {
+    s"correctly execute bulk data transfer to the VE using ${classOf[BpcvTransferDescriptor].getSimpleName}" in {
       // Batch A
       val sizeA = Random.nextInt(100) + 10
       val a1 = InputSamples.seqOpt[Int](sizeA)
@@ -369,7 +370,7 @@ final class VectorEngineFunSpec extends AnyWordSpec with WithVeProcess with VeKe
       // println(s"c3 = ${c3}")
 
       // Create batch of batches
-      val descriptor = TransferDescriptor(Seq(
+      val descriptor = BpcvTransferDescriptor(Seq(
         Seq(a1.toBytePointerColVector("_"), a2.toBytePointerColVector("_"), a3.toBytePointerColVector("_")),
         Seq(b1.toBytePointerColVector("_"), b2.toBytePointerColVector("_"), b3.toBytePointerColVector("_")),
         Seq(c1.toBytePointerColVector("_"), c2.toBytePointerColVector("_"), c3.toBytePointerColVector("_"))
@@ -403,7 +404,7 @@ final class VectorEngineFunSpec extends AnyWordSpec with WithVeProcess with VeKe
       val c1 = Seq(Some(7319), None, None, Some(4859), Some(524))
 
       // Create batch of batches
-      val descriptor = TransferDescriptor(Seq(
+      val descriptor = BpcvTransferDescriptor(Seq(
         Seq(a1.toBytePointerColVector("_")),
         Seq(b1.toBytePointerColVector("_")),
         Seq(c1.toBytePointerColVector("_"))
@@ -435,7 +436,7 @@ final class VectorEngineFunSpec extends AnyWordSpec with WithVeProcess with VeKe
       val c1 = Seq(Some(7319), None, None, Some(4859), Some(524), Some(406), None, None, Some(1154), None, None, Some(1650), Some(8040), None, None, None, None, None, None, None, None, None, Some(1146), None, Some(7268), Some(8197), None, None, None, None, Some(81), Some(2053), Some(6571), Some(4600), None, Some(3699), None, Some(8404), None, None, Some(8401), None, None, Some(6234), Some(6281), Some(7367), None, Some(4688), Some(7490), None, Some(5412), None, None, Some(871), None, Some(9086), None, Some(5362), Some(6516))
 
       // Create batch of batches
-      val descriptor = TransferDescriptor(Seq(
+      val descriptor = BpcvTransferDescriptor(Seq(
         Seq(a1.toBytePointerColVector("_")),
         Seq(b1.toBytePointerColVector("_")),
         Seq(c1.toBytePointerColVector("_"))


### PR DESCRIPTION
Part of https://github.com/XpressAI/SparkCyclone/pull/595 which only provides the custom replacement for Spark's RowToColumnar

> Use this config option to set how many rows should be accumulated before transferring them as a batch to the VE: spark.com.nec.spark.ve.columnBatchSize
If it isn't set, it will default to the value of spark.sql.inMemoryColumnarStorage.batchSize, which itself defaults to 10000.

> You probably want a higher value; 64000 is probably a good starting point. The optimal value will depend on the actual workload. This is also something that we may want to revisit, and try to come up with a more adaptive way of configuring this.