### PR TITLE
[NS-45] Decouple Executor Core Count from VE Core Count + Asynchronous `malloc()` / `free()` 

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
@@ -399,3 +399,12 @@ extern "C" int handle_transfer(
     return -1;
   }
 }
+
+extern "C" int cyclone_alloc(size_t size, uintptr_t* out){
+    out[0] = reinterpret_cast<uintptr_t>(std::malloc(size));
+    return 0;
+}
+extern "C" int cyclone_free(uintptr_t address){
+    std::free(reinterpret_cast<void*>(address));
+    return 0;
+}

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
@@ -405,9 +405,9 @@ extern "C" int cyclone_alloc(size_t size, uintptr_t* out) {
   return 0;
 }
 
-extern "C" int cyclone_free(uintptr_t* addresses, size_t count) {
-  for (size_t i = 0; i < count; i++) {
-    std::free(reinterpret_cast<void*>(addresses[i]));
-  }
+extern "C" int cyclone_free(uintptr_t* addresses, size_t count){
+    for(size_t i = 0; i < count; i++){
+        std::free(reinterpret_cast<void*>(addresses[i]));
+    }
   return 0;
 }

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
@@ -405,9 +405,9 @@ extern "C" int cyclone_alloc(size_t size, uintptr_t* out) {
   return 0;
 }
 
-extern "C" int cyclone_free(uintptr_t* addresses, size_t count){
-    for(size_t i = 0; i < count; i++){
-        std::free(reinterpret_cast<void*>(addresses[i]));
-    }
+extern "C" int cyclone_free(uintptr_t* addresses, size_t count) {
+  for(size_t i = 0; i < count; i++){
+    std::free(reinterpret_cast<void*>(addresses[i]));
+  }
   return 0;
 }

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.cc
@@ -400,11 +400,14 @@ extern "C" int handle_transfer(
   }
 }
 
-extern "C" int cyclone_alloc(size_t size, uintptr_t* out){
-    out[0] = reinterpret_cast<uintptr_t>(std::malloc(size));
-    return 0;
+extern "C" int cyclone_alloc(size_t size, uintptr_t* out) {
+  out[0] = reinterpret_cast<uintptr_t>(std::malloc(size));
+  return 0;
 }
-extern "C" int cyclone_free(uintptr_t address){
-    std::free(reinterpret_cast<void*>(address));
-    return 0;
+
+extern "C" int cyclone_free(uintptr_t* addresses, size_t count) {
+  for (size_t i = 0; i < count; i++) {
+    std::free(reinterpret_cast<void*>(addresses[i]));
+  }
+  return 0;
 }

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.hpp
@@ -26,7 +26,7 @@
 
 extern "C" int handle_transfer(char** td, uintptr_t* od);
 extern "C" int cyclone_alloc(size_t size, uintptr_t* out);
-extern "C" int cyclone_free(uintptr_t address);
+extern "C" int cyclone_free(uintptr_t* addresses, size_t count);
 
 void merge_varchar_transfer(size_t batch_count, size_t total_element_count, char* col_header, char* input_data, char* data, uint64_t* validity_buffer, char* lengths, char* offsets, uintptr_t* od, size_t &output_pos);
 template<typename T> void merge_scalar_transfer(size_t batch_count, size_t total_element_count, char* col_header, char* input_data, char* data, uint64_t* validity_buffer, uintptr_t* od, size_t &output_pos);

--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/packed_transfer.hpp
@@ -25,6 +25,8 @@
 #define VECTOR_ALIGNED(n) ((n + (7UL)) & ~(7UL))
 
 extern "C" int handle_transfer(char** td, uintptr_t* od);
+extern "C" int cyclone_alloc(size_t size, uintptr_t* out);
+extern "C" int cyclone_free(uintptr_t address);
 
 void merge_varchar_transfer(size_t batch_count, size_t total_element_count, char* col_header, char* input_data, char* data, uint64_t* validity_buffer, char* lengths, char* offsets, uintptr_t* od, size_t &output_pos);
 template<typename T> void merge_scalar_transfer(size_t batch_count, size_t total_element_count, char* col_header, char* input_data, char* data, uint64_t* validity_buffer, uintptr_t* od, size_t &output_pos);

--- a/src/main/scala/com/nec/colvector/VeColBatch.scala
+++ b/src/main/scala/com/nec/colvector/VeColBatch.scala
@@ -7,7 +7,6 @@ import com.nec.spark.agile.core.VeType
 import com.nec.util.CallContext
 import com.nec.ve.VeProcessMetrics
 import com.nec.vectorengine.VeProcess
-import com.nec.vectorengine.{VeProcess => NewVeProcess}
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
 
@@ -124,7 +123,7 @@ final case class VeColBatch(columns: Seq[VeColVector]) {
   def free()(implicit source: VeColVectorSource,
              process: VeProcess,
              context: CallContext): Unit = {
-    columns.foreach(_.free)
+    process.freeSeq(columns.flatMap(_.closeAndReturnAllocations))
   }
 
   def toArrowColumnarBatch(implicit allocator: BufferAllocator,

--- a/src/main/scala/com/nec/colvector/VeColVector.scala
+++ b/src/main/scala/com/nec/colvector/VeColVector.scala
@@ -108,10 +108,10 @@ final case class VeColVector private[colvector] (
    */
   def closeAndReturnAllocations: Seq[Long] = {
     open.synchronized {
-      if(open){
+      if (open) {
         open = false
         allocations
-      }else{
+      } else {
         logger.warn(s"[VE MEMORY ${container}] double free called!")
         Nil
       }

--- a/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
+++ b/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
@@ -21,16 +21,15 @@ package com.nec.spark
 
 import com.nec.cache.VeColBatchesCache
 import com.nec.colvector._
-import com.nec.util.CallContextOps._
-import com.nec.ve.VeProcessMetrics
 import com.nec.vectorengine._
-import scala.collection.JavaConverters._
-import scala.collection.concurrent.TrieMap
-import java.util.{Map => JMap}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.api.plugin.{ExecutorPlugin, PluginContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.metrics.source.ProcessExecutorMetrics
+
+import java.util.{Map => JMap}
+import scala.collection.JavaConverters._
+import scala.collection.concurrent.TrieMap
 
 object SparkCycloneExecutorPlugin {
   var pluginContext: PluginContext = _
@@ -83,6 +82,9 @@ class SparkCycloneExecutorPlugin extends ExecutorPlugin with Logging with LazyLo
       val resources = context.resources
       if (resources.containsKey("ve")) resources.get("ve").addresses.length else 1
     }
+
+    // Start the actual ve process by accessing something that goes to the underlying ve process.
+    SparkCycloneExecutorPlugin.veProcess.apiVersion
   }
 
   override def shutdown(): Unit = {

--- a/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
+++ b/src/main/scala/com/nec/spark/SparkCycloneExecutorPlugin.scala
@@ -22,14 +22,13 @@ package com.nec.spark
 import com.nec.cache.VeColBatchesCache
 import com.nec.colvector._
 import com.nec.vectorengine._
+import scala.collection.JavaConverters._
+import scala.collection.concurrent.TrieMap
+import java.util.{Map => JMap}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.api.plugin.{ExecutorPlugin, PluginContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.metrics.source.ProcessExecutorMetrics
-
-import java.util.{Map => JMap}
-import scala.collection.JavaConverters._
-import scala.collection.concurrent.TrieMap
 
 object SparkCycloneExecutorPlugin {
   var pluginContext: PluginContext = _
@@ -83,7 +82,7 @@ class SparkCycloneExecutorPlugin extends ExecutorPlugin with Logging with LazyLo
       if (resources.containsKey("ve")) resources.get("ve").addresses.length else 1
     }
 
-    // Start the actual ve process by accessing something that goes to the underlying ve process.
+    // Start the actual VE process by calling a method that will initialize it
     SparkCycloneExecutorPlugin.veProcess.apiVersion
   }
 

--- a/src/main/scala/com/nec/spark/planning/plans/VePartialAggregate.scala
+++ b/src/main/scala/com/nec/spark/planning/plans/VePartialAggregate.scala
@@ -3,7 +3,6 @@ package com.nec.spark.planning.plans
 import com.nec.colvector.VeColBatch
 import com.nec.spark.SparkCycloneExecutorPlugin.{source, veProcess, vectorEngine}
 import com.nec.spark.planning.{PlanCallsVeFunction, PlanMetrics, SupportsVeColBatch, VeFunction}
-import com.nec.util.CallContext
 import com.nec.util.CallContextOps._
 import com.nec.ve.VeRDDOps.RichKeyedRDDL
 import com.typesafe.scalalogging.LazyLogging
@@ -59,7 +58,7 @@ case class VePartialAggregate(
                   case (n, l) if l.head.nonEmpty =>
                     Option(n -> VeColBatch(l))
                   case (_, l) =>
-                    l.foreach(_.free())
+                    veProcess.freeSeq(l.flatMap(_.closeAndReturnAllocations))
                     None
                 }
               } finally {

--- a/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
+++ b/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
@@ -77,6 +77,13 @@ final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess w
     }
   }
 
+  def freeSeq(addresses: Seq[Long], unsafe: Boolean = false): Unit = {
+    // If the VeProcess is not instantiated yet, skip
+    if (instantiated) {
+      underlying.freeSeq(addresses, unsafe)
+    }
+  }
+
   def freeAll: Unit = {
     // If the VeProcess is not instantiated yet, skip
     if (instantiated) {

--- a/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
+++ b/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
@@ -1,11 +1,10 @@
 package com.nec.vectorengine
 
-import com.codahale.metrics.MetricRegistry
 import com.nec.colvector.{VeColVectorSource => VeSource}
+import java.nio.file.Path
+import com.codahale.metrics.MetricRegistry
 import com.typesafe.scalalogging.LazyLogging
 import org.bytedeco.javacpp.{LongPointer, Pointer}
-
-import java.nio.file.Path
 
 final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess with LazyLogging {
   private var instantiated = false

--- a/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
+++ b/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
@@ -1,11 +1,11 @@
 package com.nec.vectorengine
 
-import com.nec.colvector.{VeColVectorSource => VeSource}
-import java.nio.file.Path
 import com.codahale.metrics.MetricRegistry
+import com.nec.colvector.{VeColVectorSource => VeSource}
 import com.typesafe.scalalogging.LazyLogging
-import org.bytedeco.javacpp.{BytePointer, LongPointer, Pointer}
-import org.bytedeco.veoffload.veo_proc_handle
+import org.bytedeco.javacpp.{LongPointer, Pointer}
+
+import java.nio.file.Path
 
 final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess with LazyLogging {
   private var instantiated = false

--- a/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
+++ b/src/main/scala/com/nec/vectorengine/DeferredVeProcess.scala
@@ -42,6 +42,10 @@ final case class DeferredVeProcess(newproc: () => VeProcess) extends VeProcess w
     underlying.version
   }
 
+  lazy val numThreads: Int = {
+    if (instantiated) underlying.numThreads else 0
+  }
+
   def heapAllocations: Map[Long, VeAllocation] = {
     underlying.heapAllocations
   }

--- a/src/main/scala/com/nec/vectorengine/LibCyclone.scala
+++ b/src/main/scala/com/nec/vectorengine/LibCyclone.scala
@@ -6,9 +6,10 @@ object LibCyclone {
   final val CppTargetPath = "/cycloneve"
 
   lazy val SoPath: Path = {
-    Paths.get(getClass.getResource(s"${CppTargetPath}/libcyclone.so").toURI)
+    Paths.get(getClass.getResource(s"${CppTargetPath}/${FileName}").toURI)
   }
 
+  final val FileName = "libcyclone.so"
   final val HandleTransferFn = "handle_transfer"
   final val FreeFn = "cyclone_free"
   final val AllocFn = "cyclone_alloc"

--- a/src/main/scala/com/nec/vectorengine/LibCyclone.scala
+++ b/src/main/scala/com/nec/vectorengine/LibCyclone.scala
@@ -10,4 +10,6 @@ object LibCyclone {
   }
 
   final val HandleTransferFn = "handle_transfer"
+  final val FreeFn = "cyclone_free"
+  final val AllocFn = "cyclone_alloc"
 }

--- a/src/main/scala/com/nec/vectorengine/VeProcessTraits.scala
+++ b/src/main/scala/com/nec/vectorengine/VeProcessTraits.scala
@@ -150,10 +150,9 @@ object VeProcess extends LazyLogging {
   final val PutThroughputHistogramMetric  = "ve.histograms.put.throughput"
 
   private[vectorengine] def createVeoTuple(venode: Int,
-                                           veCores: Int): Option[(Int, veo_proc_handle, Seq[veo_thr_ctxt])] = {
+                                           veCores: Int = MaxVeCores): Option[(Int, veo_proc_handle, Seq[veo_thr_ctxt])] = {
     require(veCores > 0, "veCores must be > 0")
     require(veCores <= MaxVeCores, s"veCores must be <= ${MaxVeCores}")
-
     val nnum = if (venode < -1) venode.abs else venode
     logger.info(s"Attemping to allocate VE process on node ${nnum}...")
 
@@ -240,6 +239,7 @@ object VeProcess extends LazyLogging {
 
   def createFromContext(context: PluginContext): VeProcess = {
     val resources = context.resources
+    val maxVeCores = context.conf().get("spark.com.nec.resource.ve.cores", "8").toInt
     logger.info(s"Executor has the following resources available => ${resources}")
 
     val veCores = context.conf().get("spark.com.nec.resource.ve.cores", "8").toInt

--- a/src/test/scala/com/nec/ve/DualModeVESpec.scala
+++ b/src/test/scala/com/nec/ve/DualModeVESpec.scala
@@ -30,7 +30,7 @@ final class DualModeVESpec
 
   override def beforeAll: Unit = {
     super.beforeAll
-    SparkCycloneExecutorPlugin.veProcess = VeProcess.create(-1, getClass.getName)
+    SparkCycloneExecutorPlugin.veProcess = VeProcess.create(-1, getClass.getName, 2)
   }
 
   override def afterAll(): Unit = {

--- a/src/test/scala/com/nec/ve/DynamicBenchmarkVeCheck.scala
+++ b/src/test/scala/com/nec/ve/DynamicBenchmarkVeCheck.scala
@@ -36,7 +36,7 @@ final class DynamicBenchmarkVeCheck
   override def beforeAll: Unit = {
     super.beforeAll
     Logger.getRootLogger.setLevel(Level.INFO)
-    SparkCycloneExecutorPlugin.veProcess = VeProcess.create(-1, getClass.getName)
+    SparkCycloneExecutorPlugin.veProcess = VeProcess.create(-1, getClass.getName, 2)
   }
 
   /** TODO We could also generate Spark plan details from here for easy cross-referencing, as well as codegen */

--- a/src/test/scala/com/nec/ve/DynamicVeSqlExpressionEvaluationSpec.scala
+++ b/src/test/scala/com/nec/ve/DynamicVeSqlExpressionEvaluationSpec.scala
@@ -40,7 +40,7 @@ final class DynamicVeSqlExpressionEvaluationSpec extends DynamicCSqlExpressionEv
 
   override def beforeAll: Unit = {
     super.beforeAll
-    SparkCycloneExecutorPlugin.veProcess = VeProcess.create(-1, getClass.getName)
+    SparkCycloneExecutorPlugin.veProcess = VeProcess.create(-1, getClass.getName, 2)
   }
 
   override def afterAll: Unit = {

--- a/src/test/scala/com/nec/ve/ExchangeOnLocalSpec.scala
+++ b/src/test/scala/com/nec/ve/ExchangeOnLocalSpec.scala
@@ -3,7 +3,9 @@ package com.nec.ve
 import com.eed3si9n.expecty.Expecty.expect
 import com.nec.cyclone.annotations.VectorEngineTest
 import com.nec.spark.SparkAdditions
+import com.nec.vectorengine._
 import com.nec.vectorengine.SampleVeFunctions.PartitioningFunction
+import com.nec.spark.SparkCycloneExecutorPlugin
 import com.nec.ve.VERDDSpec.exchangeBatches
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
@@ -14,6 +16,13 @@ final class ExchangeOnLocalSpec
   with SparkAdditions
   with VeKernelInfra
   with BeforeAndAfterAll {
+
+  override def beforeAll: Unit = {
+    SparkCycloneExecutorPlugin.veProcess = DeferredVeProcess { () =>
+      // Keep the number of VE cores to a minimum during test
+      VeProcess.create(-1, getClass.getName, 2)
+    }
+  }
 
   "Exchange data across partitions in local mode (ExchangeLocal)" in withSparkSession2(
     DynamicVeSqlExpressionEvaluationSpec.VeConfiguration

--- a/src/test/scala/com/nec/ve/VERDDSpec.scala
+++ b/src/test/scala/com/nec/ve/VERDDSpec.scala
@@ -11,6 +11,7 @@ import com.nec.spark.SparkCycloneExecutorPlugin._
 import com.nec.vectorengine.SampleVeFunctions._
 import com.nec.util.CallContextOps._
 import com.nec.ve.VeRDDOps.RichKeyedRDD
+import java.nio.file.Paths
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.scalatest.BeforeAndAfterAll
@@ -64,8 +65,9 @@ object VERDDSpec {
     .mapPartitions(
       f = { iter =>
         iter.flatMap { input =>
+          // Load libcyclone first so that async alloc/free works afterwards
+          val ref = veProcess.load(Paths.get(pathStr))
           val colvec = input.toVeColVector
-          val ref = veProcess.load(java.nio.file.Paths.get(pathStr))
 
           vectorEngine.executeMulti(
             ref,

--- a/src/test/scala/com/nec/vectorengine/WithVeProcess.scala
+++ b/src/test/scala/com/nec/vectorengine/WithVeProcess.scala
@@ -8,9 +8,9 @@ import com.codahale.metrics._
 import org.apache.spark.SparkConf
 import org.apache.spark.api.plugin.PluginContext
 import org.apache.spark.resource.ResourceInformation
-import org.scalatest.{BeforeAndAfterAll, Suite}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 
-trait WithVeProcess extends BeforeAndAfterAll { self: Suite =>
+trait WithVeProcess extends BeforeAndAfterAll with BeforeAndAfterEach { self: Suite =>
   // TODO: Remove
   implicit val metrics0 = VeProcessMetrics.noOp
 
@@ -22,7 +22,7 @@ trait WithVeProcess extends BeforeAndAfterAll { self: Suite =>
     classes is eager even if annotated with @VectorEngineTest
   */
   implicit val process: VeProcess = DeferredVeProcess { () =>
-    VeProcess.create(getClass.getName, metrics)
+    VeProcess.create(getClass.getName, 2, metrics)
   }
 
   implicit def source: VeSource = {
@@ -47,6 +47,10 @@ trait WithVeProcess extends BeforeAndAfterAll { self: Suite =>
     }
 
     SparkCycloneExecutorPlugin.veProcess = process
+  }
+
+  override def beforeEach: Unit = {
+    process.load(LibCyclone.SoPath)
   }
 
   override def afterAll: Unit = {


### PR DESCRIPTION
This PR consolidates the following efforts that have been made over multiple branches (see https://github.com/XpressAI/SparkCyclone/pull/593, https://github.com/XpressAI/SparkCyclone/pull/595, https://github.com/XpressAI/SparkCyclone/compare/NS-56/2/remove-column-to-row-attempt-2?expand=1, and https://github.com/XpressAI/SparkCyclone/compare/NS-56-transfer?expand=1).

1. decouple Spark executor core count from VE core count
2. Support asynchronous `malloc()` / `free()`  

Additional code and tests have been added on top of the consolidation to harden the introduced features.

Details:

- Introduce support for multiple VEO asynchronous contexts inside the `VeProcess` abstraction.  Async contexts are to be accessed with re-entrant locks
- Force all async `VeProcess` methods to randomly pick the first available VEO async context to run on
- Update `VeProcess.createFromContext` to allow only 1 executor per VE for now
- Secure the context lock within a `withVeoProc` block, so that we don't even try to go deeper if the process has already been closed
- Remove synchronization locks  on heapRecords
- Collect Sync-ish call metrics
- Implement asynchronous `malloc` / `free`.  The idea is to move all AVEO calls (except for `veo_load_library`) away from using the main VEO thread.  This allows us to implement more fancy variants of `malloc` / `free` if needed,
including adding custom logging and metrics.
- Update `VeProcess.load()` to always attempt to load `libcyclone.so` first before loading the requested library.
- Fixes to existing VE-based unit tests to work with the VE-executor decoupling and asynchronous `malloc` / `free` features
- Update `WithVeProcess` to load `libcyclone.so` before each test case
- Update `VeProcess` creation in unit test environments to create no more than 2 VEO asynchronous contexts, since there is a large overhead in creating extra asynchronous contexts
- Add support for freeing multiple pointers with one asynchronous VE method call
- Remove heap allocation records before calling `free()` instead of after to avoid a race condition where subsequent allocation from the VE returns a new allocation with the same address, but different allocation size
- Make VE cores used per executor configurable from `VeProcess.createFromContext()`
- Don't warn about 0 pointer allocations being already known, as they are expected to happen multiple times.
- Free empty aggregation results in batched fashion
- Explicitly start the VE Process in `SparkCycloneExecutorPlugin.init()`
- Close `VeColVector` when `free()`'d externally
- Check for filepaths that are too long for AVEO to accept when loading a library
- Add tests to ensure that a proper error is thrown if `libcyclone.so` is not yet loaded
- Add unit tests for batched `free()`