### PR TITLE
simplified hash calculation for varchars in constant time

### DIFF
--- a/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/com/nec/cyclone/cpp/cyclone/transfer-definitions.hpp
@@ -28,6 +28,7 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+#include <iostream>
 
 inline void set_valid_bit(uint64_t * buffer,
                           const size_t idx,
@@ -242,11 +243,12 @@ struct nullable_varchar_vector {
     int64_t out = seed;
     auto start = offsets[idx];
     auto end = offsets[idx] + lengths[idx];
-    #pragma _NEC vector
-    #pragma _NEC ivdep
-    for (int x = start; x < end; x++) {
-      out = 31 * out + data[x];
-    }
+    auto median = (end+start) / 2;
+
+    // simplified hash in constant time:
+    // sample first, median and last element in varchar
+    out = 31*(31*(31*seed+data[start])+data[median])+data[end-1];
+
     return out;
   }
 


### PR DESCRIPTION
A very simple, but fast hash implementation for nullable_varchar.

Instead of iterating over all characters in O(n), it just samples the first, last and median element of the varchar in O(1), resulting in a speedup in many cases.

Result with TPC-H at scale 10 on vh001:

Old implementation:
real	64m30.605s
user	0m15.766s
sys	0m2.302s

With this PR:
real	49m39.123s
user	0m14.275s
sys	0m2.093s

The test was done with
- aggregate-on-ve
- amplify-batches
- --num-executors=1 --executor-cores=8
