### PR TITLE
[NS-69] Vectorized grouping for `nullable_varchar_vector`

### DIFF
--- a/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_scalar_grouping_benchmark.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_scalar_grouping_benchmark.cc
@@ -65,13 +65,13 @@ namespace cyclone::benchmarks {
     std::vector<size_t> input_keys = input->size_t_data_vec();
 
     std::vector<size_t> keys;
-    std::vector<std::vector<size_t>> groups = cyclone::separate_to_groups(input_keys, keys);
+    const auto groups = cyclone::separate_to_groups(input_keys, keys);
     return groups.size();
   }
 
 
   size_t vector_group(NullableScalarVec<int64_t> *input){
-    std::vector<std::vector<size_t>> groups = input->group_indexes();
+    const auto groups = input->group_indexes();
     return groups.size();
   }
 

--- a/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_scalar_grouping_benchmark.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_scalar_grouping_benchmark.cc
@@ -65,7 +65,7 @@ namespace cyclone::benchmarks {
     std::vector<size_t> input_keys = input->size_t_data_vec();
 
     std::vector<size_t> keys;
-    const auto groups = cyclone::separate_to_groups(input_keys, keys);
+    const auto groups = cyclone::grouping::separate_to_groups(input_keys, keys);
     return groups.size();
   }
 

--- a/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_scalar_grouping_benchmark.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_scalar_grouping_benchmark.cc
@@ -19,23 +19,22 @@
  */
 #include "benchmarks/nanobench.h"
 #include "tests/doctest.h"
-#include "frovedis/core/set_operations.hpp"
 #include "cyclone/cyclone.hpp"
-
+#include "frovedis/core/set_operations.hpp"
 
 namespace cyclone::benchmarks {
-  NullableScalarVec<int64_t>* create_input(int vector_size, int group_count){
+  NullableScalarVec<int64_t>* create_scalar_input(int vector_size, int group_count) {
     NullableScalarVec<int64_t>* res = NullableScalarVec<int64_t>::allocate();
     res->resize(vector_size);
     for(auto i = 0; i < vector_size; ++i){
       res->data[i] = i % group_count;
       res->set_validity(i, 1);
     }
-    
+
     return res;
   }
 
-  size_t tuple_group_by(NullableScalarVec<int64_t> *input){
+  size_t tuple_group_by(NullableScalarVec<int64_t> *input) {
     std::vector<std::tuple<int64_t, int>> grouping_vec(input->count);
     std::vector<size_t> sorted_idx(input->count);
 
@@ -99,14 +98,15 @@ namespace cyclone::benchmarks {
     return group1_pos_idxs_size;
   }
 
-  TEST_CASE("Benchmarking group by implementations") {
-    NullableScalarVec<int64_t>* input = create_input(3500000, 150);
-    NullableScalarVec<int64_t>* input_with_invalids = create_input(3500000, 150);
+  TEST_CASE("Scalar Group-by Implementation Benchmarks") {
+    auto *input = create_scalar_input(3500000, 150);
+    auto *input_with_invalids = create_scalar_input(3500000, 150);
     input_with_invalids->set_validity(1, 0);
 
     ankerl::nanobench::Bench().run("tuple_group_by", [&]() {
       ankerl::nanobench::doNotOptimizeAway(tuple_group_by(input));
     });
+
     ankerl::nanobench::Bench().run("tuple_group_by (some invalid input)", [&]() {
       ankerl::nanobench::doNotOptimizeAway(tuple_group_by(input_with_invalids));
     });
@@ -126,9 +126,9 @@ namespace cyclone::benchmarks {
     free(input);
     free(input_with_invalids);
 
-    NullableScalarVec<int64_t>* input1 = create_input(3500000,   69);
-    NullableScalarVec<int64_t>* input2 = create_input(3500000,  420);
-    NullableScalarVec<int64_t>* input3 = create_input(3500000, 9001);
+    auto *input1 = create_scalar_input(3500000,   69);
+    auto *input2 = create_scalar_input(3500000,  420);
+    auto *input3 = create_scalar_input(3500000, 9001);
 
     ankerl::nanobench::Bench().run("vector_multi_group (many groups)", [&]() {
       ankerl::nanobench::doNotOptimizeAway(vector_multi_group(input1, input2, input3));
@@ -138,9 +138,9 @@ namespace cyclone::benchmarks {
     free(input2);
     free(input3);
 
-    NullableScalarVec<int64_t>* input4 = create_input(3500000,  25);
-    NullableScalarVec<int64_t>* input5 = create_input(3500000,  75);
-    NullableScalarVec<int64_t>* input6 = create_input(3500000, 150);
+    auto *input4 = create_scalar_input(3500000,  25);
+    auto *input5 = create_scalar_input(3500000,  75);
+    auto *input6 = create_scalar_input(3500000, 150);
 
     ankerl::nanobench::Bench().run("vector_multi_group (150 groups)", [&]() {
       ankerl::nanobench::doNotOptimizeAway(vector_multi_group(input4, input5, input6));

--- a/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_string_grouping_benchmark.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_string_grouping_benchmark.cc
@@ -66,45 +66,10 @@ namespace cyclone::benchmarks {
     return groups.size();
   }
 
-  // size_t vector_multi_group(NullableScalarVec<int64_t> *input1, NullableScalarVec<int64_t> *input2, NullableScalarVec<int64_t> *input3){
-  //   size_t count = static_cast<size_t>(input1->count);
-  //   size_t all_group[2] = {0, count};
-  //   size_t* idx1_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
-  //   size_t* idx2_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
-
-  //   size_t* group1_pos_idxs = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
-  //   size_t* group2_pos_idxs = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
-  //   size_t group1_pos_idxs_size;
-  //   size_t group2_pos_idxs_size;
-
-  //   input1->group_indexes_on_subset(nullptr, all_group, 2, idx1_arr, group1_pos_idxs, group1_pos_idxs_size);
-  //   input2->group_indexes_on_subset(idx1_arr, group1_pos_idxs, group1_pos_idxs_size, idx2_arr, group2_pos_idxs, group2_pos_idxs_size);
-  //   input3->group_indexes_on_subset(idx2_arr, group2_pos_idxs, group2_pos_idxs_size, idx1_arr, group1_pos_idxs, group1_pos_idxs_size);
-
-  //   free(idx1_arr);
-  //   free(idx2_arr);
-  //   free(group1_pos_idxs);
-  //   free(group2_pos_idxs);
-
-  //   return group1_pos_idxs_size;
-  // }
-
   TEST_CASE("String Group-by Implementation Benchmarks") {
     auto *input = create_string_input(3500000, 150);
     auto *input_with_invalids = create_string_input(3500000, 150);
     input_with_invalids->set_validity(1, 0);
-
-    // ankerl::nanobench::Bench().run("tuple_group_by", [&]() {
-    //   ankerl::nanobench::doNotOptimizeAway(tuple_group_by(input));
-    // });
-
-    // ankerl::nanobench::Bench().run("tuple_group_by (some invalid input)", [&]() {
-    //   ankerl::nanobench::doNotOptimizeAway(tuple_group_by(input_with_invalids));
-    // });
-
-    // ankerl::nanobench::Bench().run("separate_to_groups(no validity)", [&]() {
-    //   ankerl::nanobench::doNotOptimizeAway(separate_to_groups_no_validity(input));
-    // });
 
     ankerl::nanobench::Bench().run("vector_group 1 (with validity, all valid input)", [&]() {
       ankerl::nanobench::doNotOptimizeAway(vector_group1(input));
@@ -121,28 +86,5 @@ namespace cyclone::benchmarks {
     ankerl::nanobench::Bench().run("vector_group 2 (with validity, some invalid input)", [&]() {
       ankerl::nanobench::doNotOptimizeAway(vector_group2(input_with_invalids));
     });
-
-    // free(input);
-    // free(input_with_invalids);
-
-    // auto *input1 = create_string_input(3500000,   69);
-    // auto *input2 = create_string_input(3500000,  420);
-    // auto *input3 = create_string_input(3500000, 9001);
-
-    // ankerl::nanobench::Bench().run("vector_multi_group (many groups)", [&]() {
-    //   ankerl::nanobench::doNotOptimizeAway(vector_multi_group(input1, input2, input3));
-    // });
-
-    // free(input1);
-    // free(input2);
-    // free(input3);
-
-    // auto *input4 = create_string_input(3500000,  25);
-    // auto *input5 = create_string_input(3500000,  75);
-    // auto *input6 = create_string_input(3500000, 150);
-
-    // ankerl::nanobench::Bench().run("vector_multi_group (150 groups)", [&]() {
-    //   ankerl::nanobench::doNotOptimizeAway(vector_multi_group(input4, input5, input6));
-    // });
   }
 }

--- a/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_string_grouping_benchmark.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_string_grouping_benchmark.cc
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2022 Xpress AI.
+ *
+ * This file is part of Spark Cyclone.
+ * See https://github.com/XpressAI/SparkCyclone for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "benchmarks/nanobench.h"
+#include "tests/doctest.h"
+#include "cyclone/cyclone.hpp"
+#include "frovedis/core/set_operations.hpp"
+#include <cstdlib>
+
+namespace cyclone::benchmarks {
+  std::string random_string(const size_t len) {
+    static const char alphanum[] =
+      "0123456789"
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      "abcdefghijklmnopqrstuvwxyz";
+
+    std::string tmp;
+    tmp.reserve(len);
+
+    for (auto i = 0; i < len; ++i) {
+      tmp[i] = alphanum[rand() % (sizeof(alphanum) - 1)];
+    }
+
+    return tmp;
+  }
+
+  nullable_varchar_vector* create_string_input(int vector_size, int group_count) {
+    // Generate the groups
+    std::vector<std::string> groups(group_count);
+    for (auto i = 0; i < groups.size(); i++) {
+      groups[i] = random_string(rand() % 50);
+    }
+
+    // Generate the input
+    std::vector<std::string> input(vector_size);
+    for (auto i = 0; i < input.size(); i++) {
+      input[i] = groups[i % group_count];
+    }
+
+    return new nullable_varchar_vector(input);
+  }
+
+  // size_t tuple_group_by(NullableScalarVec<int64_t> *input){
+  //   std::vector<std::tuple<int64_t, int>> grouping_vec(input->count);
+  //   std::vector<size_t> sorted_idx(input->count);
+
+  //   for (auto i = 0; i < input->count; i++) {
+  //     grouping_vec[i] = std::tuple<int64_t, int>(input->data[i], input->get_validity(i));
+  //   }
+
+  //   sorted_idx = cyclone::sort_tuples(grouping_vec, std::array<int, 2>{{ 1, 1 }});
+
+  //   for (auto j = 0; j < input->count; j++) {
+  //     auto i = sorted_idx[j];
+  //     grouping_vec[j] = std::tuple<int64_t, int>(input->data[i], input->get_validity(i));
+  //   }
+
+  //   std::vector<size_t> groups_indices = frovedis::set_separate(grouping_vec);
+  //   auto groups_count = groups_indices.size() - 1;
+
+  //   std::vector<size_t> matching_ids(groups_count);
+  //   for (auto g = 0; g < groups_count; g++) {
+  //     matching_ids[g] = sorted_idx[groups_indices[g]];
+  //   }
+
+  //   return matching_ids.size();
+  // }
+
+
+  // size_t separate_to_groups_no_validity(NullableScalarVec<int64_t> *input){
+  //   std::vector<size_t> input_keys = input->size_t_data_vec();
+
+  //   std::vector<size_t> keys;
+  //   std::vector<std::vector<size_t>> groups = cyclone::separate_to_groups(input_keys, keys);
+  //   return groups.size();
+  // }
+
+
+  // size_t vector_group(NullableScalarVec<int64_t> *input){
+  //   std::vector<std::vector<size_t>> groups = input->group_indexes();
+  //   return groups.size();
+  // }
+
+  // size_t vector_multi_group(NullableScalarVec<int64_t> *input1, NullableScalarVec<int64_t> *input2, NullableScalarVec<int64_t> *input3){
+  //   size_t count = static_cast<size_t>(input1->count);
+  //   size_t all_group[2] = {0, count};
+  //   size_t* idx1_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
+  //   size_t* idx2_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
+
+  //   size_t* group1_pos_idxs = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
+  //   size_t* group2_pos_idxs = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
+  //   size_t group1_pos_idxs_size;
+  //   size_t group2_pos_idxs_size;
+
+  //   input1->group_indexes_on_subset(nullptr, all_group, 2, idx1_arr, group1_pos_idxs, group1_pos_idxs_size);
+  //   input2->group_indexes_on_subset(idx1_arr, group1_pos_idxs, group1_pos_idxs_size, idx2_arr, group2_pos_idxs, group2_pos_idxs_size);
+  //   input3->group_indexes_on_subset(idx2_arr, group2_pos_idxs, group2_pos_idxs_size, idx1_arr, group1_pos_idxs, group1_pos_idxs_size);
+
+  //   free(idx1_arr);
+  //   free(idx2_arr);
+  //   free(group1_pos_idxs);
+  //   free(group2_pos_idxs);
+
+  //   return group1_pos_idxs_size;
+  // }
+
+  TEST_CASE("String Group-by Implementation Benchmarks") {
+    // auto *input = create_string_input(3500000, 150);
+    // auto *input_with_invalids = create_string_input(3500000, 150);
+    // input_with_invalids->set_validity(1, 0);
+
+    // ankerl::nanobench::Bench().run("tuple_group_by", [&]() {
+    //   ankerl::nanobench::doNotOptimizeAway(tuple_group_by(input));
+    // });
+
+    // ankerl::nanobench::Bench().run("tuple_group_by (some invalid input)", [&]() {
+    //   ankerl::nanobench::doNotOptimizeAway(tuple_group_by(input_with_invalids));
+    // });
+
+    // ankerl::nanobench::Bench().run("separate_to_groups(no validity)", [&]() {
+    //   ankerl::nanobench::doNotOptimizeAway(separate_to_groups_no_validity(input));
+    // });
+
+    // ankerl::nanobench::Bench().run("vector_group(with validity, all valid input)", [&]() {
+    //   ankerl::nanobench::doNotOptimizeAway(vector_group(input));
+    // });
+
+    // ankerl::nanobench::Bench().run("vector_group(with validity, some invalid input)", [&]() {
+    //   ankerl::nanobench::doNotOptimizeAway(vector_group(input_with_invalids));
+    // });
+
+    // free(input);
+    // free(input_with_invalids);
+
+    // auto *input1 = create_string_input(3500000,   69);
+    // auto *input2 = create_string_input(3500000,  420);
+    // auto *input3 = create_string_input(3500000, 9001);
+
+    // ankerl::nanobench::Bench().run("vector_multi_group (many groups)", [&]() {
+    //   ankerl::nanobench::doNotOptimizeAway(vector_multi_group(input1, input2, input3));
+    // });
+
+    // free(input1);
+    // free(input2);
+    // free(input3);
+
+    // auto *input4 = create_string_input(3500000,  25);
+    // auto *input5 = create_string_input(3500000,  75);
+    // auto *input6 = create_string_input(3500000, 150);
+
+    // ankerl::nanobench::Bench().run("vector_multi_group (150 groups)", [&]() {
+    //   ankerl::nanobench::doNotOptimizeAway(vector_multi_group(input4, input5, input6));
+    // });
+  }
+}

--- a/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_string_grouping_benchmark.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_string_grouping_benchmark.cc
@@ -66,11 +66,6 @@ namespace cyclone::benchmarks {
     return groups.size();
   }
 
-  size_t vector_group3(nullable_varchar_vector *input) {
-    auto groups = input->group_indexes3();
-    return groups.size();
-  }
-
   TEST_CASE("String Group-by Implementation Benchmarks") {
     auto *input = create_string_input(3500000, 150);
     auto *input_with_invalids = create_string_input(3500000, 150);
@@ -90,14 +85,6 @@ namespace cyclone::benchmarks {
 
     ankerl::nanobench::Bench().run("vector_group 2 (with validity, some invalid input)", [&]() {
       ankerl::nanobench::doNotOptimizeAway(vector_group2(input_with_invalids));
-    });
-
-    ankerl::nanobench::Bench().run("vector_group 3 (with validity, all valid input)", [&]() {
-      ankerl::nanobench::doNotOptimizeAway(vector_group3(input));
-    });
-
-    ankerl::nanobench::Bench().run("vector_group 3 (with validity, some invalid input)", [&]() {
-      ankerl::nanobench::doNotOptimizeAway(vector_group3(input_with_invalids));
     });
   }
 }

--- a/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_string_grouping_benchmark.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_string_grouping_benchmark.cc
@@ -56,13 +56,13 @@ namespace cyclone::benchmarks {
     return new nullable_varchar_vector(input);
   }
 
-  size_t vector_group1(nullable_varchar_vector *input) {
-    auto groups = input->group_indexes();
+  size_t vector_group0(nullable_varchar_vector *input) {
+    auto groups = input->group_indexes0();
     return groups.size();
   }
 
-  size_t vector_group2(nullable_varchar_vector *input) {
-    auto groups = input->group_indexes2();
+  size_t vector_group1(nullable_varchar_vector *input) {
+    auto groups = input->group_indexes();
     return groups.size();
   }
 
@@ -71,20 +71,20 @@ namespace cyclone::benchmarks {
     auto *input_with_invalids = create_string_input(3500000, 150);
     input_with_invalids->set_validity(1, 0);
 
+    ankerl::nanobench::Bench().run("vector_group 0 (with validity, all valid input)", [&]() {
+      ankerl::nanobench::doNotOptimizeAway(vector_group0(input));
+    });
+
+    ankerl::nanobench::Bench().run("vector_group 0 (with validity, some invalid input)", [&]() {
+      ankerl::nanobench::doNotOptimizeAway(vector_group0(input_with_invalids));
+    });
+
     ankerl::nanobench::Bench().run("vector_group 1 (with validity, all valid input)", [&]() {
       ankerl::nanobench::doNotOptimizeAway(vector_group1(input));
     });
 
     ankerl::nanobench::Bench().run("vector_group 1 (with validity, some invalid input)", [&]() {
       ankerl::nanobench::doNotOptimizeAway(vector_group1(input_with_invalids));
-    });
-
-    ankerl::nanobench::Bench().run("vector_group 2 (with validity, all valid input)", [&]() {
-      ankerl::nanobench::doNotOptimizeAway(vector_group2(input));
-    });
-
-    ankerl::nanobench::Bench().run("vector_group 2 (with validity, some invalid input)", [&]() {
-      ankerl::nanobench::doNotOptimizeAway(vector_group2(input_with_invalids));
     });
   }
 }

--- a/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_string_grouping_benchmark.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_string_grouping_benchmark.cc
@@ -66,6 +66,11 @@ namespace cyclone::benchmarks {
     return groups.size();
   }
 
+  size_t vector_group3(nullable_varchar_vector *input) {
+    auto groups = input->group_indexes3();
+    return groups.size();
+  }
+
   TEST_CASE("String Group-by Implementation Benchmarks") {
     auto *input = create_string_input(3500000, 150);
     auto *input_with_invalids = create_string_input(3500000, 150);
@@ -85,6 +90,14 @@ namespace cyclone::benchmarks {
 
     ankerl::nanobench::Bench().run("vector_group 2 (with validity, some invalid input)", [&]() {
       ankerl::nanobench::doNotOptimizeAway(vector_group2(input_with_invalids));
+    });
+
+    ankerl::nanobench::Bench().run("vector_group 3 (with validity, all valid input)", [&]() {
+      ankerl::nanobench::doNotOptimizeAway(vector_group3(input));
+    });
+
+    ankerl::nanobench::Bench().run("vector_group 3 (with validity, some invalid input)", [&]() {
+      ankerl::nanobench::doNotOptimizeAway(vector_group3(input_with_invalids));
     });
   }
 }

--- a/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_string_grouping_benchmark.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/benchmarks/cyclone_string_grouping_benchmark.cc
@@ -44,7 +44,7 @@ namespace cyclone::benchmarks {
     // Generate the groups
     std::vector<std::string> groups(group_count);
     for (auto i = 0; i < groups.size(); i++) {
-      groups[i] = random_string(rand() % 50);
+      groups[i] = random_string(rand() % 190 + 10);
     }
 
     // Generate the input
@@ -56,46 +56,15 @@ namespace cyclone::benchmarks {
     return new nullable_varchar_vector(input);
   }
 
-  // size_t tuple_group_by(NullableScalarVec<int64_t> *input){
-  //   std::vector<std::tuple<int64_t, int>> grouping_vec(input->count);
-  //   std::vector<size_t> sorted_idx(input->count);
+  size_t vector_group1(nullable_varchar_vector *input) {
+    auto groups = input->group_indexes();
+    return groups.size();
+  }
 
-  //   for (auto i = 0; i < input->count; i++) {
-  //     grouping_vec[i] = std::tuple<int64_t, int>(input->data[i], input->get_validity(i));
-  //   }
-
-  //   sorted_idx = cyclone::sort_tuples(grouping_vec, std::array<int, 2>{{ 1, 1 }});
-
-  //   for (auto j = 0; j < input->count; j++) {
-  //     auto i = sorted_idx[j];
-  //     grouping_vec[j] = std::tuple<int64_t, int>(input->data[i], input->get_validity(i));
-  //   }
-
-  //   std::vector<size_t> groups_indices = frovedis::set_separate(grouping_vec);
-  //   auto groups_count = groups_indices.size() - 1;
-
-  //   std::vector<size_t> matching_ids(groups_count);
-  //   for (auto g = 0; g < groups_count; g++) {
-  //     matching_ids[g] = sorted_idx[groups_indices[g]];
-  //   }
-
-  //   return matching_ids.size();
-  // }
-
-
-  // size_t separate_to_groups_no_validity(NullableScalarVec<int64_t> *input){
-  //   std::vector<size_t> input_keys = input->size_t_data_vec();
-
-  //   std::vector<size_t> keys;
-  //   std::vector<std::vector<size_t>> groups = cyclone::separate_to_groups(input_keys, keys);
-  //   return groups.size();
-  // }
-
-
-  // size_t vector_group(NullableScalarVec<int64_t> *input){
-  //   std::vector<std::vector<size_t>> groups = input->group_indexes();
-  //   return groups.size();
-  // }
+  size_t vector_group2(nullable_varchar_vector *input) {
+    auto groups = input->group_indexes2();
+    return groups.size();
+  }
 
   // size_t vector_multi_group(NullableScalarVec<int64_t> *input1, NullableScalarVec<int64_t> *input2, NullableScalarVec<int64_t> *input3){
   //   size_t count = static_cast<size_t>(input1->count);
@@ -121,9 +90,9 @@ namespace cyclone::benchmarks {
   // }
 
   TEST_CASE("String Group-by Implementation Benchmarks") {
-    // auto *input = create_string_input(3500000, 150);
-    // auto *input_with_invalids = create_string_input(3500000, 150);
-    // input_with_invalids->set_validity(1, 0);
+    auto *input = create_string_input(3500000, 150);
+    auto *input_with_invalids = create_string_input(3500000, 150);
+    input_with_invalids->set_validity(1, 0);
 
     // ankerl::nanobench::Bench().run("tuple_group_by", [&]() {
     //   ankerl::nanobench::doNotOptimizeAway(tuple_group_by(input));
@@ -137,13 +106,21 @@ namespace cyclone::benchmarks {
     //   ankerl::nanobench::doNotOptimizeAway(separate_to_groups_no_validity(input));
     // });
 
-    // ankerl::nanobench::Bench().run("vector_group(with validity, all valid input)", [&]() {
-    //   ankerl::nanobench::doNotOptimizeAway(vector_group(input));
-    // });
+    ankerl::nanobench::Bench().run("vector_group 1 (with validity, all valid input)", [&]() {
+      ankerl::nanobench::doNotOptimizeAway(vector_group1(input));
+    });
 
-    // ankerl::nanobench::Bench().run("vector_group(with validity, some invalid input)", [&]() {
-    //   ankerl::nanobench::doNotOptimizeAway(vector_group(input_with_invalids));
-    // });
+    ankerl::nanobench::Bench().run("vector_group 1 (with validity, some invalid input)", [&]() {
+      ankerl::nanobench::doNotOptimizeAway(vector_group1(input_with_invalids));
+    });
+
+    ankerl::nanobench::Bench().run("vector_group 2 (with validity, all valid input)", [&]() {
+      ankerl::nanobench::doNotOptimizeAway(vector_group2(input));
+    });
+
+    ankerl::nanobench::Bench().run("vector_group 2 (with validity, some invalid input)", [&]() {
+      ankerl::nanobench::doNotOptimizeAway(vector_group2(input_with_invalids));
+    });
 
     // free(input);
     // free(input_with_invalids);

--- a/src/main/resources/io/sparkcyclone/cpp/benchmarks/nanobench.h
+++ b/src/main/resources/io/sparkcyclone/cpp/benchmarks/nanobench.h
@@ -997,8 +997,20 @@ void doNotOptimizeAway(T const& val);
 // see https://github.com/google/benchmark/blob/master/include/benchmark/benchmark.h#L307
 template <typename T>
 void doNotOptimizeAway(T const& val) {
+    /*
+        Replace "r,m" with "r" here to work around the following compilation
+        failure encountered when building nanobench with nc++:
+
+        "./benchmarks/nanobench.h", line 1001: error: multiple alternative constraint
+                is not supported
+            asm volatile("" : : "r,m"(val) : "memory");
+                                ^
+                detected during instantiation of "void
+                            ankerl::nanobench::doNotOptimizeAway(Arg &&) [with
+                            Arg=size_t]" at line ...
+    */
     // NOLINTNEXTLINE(hicpp-no-assembler)
-    asm volatile("" : : "r,m"(val) : "memory");
+    asm volatile("" : : "r"(val) : "memory");
 }
 
 template <typename T>

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone.hpp
@@ -26,6 +26,7 @@
 
 #include "cyclone/transfer-definitions.hpp"
 #include "cyclone/cyclone_function_view.hpp"
+#include "cyclone/cyclone_grouping.hpp"
 #include "cyclone/cyclone_sort.hpp"
 #include "cyclone/cyclone_utils.hpp"
 #include "cyclone/packed_transfer.hpp"

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_grouping.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_grouping.hpp
@@ -19,104 +19,75 @@
  */
 #pragma once
 
-#include "cyclone/cyclone_utils.hpp"
 #include "frovedis/core/radix_sort.hpp"
 #include "frovedis/core/set_operations.hpp"
 #include <vector>
 
 namespace cyclone::grouping {
+  /*
+    Perform sort + group on multiple contiguous ranges.
+
+    Sort + group is an easy and vectorizable algorithm for grouping elements.
+    For a given array range, the steps are as follows:
+
+      1.  Run a stable sort on the array of elements using
+          [[frovedis::radix_sort]].
+      2.  With the elements now in order, compute the indexes on the array where
+          the values change using [[frovedis::set_separate]].  For example,
+          in the sorted array [ 0, 0, 3, 5 ], the values change at array indices
+          0, 2, 3, and 4.  These indices form the bounds of the groups.
+
+    Multiple sort + group is simply an application of this algorithm over to
+    multiple contiguous ranges of an array, and concatenates the indices of the
+    groups together.
+
+    Consider this example input:
+
+      ARRAY     : [ 23, 0, 1, 4, 3, -2, 1, 5, 3, 0, 1, 6, 9, 6, 42, -100 ]
+      INDEX     : [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 ]
+      GROUPING  : [ 1, 6, 11, 14 ]
+
+    The full input array consists of 16 elements, but we are asked to perform
+    sort + group specificaly on 3 ranges: [1, 6), [6, 11), and [11, 14).
+
+    After running multiple sort + group, we will get the following output:
+
+      ARRAY     : [ 23, -2, 0, 1, 3, 4, 0, 1, 1, 3, 5, 6, 6, 9, 42, -100 ]
+      INDEX     : [ 0, 5, 1, 2, 4, 3, 9, 6, 10, 8, 7, 11, 13, 12, 14, 15 ]
+      GROUPING  : [ 0, 2, 3, 4, 5, 6, 7, 9, 10, 11, 13, 14 ]
+
+    The elements of [1, 6) in the original array are now sorted in the output
+    array, but only within that range.  Likewise for ranges [6, 11), and
+    [11, 14).  Elements at indices 0, 14, and 15 remain un-touched.  The
+    output groups reflect the indices where the values change, and are a
+    concatenation of the group indices found in each range denoted by the
+    input group indices.
+
+    If this function is called with sort_ascending = false in the template
+    parameter, then the elements in each specified range will be sorted in DESC
+    order.  Using the above example input, the output will be as follows:
+
+      ARRAY     : [ 23, 4, 3, 1, 0, -2, 5, 3, 1, 1, 0, 9, 6, 6, 42, -100 ]
+      INDEX     : [ 0, 5, 1, 2, 4, 3, 9, 6, 10, 8, 7, 11, 13, 12, 14, 15 ]
+      GROUPING  : [ 0, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 14 ]
+
+    Function Arguments:
+      sort_data_arr           : The data array whose elements are to be sorted (sort keys).
+      sort_data_len           : The length of the data array.
+      index_arr               : An array of indices of the elements (sort values).  This is used for multi-stage sorting.
+      input_group_delims_arr  : Indices that denote the ranges to be sorted.  Index values are relative to &sort_data_arr[0].
+      input_group_delims_len  : Length of the input indices.
+      output_group_delims_arr : Combined indices where the values change (to be written after the sort + grouping).  Index values are relative to &sort_data_arr[0].
+      output_group_delims_len : Length of the output indices (to be written after the sort + grouping).  Index values are relative to &sort_data_arr[0].
+  */
   template <typename T, bool sort_ascending = true>
-  inline const std::vector<size_t> sort_and_group_multiple(T            * sort_data_arr,
-                                                           size_t         sort_data_len,
-                                                           size_t       * index_arr,
-                                                           const size_t * input_group_delims_arr,
-                                                           const size_t   input_group_delims_len) {
-    // If there are more group delimiters than elements in the range, then that
-    // means that each subset will contain just one element
-    if (input_group_delims_len > sort_data_len) {
-      std::vector<size_t> output_group_delims(input_group_delims_len);
-      memcpy(output_group_delims.data(), input_group_delims_arr, sizeof(size_t) * input_group_delims_len);
-      return output_group_delims;
-    }
-
-    std::vector<std::vector<size_t>> component_group_delims(input_group_delims_len - 1);
-
-    // For each subset denoted by input_group_delims, perform sort + grouping
-    // and get back a component delim group
-    #pragma _NEC vector
-    #pragma _NEC ivdep
-    for (auto i = 1; i < input_group_delims_len; i++) {
-      // Fetch the boundaries of the range containing subset i
-      const auto subset_start = input_group_delims_arr[i-1];
-      const auto subset_end   = input_group_delims_arr[i];
-      const auto subset_size  = subset_end - subset_start;
-
-      if (subset_size < 2) {
-        component_group_delims[i - 1] = {{ 0, 1 }};
-
-      } else {
-        // Sort the elements in subset i
-        if constexpr (sort_ascending) {
-          frovedis::radix_sort(&sort_data_arr[subset_start], &index_arr[subset_start], subset_size);
-        } else {
-          frovedis::radix_sort_desc(&sort_data_arr[subset_start], &index_arr[subset_start], subset_size);
-        }
-
-        // Construct the array of indices where the value of the keys change
-        component_group_delims[i - 1] = frovedis::set_separate(&sort_data_arr[subset_start], subset_size);
-      }
-    }
-
-    // Compute a prefix sum to get the offsets of the data elements
-    std::vector<size_t> data_len_offsets(input_group_delims_len, 0);
-    #pragma _NEC vector
-    for (auto i = 1; i < input_group_delims_len; i++) {
-      const auto subset_start = input_group_delims_arr[i-1];
-      const auto subset_end   = input_group_delims_arr[i];
-      data_len_offsets[i] = data_len_offsets[i - 1] + (subset_end - subset_start);
-    }
-
-    // Compute a prefix sum to get the offsets of the component delim groups
-    std::vector<size_t> component_group_offsets(input_group_delims_len, 0);
-    #pragma _NEC vector
-    for (auto i = 1; i < component_group_offsets.size(); i++) {
-      component_group_offsets[i] = component_group_offsets[i - 1] + component_group_delims[i - 1].size() - 1;
-    }
-
-    // Using the component arrays, construct the final array of indices where the
-    // value of the keys change
-    std::vector<size_t> output_group_delims(component_group_offsets.back() + 1);
-
-    // Populate the combined delimiters from the component delim groups in parallel
-    #pragma _NEC vector
-    #pragma _NEC ivdep
-    for (auto i = 0; i < component_group_delims.size(); i++) {
-      const auto delims = component_group_delims[i];
-
-      #pragma _NEC vector
-      #pragma _NEC ivdep
-      for (auto j = 0; j < delims.size() - 1; j++) {
-        // Each delim value in a component delim group is relative to the positions
-        // specified in the orignal input group, and each delim value's position
-        // in the final group array is relative as well.
-        output_group_delims[j + component_group_offsets[i]] = delims[j] + data_len_offsets[i];
-      }
-    }
-
-    // Populate the last delimiter
-    output_group_delims.back() = data_len_offsets.back();
-
-    return output_group_delims;
-  }
-
-  template <typename T, bool sort_ascending = true>
-  inline const void sort_and_group_multiple2(T            * sort_data_arr,
-                                                           size_t         sort_data_len,
-                                                           size_t       * index_arr,
-                                                           const size_t * input_group_delims_arr,
-                                                           const size_t   input_group_delims_len,
-                                                           size_t       * output_group_delims_arr,
-                                                           size_t       & output_group_delims_len) {
+  inline const void sort_and_group_multiple(T             * sort_data_arr,
+                                            const size_t    sort_data_len,
+                                            size_t        * index_arr,
+                                            const size_t  * input_group_delims_arr,
+                                            const size_t    input_group_delims_len,
+                                            size_t        * output_group_delims_arr,
+                                            size_t        & output_group_delims_len) {
     // If there are more group delimiters than elements in the range, then that
     // means that each subset will contain just one element
     if (input_group_delims_len > sort_data_len) {
@@ -153,10 +124,18 @@ namespace cyclone::grouping {
         // Construct the array of indices where the value of the keys change
         auto delims = frovedis::set_separate(&sort_data_arr[subset_start], subset_size);
 
-        // Append them to the output_group_delims_arr (accounting for relative position)
-        #pragma _NEC vector
-        for (auto d = 1; d < delims.size(); d++) {
-          output_group_delims_arr[output_group_delims_len++] = subset_start + delims[d];
+        // Append them to the output_group_delims_arr (accounting for relative
+        // positioning).  It is written in this format instead of
+        // `arr[len++] = value` to enable vectorization
+        {
+          #pragma _NEC vector
+          #pragma _NEC ivdep
+          for (auto d = 1; d < delims.size(); d++) {
+            // Adjust for offset with d - 1
+            output_group_delims_arr[output_group_delims_len + d - 1] = subset_start + delims[d];
+          }
+          // Increment by n - 1 instead of n to avoid overcounting
+          output_group_delims_len += delims.size() - 1;
         }
       }
     }
@@ -164,14 +143,18 @@ namespace cyclone::grouping {
     return;
   }
 
+  /*
+    Perform sort + group on multiple contiguous ranges.  This is the C++ version
+    of the function signature to be used mainly for testing and development.
+  */
   template <typename T, bool sort_ascending = true>
-  inline const std::vector<size_t> sort_and_group_multiple2(std::vector<T>             & sort_data,
+  inline const std::vector<size_t> sort_and_group_multiple(std::vector<T>             & sort_data,
                                                            std::vector<size_t>        & index_data,
                                                            const std::vector<size_t>  & input_group_delims) {
     std::vector<size_t> output_group_delims(input_group_delims.back() - input_group_delims.front());
     size_t output_group_delims_len;
 
-    sort_and_group_multiple2<T, sort_ascending>(
+    sort_and_group_multiple<T, sort_ascending>(
       sort_data.data(),
       sort_data.size(),
       index_data.data(),
@@ -181,20 +164,8 @@ namespace cyclone::grouping {
       output_group_delims_len
     );
 
+    // Resize the vector to match output_group_delims_len
     output_group_delims.resize(output_group_delims_len);
     return output_group_delims;
-  }
-
-  template <typename T, bool sort_ascending = true>
-  inline const std::vector<size_t> sort_and_group_multiple(std::vector<T>             & sort_data,
-                                                           std::vector<size_t>        & index_data,
-                                                           const std::vector<size_t>  & input_group_delims) {
-    return sort_and_group_multiple<T, sort_ascending>(
-      sort_data.data(),
-      sort_data.size(),
-      index_data.data(),
-      input_group_delims.data(),
-      input_group_delims.size()
-    );
   }
 }

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_grouping.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_grouping.hpp
@@ -19,6 +19,7 @@
  */
 #pragma once
 
+#include "cyclone/cyclone_utils.hpp"
 #include "frovedis/core/radix_sort.hpp"
 #include "frovedis/core/set_operations.hpp"
 #include <vector>
@@ -108,12 +109,6 @@ namespace cyclone::grouping {
     return output_group_delims;
   }
 
-
-
-
-
-
-
   template <typename T, bool sort_ascending = true>
   inline const void sort_and_group_multiple2(T            * sort_data_arr,
                                                            size_t         sort_data_len,
@@ -132,6 +127,7 @@ namespace cyclone::grouping {
 
     // Set the output_group_delims_arr to be of length 0
     output_group_delims_len = 0;
+    output_group_delims_arr[output_group_delims_len++] = 0;
 
     // For each subset denoted by input_group_delims, perform sort + grouping
     // and get back a component delim group
@@ -139,12 +135,11 @@ namespace cyclone::grouping {
     #pragma _NEC ivdep
     for (auto i = 1; i < input_group_delims_len; i++) {
       // Fetch the boundaries of the range containing subset i
-      const auto subset_start = input_group_delims_arr[i-1];
+      const auto subset_start = input_group_delims_arr[i - 1];
       const auto subset_end   = input_group_delims_arr[i];
       const auto subset_size  = subset_end - subset_start;
 
       if (subset_size == 1) {
-        output_group_delims_arr[output_group_delims_len++] = subset_start;
         output_group_delims_arr[output_group_delims_len++] = subset_end;
 
       } else {
@@ -160,7 +155,7 @@ namespace cyclone::grouping {
 
         // Append them to the output_group_delims_arr (accounting for relative position)
         #pragma _NEC vector
-        for (auto d = 0; d < delims.size(); d++) {
+        for (auto d = 1; d < delims.size(); d++) {
           output_group_delims_arr[output_group_delims_len++] = subset_start + delims[d];
         }
       }

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_grouping.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_grouping.hpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2022 Xpress AI.
+ *
+ * This file is part of Spark Cyclone.
+ * See https://github.com/XpressAI/SparkCyclone for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#pragma once
+
+#include "frovedis/core/radix_sort.hpp"
+#include "frovedis/core/set_operations.hpp"
+#include <vector>
+
+namespace cyclone::grouping {
+  template <typename T, bool sort_ascending = true>
+  inline const std::vector<size_t> sort_and_group_multiple(T            * sort_data_arr,
+                                                           size_t         sort_data_len,
+                                                           size_t       * index_data_arr,
+                                                           const size_t * input_group_delims_arr,
+                                                           const size_t   input_group_delims_len) {
+    // If there are more group delimiters than elements in the range, then that
+    // means that each subset will contain just one element
+    if (input_group_delims_len > sort_data_len) {
+      std::vector<size_t> output_group_delims(input_group_delims_len);
+      memcpy(output_group_delims.data(), input_group_delims_arr, sizeof(size_t) * input_group_delims_len);
+      return output_group_delims;
+    }
+
+    std::vector<std::vector<size_t>> component_group_delims(input_group_delims_len - 1);
+
+    // For each subset denoted by input_group_delims, perform sort + grouping
+    // and get back a component delim group
+    #pragma _NEC vector
+    #pragma _NEC ivdep
+    for (auto i = 1; i < input_group_delims_len; i++) {
+      // Fetch the boundaries of the range containing subset i
+      const auto subset_start = input_group_delims_arr[i-1];
+      const auto subset_end   = input_group_delims_arr[i];
+      const auto subset_size  = subset_end - subset_start;
+
+      if (subset_size < 2) {
+        component_group_delims[i - 1] = {{ 0, 1 }};
+
+      } else {
+        // Sort the elements in subset i
+        if constexpr (sort_ascending) {
+          frovedis::radix_sort(&sort_data_arr[subset_start], &index_data_arr[subset_start], subset_size);
+        } else {
+          frovedis::radix_sort_desc(&sort_data_arr[subset_start], &index_data_arr[subset_start], subset_size);
+        }
+
+        // Construct the array of indices where the value of the keys change
+        component_group_delims[i - 1] = frovedis::set_separate(&sort_data_arr[subset_start], subset_size);
+      }
+    }
+
+    // Compute a prefix sum to get the offsets of the data elements
+    std::vector<size_t> data_len_offsets(input_group_delims_len, 0);
+    #pragma _NEC vector
+    for (auto i = 1; i < input_group_delims_len; i++) {
+      const auto subset_start = input_group_delims_arr[i-1];
+      const auto subset_end   = input_group_delims_arr[i];
+      data_len_offsets[i] = data_len_offsets[i - 1] + (subset_end - subset_start);
+    }
+
+    // Compute a prefix sum to get the offsets of the component delim groups
+    std::vector<size_t> component_group_offsets(input_group_delims_len, 0);
+    #pragma _NEC vector
+    for (auto i = 1; i < component_group_offsets.size(); i++) {
+      component_group_offsets[i] = component_group_offsets[i - 1] + component_group_delims[i - 1].size() - 1;
+    }
+
+    // Using the component arrays, construct the final array of indices where the
+    // value of the keys change
+    std::vector<size_t> output_group_delims(component_group_offsets.back() + 1);
+
+    // Populate the combined delimiters from the component delim groups in parallel
+    #pragma _NEC vector
+    #pragma _NEC ivdep
+    for (auto i = 0; i < component_group_delims.size(); i++) {
+      const auto delims = component_group_delims[i];
+
+      #pragma _NEC vector
+      #pragma _NEC ivdep
+      for (auto j = 0; j < delims.size() - 1; j++) {
+        // Each delim value in a component delim group is relative to the positions
+        // specified in the orignal input group, and each delim value's position
+        // in the final group array is relative as well.
+        output_group_delims[j + component_group_offsets[i]] = delims[j] + data_len_offsets[i];
+      }
+    }
+
+    // Populate the last delimiter
+    output_group_delims.back() = data_len_offsets.back();
+
+    return output_group_delims;
+  }
+
+  template <typename T, bool sort_ascending = true>
+  inline const std::vector<size_t> sort_and_group_multiple(std::vector<T>             & sort_data,
+                                                           std::vector<size_t>        & index_data,
+                                                           const std::vector<size_t>  & input_group_delims) {
+    return sort_and_group_multiple<T, sort_ascending>(
+      sort_data.data(),
+      sort_data.size(),
+      index_data.data(),
+      input_group_delims.data(),
+      input_group_delims.size()
+    );
+  }
+}

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_grouping.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_grouping.hpp
@@ -168,4 +168,56 @@ namespace cyclone::grouping {
     output_group_delims.resize(output_group_delims_len);
     return output_group_delims;
   }
+
+  inline const std::vector<std::vector<size_t>> separate_to_groups(const std::vector<size_t> &ids,
+                                                                   std::vector<size_t> &group_keys) {
+    auto groups = ids;
+    frovedis::radix_sort(groups);
+    auto unique_groups = frovedis::set_unique(groups);
+    std::vector<size_t> group_counts(unique_groups.size());
+
+    auto ids_count = ids.size();
+    auto ids_arr = ids.data();
+    auto groups_arr = groups.data();
+    auto groups_size = groups.size();
+    auto groups_count_arr = group_counts.data();
+    auto unique_groups_arr = unique_groups.data();
+    auto unique_groups_size = unique_groups.size();
+
+    // Count the number of groups
+    for (size_t g = 0; g < unique_groups_size; g++) {
+      size_t current_count = 0;
+      size_t the_group = unique_groups_arr[g];
+
+      #pragma _NEC vector
+      for (size_t i = 0; i < groups_size; i++) {
+        if (groups_arr[i] == the_group) {
+          current_count++;
+        }
+      }
+      groups_count_arr[g] = current_count;
+    }
+
+    std::vector<std::vector<size_t>> ret(unique_groups_size);
+    for (size_t i = 0; i < unique_groups_size; i++) {
+      ret[i].resize(groups_count_arr[i]);
+    }
+
+    auto ret_arr = ret.data();
+
+    for (auto g = 0; g < unique_groups_size; g++) {
+      size_t group_pos = 0;
+      size_t group = unique_groups_arr[g];
+      auto ret_g_arr = ret_arr[g].data();
+      #pragma _NEC vector
+      for (size_t i = 0; i < ids_count; i++) {
+        if (ids_arr[i] == group) {
+          ret_g_arr[group_pos++] = i;
+        }
+      }
+    }
+
+    group_keys = unique_groups;
+    return ret;
+  }
 }

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_grouping.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_grouping.hpp
@@ -74,11 +74,11 @@ namespace cyclone::grouping {
     Function Arguments:
       sort_data_arr           : The data array whose elements are to be sorted (sort keys).
       sort_data_len           : The length of the data array.
-      index_arr               : An array of indices of the elements (sort values).  This is used for multi-stage sorting.
+      index_arr               : An array of indices of the elements (sort values, to be re-arranged).  This is used for multi-stage sorting.
       input_group_delims_arr  : Indices that denote the ranges to be sorted.  Index values are relative to &sort_data_arr[0].
-      input_group_delims_len  : Length of the input indices.
-      output_group_delims_arr : Combined indices where the values change (to be written after the sort + grouping).  Index values are relative to &sort_data_arr[0].
-      output_group_delims_len : Length of the output indices (to be written after the sort + grouping).  Index values are relative to &sort_data_arr[0].
+      input_group_delims_len  : Length of input_group_delims_arr.
+      output_group_delims_arr : Combined indices where the values change after sort + grouping (pre-allocated and to be written).  Index values are relative to &sort_data_arr[0].
+      output_group_delims_len : Length of output_group_delims_arr (to be written).  Index values are relative to &sort_data_arr[0].
   */
   template <typename T, bool sort_ascending = true>
   inline const void sort_and_group_multiple(T             * sort_data_arr,

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_utils.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_utils.hpp
@@ -172,6 +172,14 @@ namespace cyclone {
     std::cout << name <<  " = " << vec << std::endl;
   }
 
+  template<typename T>
+  void print_vec(const std::string &name, const T * array, const size_t len) {
+    std::cout << name <<  " = [ ";
+    for (auto i = 0; i < len; i++) {
+      std::cout << array[i] << ", ";
+    }
+    std::cout << "]" << std::endl;
+  }
 
   /**
    * Append two bitsets using uint64_t as the container type.

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_utils.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/cyclone_utils.hpp
@@ -34,58 +34,6 @@
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
 namespace cyclone {
-  inline const std::vector<std::vector<size_t>> separate_to_groups(const std::vector<size_t> &ids,
-                                                                   std::vector<size_t> &group_keys) {
-    std::vector<size_t> groups = ids;
-    frovedis::radix_sort(groups);
-    std::vector<size_t> unique_groups = frovedis::set_unique(groups);
-    std::vector<size_t> group_counts(unique_groups.size());
-
-    auto ids_count = ids.size();
-    auto ids_arr = ids.data();
-    auto groups_arr = groups.data();
-    auto groups_size = groups.size();
-    auto groups_count_arr = group_counts.data();
-    auto unique_groups_arr = unique_groups.data();
-    auto unique_groups_size = unique_groups.size();
-
-    // Count the number of groups
-    for (size_t g = 0; g < unique_groups_size; g++) {
-      size_t current_count = 0;
-      size_t the_group = unique_groups_arr[g];
-
-      #pragma _NEC vector
-      for (size_t i = 0; i < groups_size; i++) {
-        if (groups_arr[i] == the_group) {
-          current_count++;
-        }
-      }
-      groups_count_arr[g] = current_count;
-    }
-
-    std::vector<std::vector<size_t>> ret(unique_groups_size);
-    for (size_t i = 0; i < unique_groups_size; i++) {
-      ret[i].resize(groups_count_arr[i]);
-    }
-
-    auto ret_arr = ret.data();
-
-    for (size_t g = 0; g < unique_groups_size; g++) {
-      size_t group_pos = 0;
-      size_t group = unique_groups_arr[g];
-      auto ret_g_arr = ret_arr[g].data();
-      #pragma _NEC vector
-      for (size_t i = 0; i < ids_count; i++) {
-        if (ids_arr[i] == group) {
-          ret_g_arr[group_pos++] = i;
-        }
-      }
-    }
-
-    group_keys = unique_groups;
-    return ret;
-  }
-
   inline const std::vector<size_t> bitmask_to_matching_ids(const std::vector<size_t> &mask) {
     // Count the number of 1-bits
     size_t m_count = 0;

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_scalar_vector.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_scalar_vector.cc
@@ -365,7 +365,7 @@ NullableScalarVec<T> * NullableScalarVec<T>::merge(const NullableScalarVec<T> * 
   }
 
   // Preserve the validityBuffer across the merge
-  fast_validity_merge(output->validityBuffer, inputs, batches);
+  cyclone::fast_validity_merge(output->validityBuffer, inputs, batches);
 
   return output;
 }
@@ -528,7 +528,7 @@ template <typename T>
 const std::vector<std::vector<size_t>> NullableScalarVec<T>::group_indexes() const {
   // Short-circuit for simple cases
   if (count == 0) return {};
-  if (count == 1) return {{0}};
+  if (count == 1) return {{ 0 }};
 
   // group_indexes is a special case of group_indexes_on_subset, where we are
   // performing grouping on just one subset, which is the entire data array.

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_scalar_vector.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_scalar_vector.cc
@@ -387,108 +387,135 @@ const std::vector<size_t> NullableScalarVec<T>::eval_in(const std::vector<T> &el
   return bitmask;
 }
 
-template <typename T>
-void NullableScalarVec<T>::group_indexes_on_subset(size_t* iter_order_arr, size_t* group_pos, size_t group_pos_size, size_t* idx_arr, size_t* out_group_pos, size_t &out_group_pos_size) const {
-  // Shortcut for case when every element would end up in its own group anyway
-  if(group_pos_size > count){
+template<typename T>
+void NullableScalarVec<T>::group_indexes_on_subset(const size_t * iter_order_arr,
+                                                   const size_t * group_pos,
+                                                   const size_t group_pos_size,
+                                                   size_t * idx_arr,
+                                                   size_t * out_group_pos,
+                                                   size_t & out_group_pos_size) const {
+  // If there are more group positions than elements in the vector, it means
+  // each subset will contain just one element, so we can apply shortcut.
+  if (group_pos_size > count) {
     auto start = group_pos[0];
     auto end = group_pos[group_pos_size - 1];
-    auto count = end - start;
 
-    if(iter_order_arr == nullptr) {
+    // If iteration order array is not given, generate start.to(end)
+    if (iter_order_arr == nullptr) {
       #pragma _NEC vector
       #pragma _NEC ivdep
-      for(auto i = start; i < end; i++) {
-          idx_arr[i] = i;
+      for (auto i = start; i < end; i++) {
+        idx_arr[i] = i;
       }
     } else {
-      memcpy(&idx_arr[start], &iter_order_arr[start], sizeof(size_t) * count);
+      // Else just copy the index array to the output
+      memcpy(&idx_arr[start], &iter_order_arr[start], sizeof(size_t) * (end - start));
     }
+
+    // Copy the group positions to output
     memcpy(out_group_pos, group_pos, sizeof(size_t) * group_pos_size);
     out_group_pos_size = group_pos_size;
     return;
   }
 
-  // Allocate memory for the largest possible group
-  // We will reuse that memory for every group, so we don't have to allocate/free often
+  // Figure out the largest possible group (subset of data) and allocate memory
+  // of that size.  This chunk of memory will be used for sorting each subset
+  // so that we only need to allocate and free once.
   size_t largest_group_size = 0;
-#pragma _NEC vector
-  for(auto g = 1; g < group_pos_size; g++){
-    auto total_el_count = group_pos[g] - group_pos[g - 1];
-    if(largest_group_size < total_el_count) largest_group_size = total_el_count;
+  #pragma _NEC vector
+  for (auto g = 1; g < group_pos_size; g++) {
+    auto element_count = group_pos[g] - group_pos[g - 1];
+    if (largest_group_size < element_count) largest_group_size = element_count;
   }
-  T* sorted_data = static_cast<T *>(malloc(sizeof(T) * largest_group_size));
+  T * sorted_data = static_cast<T *>(malloc(sizeof(T) * largest_group_size));
 
+  // Initialize the output groups
   out_group_pos_size = 0;
   out_group_pos[out_group_pos_size++] = group_pos[0];
-#pragma _NEC vector
-  for(auto g = 1; g < group_pos_size; g++){
+
+  // Iterate over all subsets
+  #pragma _NEC vector
+  for (auto g = 1; g < group_pos_size; g++) {
     auto start = group_pos[g - 1];
     auto end = group_pos[g];
+    auto element_count = end - start;
 
-    auto total_el_count = end - start;
-    if(total_el_count == 1){
-      // Shortcut for single element groups
-      if(iter_order_arr == nullptr){
+    // If there is only one element in the current subset, then we're done with
+    // its grouping
+    if (element_count == 1) {
+      if (iter_order_arr == nullptr) {
         idx_arr[start] = start;
-      }else{
+      } else {
         idx_arr[start] = iter_order_arr[start];
       }
       out_group_pos[out_group_pos_size++] = end;
-    }else{
+
+    } else {
+      // Hold the count of valid and invalid elements in the subset
       size_t cur_invalid_count = 0;
       size_t cur_valid_count = 0;
 
-      if(iter_order_arr == nullptr){
-#pragma _NEC vector
-#pragma _NEC ivdep
-        for(auto i = start; i < end; i++){
-          if(get_validity(i)){
-            idx_arr[start + cur_valid_count++] = i;
-          }else{
-            idx_arr[end - (++cur_invalid_count)] = i;
+      // Shift indices of all valid and invalid elements to the left and ight of
+      // the subset, respectively
+      {
+        if (iter_order_arr == nullptr) {
+          #pragma _NEC vector
+          #pragma _NEC ivdep
+          for (auto i = start; i < end; i++) {
+            if (get_validity(i)) {
+              idx_arr[start + cur_valid_count++] = i;
+            } else {
+              idx_arr[end - (++cur_invalid_count)] = i;
+            }
           }
-        }
-      }else{
-#pragma _NEC vector
-#pragma _NEC ivdep
-        for(auto i = start; i < end; i++){
-          auto j = iter_order_arr[i];
-          if(get_validity(j)){
-            idx_arr[start + cur_valid_count++] = j;
-          }else{
-            idx_arr[end - (++cur_invalid_count)] = j;
+
+        } else {
+          #pragma _NEC vector
+          #pragma _NEC ivdep
+          for (auto i = start; i < end; i++) {
+            auto j = iter_order_arr[i];
+            if (get_validity(j)) {
+              idx_arr[start + cur_valid_count++] = j;
+            } else {
+              idx_arr[end - (++cur_invalid_count)] = j;
+            }
           }
         }
       }
 
-      { // Setup valid inputs
-#pragma _NEC vector
+      // Set up the data array for the subset
+      {
+        #pragma _NEC vector
         for (auto i = 0; i < cur_valid_count; i++) {
-            sorted_data[i] = data[idx_arr[start + i]];
+          sorted_data[i] = data[idx_arr[start + i]];
         }
       }
 
-      // Sort data for grouping
+      // Grouping data using Frovedis involves sorting, followed by set_separate
+      // to figure out the indices in the sorted array where the element changes
+      // value.
       frovedis::radix_sort(sorted_data, &idx_arr[start], cur_valid_count);
-      std::vector<size_t> group_pos_idxs = frovedis::set_separate(sorted_data, cur_valid_count);
+      std::vector <size_t> group_pos_idxs = frovedis::set_separate(sorted_data, cur_valid_count);
 
-      auto new_group_count = group_pos_idxs.size();
-      auto new_group_arr = group_pos_idxs.data();
-      size_t out_group_idx = out_group_pos_size;
-#pragma _NEC vector
-      for(auto i = 1; i < new_group_count; i++){
+      auto group_pos_idxs_arr = group_pos_idxs.data();
+      auto out_group_idx = out_group_pos_size;
+
+      // Copy the subset's grouping indices to the output
+      #pragma _NEC vector
+      for (auto i = 1; i < group_pos_idxs.size(); i++) {
         // We are skipping the first entry here, because it will already be
         // included in the result, either as the very first value, or because
         // it was specified as the last value from a previous iteration.
-        auto offset_idx = new_group_arr[i] + start;
+        auto offset_idx = group_pos_idxs_arr[i] + start;
         out_group_pos[out_group_idx++] = offset_idx;
       }
+
       out_group_pos_size = out_group_idx;
+
       // The last group index will be based on the last valid group
       // to account for the invalid group, if it exists, we need to
       // add the last possible index of this subset, too
-      if(cur_invalid_count > 0){
+      if (cur_invalid_count > 0) {
         out_group_pos[out_group_pos_size++] = end;
       }
     }
@@ -500,10 +527,11 @@ void NullableScalarVec<T>::group_indexes_on_subset(size_t* iter_order_arr, size_
 template <typename T>
 const std::vector<std::vector<size_t>> NullableScalarVec<T>::group_indexes() const {
   // Short-circuit for simple cases
-  if(count == 0) return {};
-  if(count == 1) return {{0}};
+  if (count == 0) return {};
+  if (count == 1) return {{0}};
 
-
+  // group_indexes is a special case of group_indexes_on_subset, where we are
+  // performing grouping on just one subset, which is the entire data array.
   size_t group_pos[2] = {0, static_cast<size_t>(count)};
   size_t* idx_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
   size_t* max_group_pos = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
@@ -512,8 +540,8 @@ const std::vector<std::vector<size_t>> NullableScalarVec<T>::group_indexes() con
 
   std::vector<std::vector<size_t>> result;
 
-#pragma _NEC vector
-  for(auto g = 1; g < group_pos_count; g++){
+  #pragma _NEC vector
+  for (auto g = 1; g < group_pos_count; g++) {
     std::vector<size_t> output_group(&idx_arr[max_group_pos[g - 1]], &idx_arr[max_group_pos[g]]);
     result.push_back(output_group);
   }

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_scalar_vector.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_scalar_vector.cc
@@ -483,8 +483,9 @@ void NullableScalarVec<T>::group_indexes_on_subset(const size_t * iter_order_arr
         }
       }
 
-      // Set up the data array for the subset
+
       {
+        // Set up the data array for the subset
         #pragma _NEC vector
         for (auto i = 0; i < cur_valid_count; i++) {
           sorted_data[i] = data[idx_arr[start + i]];

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -618,6 +618,7 @@ void nullable_varchar_vector::group_indexes_on_subset(const size_t * iter_order_
 
   out_group_pos_size = 0;
   out_group_pos[out_group_pos_size++] = group_pos[0];
+
   #pragma _NEC vector
   for (auto g = 1; g < group_pos_size; g++) {
     auto start = group_pos[g - 1];

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_varchar_vector.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/nullable_varchar_vector.cc
@@ -579,21 +579,26 @@ nullable_varchar_vector * nullable_varchar_vector::from_binary_choice(const size
   return from_words(output_words);
 }
 
-void nullable_varchar_vector::group_indexes_on_subset(size_t* iter_order_arr, size_t* group_pos, size_t group_pos_size, size_t* idx_arr, size_t* out_group_pos, size_t &out_group_pos_size) const {
+void nullable_varchar_vector::group_indexes_on_subset(const size_t * iter_order_arr,
+                                                      const size_t * group_pos,
+                                                      const size_t group_pos_size,
+                                                      size_t * idx_arr,
+                                                      size_t * out_group_pos,
+                                                      size_t & out_group_pos_size) const {
   // Shortcut for case when every element would end up in its own group anyway
-  if(group_pos_size > count){
+  if (group_pos_size > count) {
     auto start = group_pos[0];
     auto end = group_pos[group_pos_size - 1];
     auto count = end - start;
 
-    if(iter_order_arr == nullptr){
+    if (iter_order_arr == nullptr) {
       #pragma _NEC vector
       #pragma _NEC ivdep
-      for(auto i = start; i < end; i++) {
-          idx_arr[i] = i;
+      for (auto i = start; i < end; i++) {
+        idx_arr[i] = i;
       }
     } else {
-      memcpy(&idx_arr[start], &iter_order_arr[start], sizeof(size_t) * count);
+      memcpy( & idx_arr[start], & iter_order_arr[start], sizeof(size_t) * count);
     }
     memcpy(out_group_pos, group_pos, sizeof(size_t) * group_pos_size);
     out_group_pos_size = group_pos_size;
@@ -603,72 +608,73 @@ void nullable_varchar_vector::group_indexes_on_subset(size_t* iter_order_arr, si
   // Allocate memory for the largest possible group
   // We will reuse that memory for every group, so we don't have to allocate/free often
   size_t largest_group_size = 0;
-#pragma _NEC vector
-  for(auto g = 1; g < group_pos_size; g++){
+  #pragma _NEC vector
+  for (auto g = 1; g < group_pos_size; g++) {
     auto total_el_count = group_pos[g] - group_pos[g - 1];
-    if(largest_group_size < total_el_count) largest_group_size = total_el_count;
+    if (largest_group_size < total_el_count) largest_group_size = total_el_count;
   }
-  size_t* sorted_data = static_cast<size_t *>(malloc(sizeof(size_t) * largest_group_size));
+  size_t * sorted_data = static_cast < size_t * > (malloc(sizeof(size_t) * largest_group_size));
 
   out_group_pos_size = 0;
   out_group_pos[out_group_pos_size++] = group_pos[0];
-#pragma _NEC vector
-  for(auto g = 1; g < group_pos_size; g++){
+  #pragma _NEC vector
+  for (auto g = 1; g < group_pos_size; g++) {
     auto start = group_pos[g - 1];
     auto end = group_pos[g];
 
     auto total_el_count = end - start;
-    if(total_el_count == 1){
+    if (total_el_count == 1) {
       // Shortcut for single element groups
-      if(iter_order_arr == nullptr){
+      if (iter_order_arr == nullptr) {
         idx_arr[start] = start;
-      }else{
+      } else {
         idx_arr[start] = iter_order_arr[start];
       }
       out_group_pos[out_group_pos_size++] = end;
-    }else{
+    } else {
       size_t cur_invalid_count = 0;
       size_t cur_valid_count = 0;
 
-      if(iter_order_arr == nullptr){
-#pragma _NEC vector
-#pragma _NEC ivdep
-        for(auto i = start; i < end; i++){
-          if(get_validity(i)){
+      if (iter_order_arr == nullptr) {
+        #pragma _NEC vector
+        #pragma _NEC ivdep
+        for (auto i = start; i < end; i++) {
+          if (get_validity(i)) {
             idx_arr[start + cur_valid_count++] = i;
-          }else{
+          } else {
             idx_arr[end - (++cur_invalid_count)] = i;
           }
         }
-      }else{
-#pragma _NEC vector
-#pragma _NEC ivdep
-        for(auto i = start; i < end; i++){
+      } else {
+        #pragma _NEC vector
+        #pragma _NEC ivdep
+        for (auto i = start; i < end; i++) {
           auto j = iter_order_arr[i];
-          if(get_validity(j)){
+          if (get_validity(j)) {
             idx_arr[start + cur_valid_count++] = j;
-          }else{
+          } else {
             idx_arr[end - (++cur_invalid_count)] = j;
           }
         }
       }
 
       { // Setup valid inputs
-#pragma _NEC vector
+        #pragma _NEC vector
         for (auto i = 0; i < cur_valid_count; i++) {
-            sorted_data[i] = hash_at(idx_arr[start + i], 1);
+          sorted_data[i] = hash_at(idx_arr[start + i], 1);
         }
       }
 
       // Sort data for grouping
-      frovedis::radix_sort(sorted_data, &idx_arr[start], cur_valid_count);
+      frovedis::radix_sort(sorted_data, & idx_arr[start], cur_valid_count);
       std::vector<size_t> group_pos_idxs = frovedis::set_separate(sorted_data, cur_valid_count);
 
       auto new_group_count = group_pos_idxs.size();
       auto new_group_arr = group_pos_idxs.data();
       size_t out_group_idx = out_group_pos_size;
-#pragma _NEC vector
-      for(auto i = 1; i < new_group_count; i++){
+
+      #pragma _NEC vector
+      for (auto i = 1; i < new_group_count; i++) {
         // We are skipping the first entry here, because it will already be
         // included in the result, either as the very first value, or because
         // it was specified as the last value from a previous iteration.
@@ -679,7 +685,7 @@ void nullable_varchar_vector::group_indexes_on_subset(size_t* iter_order_arr, si
       // The last group index will be based on the last valid group
       // to account for the invalid group, if it exists, we need to
       // add the last possible index of this subset, too
-      if(cur_invalid_count > 0){
+      if (cur_invalid_count > 0) {
         out_group_pos[out_group_pos_size++] = end;
       }
     }
@@ -688,23 +694,25 @@ void nullable_varchar_vector::group_indexes_on_subset(size_t* iter_order_arr, si
   free(sorted_data);
 }
 
-const std::vector<std::vector<size_t>> nullable_varchar_vector::group_indexes() const {
+const std::vector < std::vector < size_t >> nullable_varchar_vector::group_indexes() const {
   // Short-circuit for simple cases
-  if(count == 0) return {};
-  if(count == 1) return {{0}};
+  if (count == 0) return {};
+  if (count == 1) return {{ 0 }};
 
-
-  size_t group_pos[2] = {0, static_cast<size_t>(count)};
-  size_t* idx_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
-  size_t* max_group_pos = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
+  size_t group_pos[2] = {
+    0,
+    static_cast < size_t > (count)
+  };
+  size_t * idx_arr = static_cast < size_t * > (malloc(sizeof(size_t) * count));
+  size_t * max_group_pos = static_cast < size_t * > (malloc(sizeof(size_t) * (count + 1)));
   size_t group_pos_count;
   group_indexes_on_subset(nullptr, group_pos, 2, idx_arr, max_group_pos, group_pos_count);
 
-  std::vector<std::vector<size_t>> result;
+  std::vector < std::vector < size_t >> result;
 
-#pragma _NEC vector
-  for(auto g = 1; g < group_pos_count; g++){
-    std::vector<size_t> output_group(&idx_arr[max_group_pos[g - 1]], &idx_arr[max_group_pos[g]]);
+  #pragma _NEC vector
+  for (auto g = 1; g < group_pos_count; g++) {
+    std::vector < size_t > output_group( & idx_arr[max_group_pos[g - 1]], & idx_arr[max_group_pos[g]]);
     result.push_back(output_group);
   }
 

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/packed_transfer.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/packed_transfer.cc
@@ -17,8 +17,6 @@
  * limitations under the License.
  *
  */
-#pragma once
-
 #include "cyclone/packed_transfer.hpp"
 #include "cyclone/transfer-definitions.hpp"
 #include "cyclone/cyclone_utils.hpp"

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
@@ -305,7 +305,6 @@ struct nullable_varchar_vector {
 
   // Return groups of indexes for elements of the same value
   const std::vector<std::vector<size_t>> group_indexes() const;
-  const std::vector<std::vector<size_t>> group_indexes3() const;
 
   // Create group index array on a subset of data.
   // iter_order_arr may be null if the regular iteration order is to be used
@@ -316,12 +315,12 @@ struct nullable_varchar_vector {
   // out_group_pos will be in the same format as group_pos and delineate the
   // found groups
   // out_group_pos_size will contain the number of elements in out_group_group_pos
-  void group_indexes_on_subset(const size_t * iter_order_arr,
-                               const size_t * group_pos,
-                               const size_t group_pos_size,
-                               size_t * idx_arr,
-                               size_t * out_group_pos,
-                               size_t & out_group_pos_size) const;
+  const void group_indexes_on_subset(const size_t * iter_order_arr,
+                                     const size_t * group_pos,
+                                     const size_t group_pos_size,
+                                     size_t * idx_arr,
+                                     size_t * out_group_pos,
+                                     size_t & out_group_pos_size) const;
 
   const void group_indexes_on_subset2(const size_t  * input_index_arr,
                                 const size_t  * input_group_delims_arr,

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
@@ -156,7 +156,12 @@ struct NullableScalarVec {
   // out_group_pos will be in the same format as group_pos and delineate the
   // found groups
   // out_group_pos_size will contain the number of elements in out_group_group_pos
-  void group_indexes_on_subset(size_t* iter_order_arr, size_t* group_pos, size_t group_pos_size, size_t* idx_arr, size_t* out_group_pos, size_t &out_group_pos_size) const;
+  void group_indexes_on_subset(const size_t * iter_order_arr,
+                               const size_t * group_pos,
+                               const size_t group_pos_size,
+                               size_t * idx_arr,
+                               size_t * out_group_pos,
+                               size_t & out_group_pos_size) const;
 };
 
 // Explicitly instantiate struct template for int32_t
@@ -310,7 +315,12 @@ struct nullable_varchar_vector {
   // out_group_pos will be in the same format as group_pos and delineate the
   // found groups
   // out_group_pos_size will contain the number of elements in out_group_group_pos
-  void group_indexes_on_subset(size_t* iter_order_arr, size_t* group_pos, size_t group_pos_size, size_t* idx_arr, size_t* out_group_pos, size_t &out_group_pos_size) const;
+  void group_indexes_on_subset(const size_t * iter_order_arr,
+                               const size_t * group_pos,
+                               const size_t group_pos_size,
+                               size_t * idx_arr,
+                               size_t * out_group_pos,
+                               size_t & out_group_pos_size) const;
 };
 
 struct non_null_c_bounded_string {

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
@@ -322,14 +322,14 @@ struct nullable_varchar_vector {
                                      size_t * out_group_pos,
                                      size_t & out_group_pos_size) const;
 
-  const void group_indexes_on_subset2(const size_t  * input_index_arr,
-                                const size_t  * input_group_delims_arr,
-                                const size_t    input_group_delims_len,
-                                size_t        * output_index_arr,
-                                size_t        * output_group_delims_arr,
-                                size_t        & output_group_delims_len) const;
+  const void group_indexes_on_subset0(const size_t  * input_index_arr,
+                                      const size_t  * input_group_delims_arr,
+                                      const size_t    input_group_delims_len,
+                                      size_t        * output_index_arr,
+                                      size_t        * output_group_delims_arr,
+                                      size_t        & output_group_delims_len) const;
 
-  const std::vector<std::vector<size_t>> group_indexes2() const;
+  const std::vector<std::vector<size_t>> group_indexes0() const;
 };
 
 struct non_null_c_bounded_string {

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
@@ -306,28 +306,65 @@ struct nullable_varchar_vector {
   // Return groups of indexes for elements of the same value
   const std::vector<std::vector<size_t>> group_indexes() const;
 
-  // Create group index array on a subset of data.
-  // iter_order_arr may be null if the regular iteration order is to be used
-  // group_pos defines the subset(s) to work on. Every subset will be treated
-  // as its own group. It is given as a vector [start, mid-1, mid-2, ..., end].
-  // group_pos_size specifies the number of elements in group_pos
-  // idx_arr will contain a continuous array of indexes
-  // out_group_pos will be in the same format as group_pos and delineate the
-  // found groups
-  // out_group_pos_size will contain the number of elements in out_group_group_pos
-  const void group_indexes_on_subset(const size_t * iter_order_arr,
-                                     const size_t * group_pos,
-                                     const size_t group_pos_size,
-                                     size_t * idx_arr,
-                                     size_t * out_group_pos,
-                                     size_t & out_group_pos_size) const;
+  /*
+    Perform sort + grouping on multiple contiguous ranges.
 
-  const void group_indexes_on_subset0(const size_t  * input_index_arr,
-                                      const size_t  * input_group_delims_arr,
-                                      const size_t    input_group_delims_len,
-                                      size_t        * output_index_arr,
-                                      size_t        * output_group_delims_arr,
-                                      size_t        & output_group_delims_len) const;
+    The sort + group algorithm for varchars is slightly different from that for
+    scalars.  Given a single range in the nullablr_varchar_vector, the algorithm
+    steps are as follows:
+
+      1.  Sort and group by elements marked as valid vs invalid.
+      2.  For the valid-elements group, sort and group by string length.
+      3.  For each of the same-length subgroups, sort and group by the ith
+          character, for i from 0 to N, where N is the string length of all
+          elements in the subgroup.
+
+    Using a example (`#` indicates invalid element):
+      [ JAN, JANU, FEBU, FEB, #FOO, MARCH, MARCG, APR, APR, #BAR, JANU, SEP, OCT, NOV, DEC2, DEC1, DEC0, ]
+
+    After step 1, the invalid elements are grouped to the right (`|` indicates grouping):
+      [ JAN, JANU, FEBU, FEB, MARCH, MARCG, APR, APR, JANU, SEP, OCT, NOV, DEC2, DEC1, DEC0, | #FOO, #BAR, ]
+
+    After step 2, the elements are grouped by string length:
+      [ JAN, FEB, APR, APR, SEP, OCT, NOV, | JANU, FEBU, JANU, DEC2, DEC1, DEC0, | MARCH, MARCG, | #FOO, #BAR, ]
+
+    After step 3a, elements of length 3 are sorted and grouped:
+      [ APR, APR, | FEB, | JAN, | NOV, | OCT, | SEP, | JANU, FEBU, JANU, DEC2, DEC1, DEC0, | MARCH, MARCG, | #FOO, #BAR, ]
+
+    After step 3b, elements of length 4 are sorted and grouped:
+      [ APR, APR, | FEB, | JAN, | NOV, | OCT, | SEP, | DEC0, | DEC1, | DEC2, | FEBU, | JANU, JANU, | MARCH, MARCG, | #FOO, #BAR, ]
+
+    After step 3c, elements of length 5 are sorted and grouped:
+      [ APR, APR, | FEB, | JAN, | NOV, | OCT, | SEP, | DEC0, | DEC1, | DEC2, | FEBU, | JANU, JANU, | MARCG, | MARCH, | #FOO, #BAR, ]
+
+    The delimiters of the groups are given by the indices relative to the input array:
+      [ 0, 2, 3, 4, 5, 6, 7, 8, 9, 19, 12, 13, 14, 15, 17 ]
+
+
+    group_indexes_on_subset() applies the sort + grouping algorithm onto on
+    multiple contiguous ranges of the nullable_varchar_vector.
+
+    Function Arguments:
+      input_index_arr0        : An array of indices of the elements (sort values).  If set to nullptr, the regular iteration order is used.
+      input_group_delims_arr  : Indices that denote the subset ranges to be sorted.  Index values are relative to this->data.
+      input_group_delims_len  : Length of the input indices.
+      output_index_arr        : An array of indices that reflect input_index_arr0 after sort + grouping (pre-allocated and to be written).
+      output_group_delims_arr : Combined indices where the values change after sort + grouping (pre-allocated and to be written).  Index values are relative to this->data.
+      output_group_delims_len : Length of output_group_delims_arr (to be written).  Index values are relative to this->data.
+  */
+  void group_indexes_on_subset(const size_t * input_index_arr0,
+                               const size_t * input_group_delims_arr,
+                               const size_t   input_group_delims_len,
+                               size_t       * output_index_arr,
+                               size_t       * output_group_delims_arr,
+                               size_t       & output_group_delims_len) const;
+
+  void group_indexes_on_subset0(const size_t  * input_index_arr0,
+                                const size_t  * input_group_delims_arr,
+                                const size_t    input_group_delims_len,
+                                size_t        * output_index_arr,
+                                size_t        * output_group_delims_arr,
+                                size_t        & output_group_delims_len) const;
 
   const std::vector<std::vector<size_t>> group_indexes0() const;
 };

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
@@ -305,6 +305,7 @@ struct nullable_varchar_vector {
 
   // Return groups of indexes for elements of the same value
   const std::vector<std::vector<size_t>> group_indexes() const;
+  const std::vector<std::vector<size_t>> group_indexes2() const;
 
   // Create group index array on a subset of data.
   // iter_order_arr may be null if the regular iteration order is to be used

--- a/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
+++ b/src/main/resources/io/sparkcyclone/cpp/cyclone/transfer-definitions.hpp
@@ -305,7 +305,7 @@ struct nullable_varchar_vector {
 
   // Return groups of indexes for elements of the same value
   const std::vector<std::vector<size_t>> group_indexes() const;
-  const std::vector<std::vector<size_t>> group_indexes2() const;
+  const std::vector<std::vector<size_t>> group_indexes3() const;
 
   // Create group index array on a subset of data.
   // iter_order_arr may be null if the regular iteration order is to be used
@@ -322,6 +322,15 @@ struct nullable_varchar_vector {
                                size_t * idx_arr,
                                size_t * out_group_pos,
                                size_t & out_group_pos_size) const;
+
+  const void group_indexes_on_subset2(const size_t  * input_index_arr,
+                                const size_t  * input_group_delims_arr,
+                                const size_t    input_group_delims_len,
+                                size_t        * output_index_arr,
+                                size_t        * output_group_delims_arr,
+                                size_t        & output_group_delims_len) const;
+
+  const std::vector<std::vector<size_t>> group_indexes2() const;
 };
 
 struct non_null_c_bounded_string {

--- a/src/main/resources/io/sparkcyclone/cpp/examples.cpp
+++ b/src/main/resources/io/sparkcyclone/cpp/examples.cpp
@@ -187,86 +187,9 @@ void test_statement_expressions() {
   std::cout << "================================================================================" << std::endl;
 }
 
-
-template <typename T, bool sort_ascending = true>
-inline const std::vector<size_t> multiple_radix_sort_and_group(T      * sort_data_arr,
-                                                               size_t * index_data_arr,
-                                                               const std::vector<size_t> & input_group_delims) {
-
-  std::vector<std::vector<size_t>> component_group_delims(input_group_delims.size() - 1);
-
-  // For each subset denoted by input_group_delims, perform sort + grouping
-  // and get back a component delim group
-  #pragma _NEC vector
-  #pragma _NEC ivdep
-  for (auto i = 1; i < input_group_delims.size(); i++) {
-    // Fetch the boundaries of the range containing subset i
-    const auto subset_start = input_group_delims[i-1];
-    const auto subset_end   = input_group_delims[i];
-    const auto subset_size  = subset_end - subset_start;
-
-    if (subset_size < 2) {
-      component_group_delims[i - 1] = {{ 0, 1 }};
-
-    } else {
-      // Sort the elements in subset i
-      if constexpr (sort_ascending) {
-        frovedis::radix_sort(&sort_data_arr[subset_start], &index_data_arr[subset_start], subset_size);
-      } else {
-        frovedis::radix_sort_desc(&sort_data_arr[subset_start], &index_data_arr[subset_start], subset_size);
-      }
-
-      // Construct the array of indices where the value of the keys change
-      component_group_delims[i - 1] = frovedis::set_separate(&sort_data_arr[subset_start], subset_size);
-    }
-  }
-
-  // Compute a prefix sum to get the offsets of the data elements
-  std::vector<size_t> data_len_offsets(input_group_delims.size(), 0);
-  #pragma _NEC vector
-  for (auto i = 1; i < input_group_delims.size(); i++) {
-    const auto subset_start = input_group_delims[i-1];
-    const auto subset_end   = input_group_delims[i];
-    data_len_offsets[i] = data_len_offsets[i - 1] + (subset_end - subset_start);
-  }
-
-  // Compute a prefix sum to get the offsets of the component delim groups
-  std::vector<size_t> component_group_offsets(input_group_delims.size(), 0);
-  #pragma _NEC vector
-  for (auto i = 1; i < component_group_offsets.size(); i++) {
-    component_group_offsets[i] = component_group_offsets[i - 1] + component_group_delims[i - 1].size() - 1;
-  }
-
-  // Using the component arrays, construct the final array of indices where the
-  // value of the keys change
-  std::vector<size_t> output_group_delims(component_group_offsets.back() + 1);
-
-  // Populate the combined delimiters from the component delim groups in parallel
-  #pragma _NEC vector
-  #pragma _NEC ivdep
-  for (auto i = 0; i < component_group_delims.size(); i++) {
-    const auto delims = component_group_delims[i];
-
-    #pragma _NEC vector
-    #pragma _NEC ivdep
-    for (auto j = 0; j < delims.size() - 1; j++) {
-      // Each delim value in a component delim group is relative to the positions
-      // specified in the orignal input group, and each delim value's position
-      // in the final group array is relative as well.
-      output_group_delims[j + component_group_offsets[i]] = delims[j] + data_len_offsets[i];
-    }
-  }
-
-  // Populate the last delimiter
-  output_group_delims.back() = data_len_offsets.back();
-
-  return output_group_delims;
-}
-
 void group_strings(const nullable_varchar_vector *input) {
   // Fetch the validity vector and re-use the underyling data for sorting later on
-  auto tmp = input->validity_vec();
-  auto * sorted_data = tmp.data();
+  auto sorted_data = input->validity_vec();
 
   // Set up the indices
   std::vector<size_t> index(input->count);
@@ -282,7 +205,7 @@ void group_strings(const nullable_varchar_vector *input) {
 
     // Sort DESC by validity bits (valid values go left and invalid values
     // go right)
-    grouping = multiple_radix_sort_and_group<int32_t, false>(sorted_data, index.data(), grouping);
+    grouping = cyclone::grouping::sort_and_group_multiple<int32_t, false>(sorted_data, index, grouping);
     std::cout << "grouping: " << grouping << std::endl;
 
     // The returned grouping should have either 2 elements (all strings are
@@ -306,7 +229,7 @@ void group_strings(const nullable_varchar_vector *input) {
     }
 
     // Sort ASC by element length
-    grouping = multiple_radix_sort_and_group<int32_t, true>(sorted_data, index.data(), grouping);
+    grouping = cyclone::grouping::sort_and_group_multiple<int32_t, true>(sorted_data, index, grouping);
   }
 
   {
@@ -336,13 +259,30 @@ void group_strings(const nullable_varchar_vector *input) {
       }
 
       // Sort ASC by elem[pos]. using the existing grouping
-      grouping = multiple_radix_sort_and_group<int32_t, true>(sorted_data, index.data(), grouping);
+      grouping = cyclone::grouping::sort_and_group_multiple<int32_t, true>(sorted_data, index, grouping);
     }
+  }
+
+  {
+    // STEP 4: Iterate over n, where n = max length of a valid element, and sort
+    grouping.resize(grouping.size() + 1);
+    grouping.back() = input->count;
   }
 
   std::cout << "index: " << index << std::endl;
   std::cout << "grouping: " << grouping << std::endl;
   input->select(index)->print();
+
+  std::vector<std::vector<size_t>> result(grouping.size() - 1);
+  #pragma _NEC vector
+  #pragma _NEC ivdep
+  for (auto i = 1; i < grouping.size(); i++) {
+    result[i - 1] = std::vector<size_t>(&index[grouping[i - 1]], &index[grouping[i]]);
+  }
+  std::cout << "result: " << result << std::endl;
+  std::cout << "result: " << result.size() << std::endl;
+
+  std::cout << "reference: " << input->group_indexes() << std::endl;
 }
 
 void test_grouping() {
@@ -355,7 +295,7 @@ void test_grouping() {
   std::cout << "index: " << index << std::endl;
   std::cout << "grouping: " << grouping << std::endl;
 
-  auto new_grouping = multiple_radix_sort_and_group(input.data(), index.data(), grouping);
+  auto new_grouping = cyclone::grouping::sort_and_group_multiple(input, index, grouping);
 
   std::cout << "values after grouping: " << input << std::endl;
   std::cout << "new grouping: " << new_grouping << std::endl;
@@ -371,7 +311,7 @@ void test_grouping_desc() {
   std::cout << "index: " << index << std::endl;
   std::cout << "grouping: " << grouping << std::endl;
 
-  auto new_grouping = multiple_radix_sort_and_group<int32_t, false>(input.data(), index.data(), grouping);
+  auto new_grouping = cyclone::grouping::sort_and_group_multiple<int32_t, false>(input, index, grouping);
 
   std::cout << "values after grouping: " << input << std::endl;
   std::cout << "new grouping: " << new_grouping << std::endl;

--- a/src/main/resources/io/sparkcyclone/cpp/examples.cpp
+++ b/src/main/resources/io/sparkcyclone/cpp/examples.cpp
@@ -331,6 +331,9 @@ int main() {
   auto vec1 = nullable_varchar_vector(std::vector<std::string> { "JAN", "JANU", "FEBU", "FEB", "MARCH", "MARCG", "APR", "JANU", "SEP", "OCT", "NOV", "DEC" });
   vec1.set_validity(3, 0);
   vec1.set_validity(9, 0);
-  vec1.print();
-  group_strings(&vec1);
+  // vec1.print();
+  // group_strings(&vec1);
+
+  std::cout << "original" << vec1.group_indexes()  << std::endl;
+  std::cout << "new" << vec1.group_indexes2()  << std::endl;
 }

--- a/src/main/resources/io/sparkcyclone/cpp/examples.cpp
+++ b/src/main/resources/io/sparkcyclone/cpp/examples.cpp
@@ -333,15 +333,21 @@ int main() {
   // test_lambda();
   // test_statement_expressions();
 
-  test_grouping();
-  test_grouping_desc();
+  // test_grouping();
+  // test_grouping_desc();
 
-  auto vec1 = nullable_varchar_vector(std::vector<std::string> { "JAN", "JANU", "FEBU", "FEB", "MARCH", "MARCG", "APR", "JANU", "SEP", "OCT", "NOV", "DEC" });
+  auto input = std::vector<std::string> { "JAN", "JANU", "FEBU", "FEB", "MARCH", "MARCG", "APR", "APR", "JANU", "SEP", "OCT", "NOV", "DEC2", "DEC1", "DEC0" };
+  auto vec1 = nullable_varchar_vector(input);
   vec1.set_validity(3, 0);
-  vec1.set_validity(9, 0);
+  vec1.set_validity(10, 0);
   // vec1.print();
-  group_strings(&vec1);
+  // group_strings(&vec1);
+  // std::cout << "\n\n\n\n\n" << std::endl;
 
-  std::cout << "original" << vec1.group_indexes()  << std::endl;
-  std::cout << "new" << vec1.group_indexes2()  << std::endl;
+  // std::cout << "original" << vec1.group_indexes()  << std::endl;
+  // std::cout << "new" << vec1.group_indexes3()  << std::endl;
+  // std::cout << "new" << vec1.group_indexes2()  << std::endl;
+
+  // std::cout << input << std::endl;
+  vec1.group_indexes2();
 }

--- a/src/main/resources/io/sparkcyclone/cpp/examples.cpp
+++ b/src/main/resources/io/sparkcyclone/cpp/examples.cpp
@@ -237,6 +237,45 @@ void test_string_grouping() {
   std::cout << " ]" << std::endl;
 }
 
+void test_string_grouping2() {
+  auto input = std::vector<std::string> { "JAN", "JANU", "FEBU", "FEB", "MARCH", "MARCG", "APR", "NOV", "MARCG", "SEPT", "SEPT", "APR", "JANU", "SEP", "OCT", "NOV", "DEC2", "DEC1", "DEC0" };
+  std::cout << input << std::endl;
+  auto vec1 = new nullable_varchar_vector(input);
+  vec1->set_validity(7, 0);
+  vec1->set_validity(11, 0);
+  vec1->set_validity(13, 0);
+
+  vec1->print();
+
+  // Sort 3 subsets separately
+  auto input_group_delims = std::vector<size_t> { 3, 8, 14, 17 };
+
+  // Set up output
+  std::vector<size_t> output_index(vec1->count);
+  std::vector<size_t> output_group_delims(vec1->count + 1);
+  size_t output_group_delims_len;
+
+  // Group indices
+  vec1->group_indexes_on_subset(
+    nullptr,
+    input_group_delims.data(),
+    input_group_delims.size(),
+    output_index.data(),
+    output_group_delims.data(),
+    output_group_delims_len
+  );
+
+  // // Adjust the output
+  // output_group_delims.resize(output_group_delims_len);
+
+  std::cout << std::endl;
+  // vec1->print();
+  // std::cout << "data = " << vec1->data[0] << std::endl;
+  std::cout << input_group_delims << std::endl;
+  // std::cout << output_group_delims << std::endl;
+  vec1->select(output_index)->print();
+}
+
 int main() {
   // projection_test();
   // filter_test();
@@ -245,6 +284,6 @@ int main() {
   // test_lambda();
   // test_statement_expressions();
 
-  test_multiple_grouping();
-  test_string_grouping();
+  // test_multiple_grouping();
+  test_string_grouping2();
 }

--- a/src/main/resources/io/sparkcyclone/cpp/examples.cpp
+++ b/src/main/resources/io/sparkcyclone/cpp/examples.cpp
@@ -192,8 +192,8 @@ void test_multiple_grouping() {
   std::cout << "GROUPING TEST\n" << std::endl;
 
   std::vector<int32_t>      input1 { 23, 0, 1, 4, 3, -2, 1, 5, 3, 0, 1, 6, 9, 6, 42, -100 };
-  std::vector<size_t>       index1(input1.size());
   const std::vector<size_t> grouping {{ 1, 6, 11, 14 }};
+  std::vector<size_t>       index1(input1.size());
   for (auto i = 0; i < index1.size(); i++) index1[i] = i;
 
   auto input2 = input1;

--- a/src/main/resources/io/sparkcyclone/cpp/examples.cpp
+++ b/src/main/resources/io/sparkcyclone/cpp/examples.cpp
@@ -265,8 +265,8 @@ void test_string_grouping2() {
     output_group_delims_len
   );
 
-  // // Adjust the output
-  // output_group_delims.resize(output_group_delims_len);
+  // Adjust the output
+  output_group_delims.resize(output_group_delims_len);
 
   std::cout << std::endl;
   // vec1->print();
@@ -274,6 +274,8 @@ void test_string_grouping2() {
   std::cout << input_group_delims << std::endl;
   // std::cout << output_group_delims << std::endl;
   vec1->select(output_index)->print();
+
+  std::cout << output_group_delims << std::endl;
 }
 
 int main() {
@@ -285,5 +287,5 @@ int main() {
   // test_statement_expressions();
 
   // test_multiple_grouping();
-  test_string_grouping2();
+  test_string_grouping();
 }

--- a/src/main/resources/io/sparkcyclone/cpp/examples.cpp
+++ b/src/main/resources/io/sparkcyclone/cpp/examples.cpp
@@ -286,6 +286,9 @@ void group_strings(const nullable_varchar_vector *input) {
 }
 
 void test_grouping() {
+  std::cout << "================================================================================" << std::endl;
+  std::cout << "GROUPING TEST 1\n" << std::endl;
+
   std::vector<int32_t>      input { 0, 1, 1, 1, 1, 1, 2, 3, 0, 1, 6, 9, 6, };
   std::vector<size_t>       index(input.size());
   const std::vector<size_t> grouping {{ 0, 5, 10, 13 }};
@@ -295,13 +298,17 @@ void test_grouping() {
   std::cout << "index: " << index << std::endl;
   std::cout << "grouping: " << grouping << std::endl;
 
-  auto new_grouping = cyclone::grouping::sort_and_group_multiple(input, index, grouping);
+  auto new_grouping = cyclone::grouping::sort_and_group_multiple2(input, index, grouping);
 
   std::cout << "values after grouping: " << input << std::endl;
   std::cout << "new grouping: " << new_grouping << std::endl;
+  std::cout << "================================================================================" << std::endl;
 }
 
 void test_grouping_desc() {
+  std::cout << "================================================================================" << std::endl;
+  std::cout << "GROUPING TEST 2\n" << std::endl;
+
   std::vector<int32_t>      input { 0, 1, 1, 1, 1, 1, 2, 3, 0, 1, 6, 9, 6, };
   std::vector<size_t>       index(input.size());
   const std::vector<size_t> grouping {{ 0, 5, 10, 13 }};
@@ -311,10 +318,11 @@ void test_grouping_desc() {
   std::cout << "index: " << index << std::endl;
   std::cout << "grouping: " << grouping << std::endl;
 
-  auto new_grouping = cyclone::grouping::sort_and_group_multiple<int32_t, false>(input, index, grouping);
+  auto new_grouping = cyclone::grouping::sort_and_group_multiple2<int32_t, false>(input, index, grouping);
 
   std::cout << "values after grouping: " << input << std::endl;
   std::cout << "new grouping: " << new_grouping << std::endl;
+  std::cout << "================================================================================" << std::endl;
 }
 
 int main() {
@@ -325,14 +333,14 @@ int main() {
   // test_lambda();
   // test_statement_expressions();
 
-  // test_grouping();
-  // test_grouping_desc();
+  test_grouping();
+  test_grouping_desc();
 
   auto vec1 = nullable_varchar_vector(std::vector<std::string> { "JAN", "JANU", "FEBU", "FEB", "MARCH", "MARCG", "APR", "JANU", "SEP", "OCT", "NOV", "DEC" });
   vec1.set_validity(3, 0);
   vec1.set_validity(9, 0);
   // vec1.print();
-  // group_strings(&vec1);
+  group_strings(&vec1);
 
   std::cout << "original" << vec1.group_indexes()  << std::endl;
   std::cout << "new" << vec1.group_indexes2()  << std::endl;

--- a/src/main/resources/io/sparkcyclone/cpp/tests/cyclone_grouping_spec.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/tests/cyclone_grouping_spec.cc
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022 Xpress AI.
+ *
+ * This file is part of Spark Cyclone.
+ * See https://github.com/XpressAI/SparkCyclone for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "cyclone/cyclone.hpp"
+#include "tests/doctest.h"
+#include <stddef.h>
+
+namespace cyclone::tests {
+  TEST_SUITE("cyclone::grouping") {
+    TEST_CASE_TEMPLATE("sort_and_group_multiple<T, true>() works for T=", T, int32_t, int64_t, float, double) {
+      std::vector<T>            input     {{ 23, 0, 1, 4, 3, -2, 1, 5, 3, 0, 1, 6, 9, 6, 42, -100 }};
+      const std::vector<size_t> grouping  {{ 1, 6, 11, 14 }};
+      std::vector<size_t>       index(input.size());
+      for (auto i = 0; i < index.size(); i++) index[i] = i;
+
+      const std::vector<T>      expected_input    {{ 23, -2, 0, 1, 3, 4, 0, 1, 1, 3, 5, 6, 6, 9, 42, -100 }};
+      const std::vector<size_t> expected_index    {{ 0, 5, 1, 2, 4, 3, 9, 6, 10, 8, 7, 11, 13, 12, 14, 15 }};
+      const std::vector<size_t> expected_grouping {{ 0, 2, 3, 4, 5, 6, 7, 9, 10, 11, 13, 14 }};
+
+      auto new_grouping = cyclone::grouping::sort_and_group_multiple<T, true>(input, index, grouping);
+
+      CHECK(input == expected_input);
+      CHECK(index == expected_index);
+      CHECK(new_grouping == expected_grouping);
+    }
+
+    TEST_CASE("separate_to_groups() works [0]") {
+      std::vector<size_t> grouping = { 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1 };
+      std::vector<size_t> expected_1 = { 2, 7, 8, 9, 10, 13, 14 };
+      std::vector<size_t> expected_0 = { 0, 1, 3, 4, 5, 6, 11, 12 };
+      std::vector<size_t> expected_keys = {0, 1};
+      std::vector<size_t> keys;
+      std::vector<std::vector<size_t>> groups = cyclone::grouping::separate_to_groups(grouping, keys);
+
+      cyclone::print_vec("groups[0]", groups[0]);
+      cyclone::print_vec("expect_0:", expected_0);
+      cyclone::print_vec("groups[1]", groups[1]);
+      cyclone::print_vec("expect_1:", expected_1);
+
+      CHECK(groups[0] == expected_0);
+      CHECK(groups[1] == expected_1);
+      CHECK(keys == expected_keys);
+    }
+
+    TEST_CASE("separate_to_groups() works [1]") {
+      std::vector<size_t> grouping = { 10, 10, 11, 10, 10, 10, 10, 11, 11, 11, 11, 10, 10, 11, 11 };
+      std::vector<size_t> expected_1 = { 2, 7, 8, 9, 10, 13, 14 };
+      std::vector<size_t> expected_0 = { 0, 1, 3, 4, 5, 6, 11, 12 };
+      std::vector<size_t> expected_keys = {10, 11};
+      std::vector<size_t> keys;
+      std::vector<std::vector<size_t>> groups = cyclone::grouping::separate_to_groups(grouping, keys);
+
+      cyclone::print_vec("groups[0]", groups[0]);
+      cyclone::print_vec("expect_0:", expected_0);
+      cyclone::print_vec("groups[1]", groups[1]);
+      cyclone::print_vec("expect_1:", expected_1);
+
+      CHECK(groups[0] == expected_0);
+      CHECK(groups[1] == expected_1);
+      CHECK(keys == expected_keys);
+    }
+
+    TEST_CASE("separate_to_groups() works for empty grouping and keys") {
+      std::vector<size_t> grouping = {};
+      std::vector<size_t> keys;
+      std::vector<size_t> empty_keys = {};
+      std::vector<std::vector<size_t>> groups = cyclone::grouping::separate_to_groups(grouping, keys);
+
+      CHECK(groups.size() == 0);
+      CHECK(keys == empty_keys);
+    }
+  }
+}

--- a/src/main/resources/io/sparkcyclone/cpp/tests/cyclone_utils_spec.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/tests/cyclone_utils_spec.cc
@@ -38,53 +38,6 @@ namespace cyclone::tests {
     std::cout << tup << std::endl;
   }
 
-  TEST_CASE("separate_to_groups() works") {
-      // std::vector<size_t> grouping = { 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1 };
-      std::vector<size_t> grouping = { 10, 10, 11, 10, 10, 10, 10, 11, 11, 11, 11, 10, 10, 11, 11 };
-      std::vector<size_t> expected_1 = { 2, 7, 8, 9, 10, 13, 14 };
-      std::vector<size_t> expected_0 = { 0, 1, 3, 4, 5, 6, 11, 12 };
-      std::vector<size_t> expected_keys = {10, 11};
-      std::vector<size_t> keys;
-      std::vector<std::vector<size_t>> groups = cyclone::separate_to_groups(grouping, keys);
-
-      cyclone::print_vec("groups[0]", groups[0]);
-      cyclone::print_vec("expect_0:", expected_0);
-      cyclone::print_vec("groups[1]", groups[1]);
-      cyclone::print_vec("expect_1:", expected_1);
-
-      CHECK(groups[0] == expected_0);
-      CHECK(groups[1] == expected_1);
-      CHECK(keys == expected_keys);
-  }
-
-  TEST_CASE("old separate_to_groups() works") {
-    std::vector<size_t> grouping = { 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1 };
-    std::vector<size_t> expected_1 = { 2, 7, 8, 9, 10, 13, 14 };
-    std::vector<size_t> expected_0 = { 0, 1, 3, 4, 5, 6, 11, 12 };
-    std::vector<size_t> expected_keys = {0, 1};
-    std::vector<size_t> keys;
-    std::vector<std::vector<size_t>> groups = cyclone::separate_to_groups(grouping, keys);
-
-    cyclone::print_vec("groups[0]", groups[0]);
-    cyclone::print_vec("expect_0:", expected_0);
-    cyclone::print_vec("groups[1]", groups[1]);
-    cyclone::print_vec("expect_1:", expected_1);
-
-    CHECK(groups[0] == expected_0);
-    CHECK(groups[1] == expected_1);
-    CHECK(keys == expected_keys);
-  }
-
-  TEST_CASE("empty separate_to_groups() is still ok.") {
-    std::vector<size_t> grouping = {};
-    std::vector<size_t> keys;
-    std::vector<size_t> empty_keys = {};
-    std::vector<std::vector<size_t>> groups = cyclone::separate_to_groups(grouping, keys);
-
-    CHECK(groups.size() == 0);
-    CHECK(keys == empty_keys);
-  }
-
   TEST_CASE("joining works on fully matched pairs") {
     std::vector<size_t> left = {1, 2, 3, 4, 5, 6};
     std::vector<size_t> right = {6, 3, 2, 4, 5, 1};

--- a/src/main/resources/io/sparkcyclone/cpp/tests/nullable_scalar_vector_spec.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/tests/nullable_scalar_vector_spec.cc
@@ -258,8 +258,6 @@ namespace cyclone::tests {
       CHECK(grouped[0] == expected_0);
       CHECK(grouped[1] == expected_1);
       CHECK(grouped.size() == 2);
-
-
     }
 
     TEST_CASE_TEMPLATE("group_indexes works with all valid values (3 groups)", T, int32_t, int64_t, float, double){

--- a/src/main/resources/io/sparkcyclone/cpp/tests/nullable_scalar_vector_spec.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/tests/nullable_scalar_vector_spec.cc
@@ -243,176 +243,176 @@ namespace cyclone::tests {
       CHECK(input->eval_in(std::vector<T> { 586, 42 }) == expected1);
       CHECK(input->eval_in(std::vector<T> { 106, 538 }) == expected2);
     }
-  }
 
-  TEST_CASE_TEMPLATE("group_indexes works with all valid values", T, int32_t, int64_t, float, double){
-    std::vector<T> grouping = { 10, 10, 11, 10, 10, 10, 10, 11, 11, 11, 11, 10, 10, 11, 11 };
-    std::vector<size_t> expected_0 = { 0, 1, 3, 4, 5, 6, 11, 12 };
-    std::vector<size_t> expected_1 = { 2, 7, 8, 9, 10, 13, 14 };
+    TEST_CASE_TEMPLATE("group_indexes works with all valid values", T, int32_t, int64_t, float, double){
+      std::vector<T> grouping = { 10, 10, 11, 10, 10, 10, 10, 11, 11, 11, 11, 10, 10, 11, 11 };
+      std::vector<size_t> expected_0 = { 0, 1, 3, 4, 5, 6, 11, 12 };
+      std::vector<size_t> expected_1 = { 2, 7, 8, 9, 10, 13, 14 };
 
-    const auto *input = new NullableScalarVec(grouping);
-    auto grouped = input->group_indexes();
+      const auto *input = new NullableScalarVec(grouping);
+      auto grouped = input->group_indexes();
 
-    cyclone::print_vec("grouped[0]", grouped[0]);
-    cyclone::print_vec("grouped[1]", grouped[1]);
+      cyclone::print_vec("grouped[0]", grouped[0]);
+      cyclone::print_vec("grouped[1]", grouped[1]);
 
-    CHECK(grouped[0] == expected_0);
-    CHECK(grouped[1] == expected_1);
-    CHECK(grouped.size() == 2);
+      CHECK(grouped[0] == expected_0);
+      CHECK(grouped[1] == expected_1);
+      CHECK(grouped.size() == 2);
 
 
-  }
-
-  TEST_CASE_TEMPLATE("group_indexes works with all valid values (3 groups)", T, int32_t, int64_t, float, double){
-    std::vector<T> grouping = { 10, 10, 11, 12, 10, 10, 10, 11, 11, 11, 12, 10, 10, 11, 11 };
-    std::vector<size_t> expected_0 = { 0, 1, 4, 5, 6, 11, 12 };
-    std::vector<size_t> expected_1 = { 2, 7, 8, 9, 13, 14 };
-    std::vector<size_t> expected_2 = { 3, 10 };
-
-    const auto *input = new NullableScalarVec(grouping);
-    auto grouped = input->group_indexes();
-
-    cyclone::print_vec("grouped[0]", grouped[0]);
-    cyclone::print_vec("grouped[1]", grouped[1]);
-    cyclone::print_vec("grouped[2]", grouped[2]);
-
-    CHECK(grouped[0] == expected_0);
-    CHECK(grouped[1] == expected_1);
-    CHECK(grouped[2] == expected_2);
-    CHECK(grouped.size() == 3);
-  }
-
-  TEST_CASE_TEMPLATE("group_indexes works with some invalid values", T, int32_t, int64_t, float, double){
-    std::vector<T> grouping = { 10, 10, 11, 10, 10, 10, 10, 11, 11, 11, 11, 10, 10, 11, 11 };
-    std::vector<size_t> expected_0 = { 1, 3, 4, 5, 6, 11, 12 };
-    std::vector<size_t> expected_1 = { 7, 8, 9, 10, 13, 14 };
-    std::vector<size_t> expected_2 = { 2, 0 };
-
-    auto *input = new NullableScalarVec(grouping);
-    input->set_validity(0, 0);
-    input->set_validity(2, 0);
-
-    auto grouped = input->group_indexes();
-
-    cyclone::print_vec("grouped[0]", grouped[0]);
-    cyclone::print_vec("grouped[1]", grouped[1]);
-    cyclone::print_vec("grouped[2]", grouped[2]);
-
-    CHECK(grouped[0] == expected_0);
-    CHECK(grouped[1] == expected_1);
-    CHECK(grouped[2] == expected_2);
-    CHECK(grouped.size() == 3);
-  }
-
-  TEST_CASE("group_indexes_on_subset works (with different types)"){
-    std::vector<int64_t> grouping_1 =   { 10, 10, 11, 10, 10, 10, 10, 11, 11, 11, 11, 10, 10, 11, 11 };
-    auto *input1 = new NullableScalarVec(grouping_1);
-
-    //    0   1   2   3   4   5   6   7   8   9  10  11  12  13  14
-    // { 10, 10, 11, 10, 10, 10, 10, 11, 11, 11, 11, 10, 10, 11, 11 }
-    // { 10,  7, 11,  7,  5, 10, 10,  5, 11,  3, 11,  3, 10, 11,  7 };
-    //  10,  10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11
-    //   3,   5,  7,  7, 10, 10, 10, 10, 11,  5, 11,  3, 11, 11,  7
-    //
-
-    std::vector<double> grouping_2 = { 10,  7, 11,  7,  5, 10, 10,  5, 11,  3, 11,  3, 10, 11,  7 };
-    auto *input2 = new NullableScalarVec(grouping_2);
-
-    std::vector<int> grouping_3 =    {  1,  8,  1,  8,  1,  8,  1,  8,  1,  8,  1,  8,  1,  8,  1 };
-    auto *input3 = new NullableScalarVec(grouping_3);
-
-    std::vector<std::vector<size_t>> expected = {{11}, {4}, {1, 3}, {0, 6, 12}, {5}, {9}, {7}, {14}, {2, 8, 10}, {13}};
-
-    size_t count = grouping_1.size();
-    size_t start_group_pos[2] = {0, count};
-    size_t* a_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
-    size_t* b_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
-
-    size_t* a_pos_idxs = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
-    size_t* b_pos_idxs = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
-
-    size_t a_pos_idxs_size;
-    size_t b_pos_idxs_size;
-
-    input1->group_indexes_on_subset(nullptr, start_group_pos, 2, a_arr, a_pos_idxs, a_pos_idxs_size);
-    std::cout << "Pos Idxs: ";
-    for(auto i = 0; i < a_pos_idxs_size; i++){
-      std::cout << a_pos_idxs[i] << " ";
     }
-    std::cout << std::endl;
-    std::cout << "Result Array: ";
-    for(auto i = 0; i < count; i++){
-      std::cout << a_arr[i] << " ";
+
+    TEST_CASE_TEMPLATE("group_indexes works with all valid values (3 groups)", T, int32_t, int64_t, float, double){
+      std::vector<T> grouping = { 10, 10, 11, 12, 10, 10, 10, 11, 11, 11, 12, 10, 10, 11, 11 };
+      std::vector<size_t> expected_0 = { 0, 1, 4, 5, 6, 11, 12 };
+      std::vector<size_t> expected_1 = { 2, 7, 8, 9, 13, 14 };
+      std::vector<size_t> expected_2 = { 3, 10 };
+
+      const auto *input = new NullableScalarVec(grouping);
+      auto grouped = input->group_indexes();
+
+      cyclone::print_vec("grouped[0]", grouped[0]);
+      cyclone::print_vec("grouped[1]", grouped[1]);
+      cyclone::print_vec("grouped[2]", grouped[2]);
+
+      CHECK(grouped[0] == expected_0);
+      CHECK(grouped[1] == expected_1);
+      CHECK(grouped[2] == expected_2);
+      CHECK(grouped.size() == 3);
     }
-    std::cout << std::endl;
-    input2->group_indexes_on_subset(a_arr, a_pos_idxs, a_pos_idxs_size, b_arr, b_pos_idxs, b_pos_idxs_size);
-    std::cout << "Pos Idxs: ";
-    for(auto i = 0; i < b_pos_idxs_size; i++){
-      std::cout << b_pos_idxs[i] << " ";
+
+    TEST_CASE_TEMPLATE("group_indexes works with some invalid values", T, int32_t, int64_t, float, double){
+      std::vector<T> grouping = { 10, 10, 11, 10, 10, 10, 10, 11, 11, 11, 11, 10, 10, 11, 11 };
+      std::vector<size_t> expected_0 = { 1, 3, 4, 5, 6, 11, 12 };
+      std::vector<size_t> expected_1 = { 7, 8, 9, 10, 13, 14 };
+      std::vector<size_t> expected_2 = { 2, 0 };
+
+      auto *input = new NullableScalarVec(grouping);
+      input->set_validity(0, 0);
+      input->set_validity(2, 0);
+
+      auto grouped = input->group_indexes();
+
+      cyclone::print_vec("grouped[0]", grouped[0]);
+      cyclone::print_vec("grouped[1]", grouped[1]);
+      cyclone::print_vec("grouped[2]", grouped[2]);
+
+      CHECK(grouped[0] == expected_0);
+      CHECK(grouped[1] == expected_1);
+      CHECK(grouped[2] == expected_2);
+      CHECK(grouped.size() == 3);
     }
-    std::cout << std::endl;
-    std::cout << "Result Array: ";
-    for(auto i = 0; i < count; i++){
-      std::cout << b_arr[i] << " ";
+
+    TEST_CASE("group_indexes_on_subset works (with different types)"){
+      std::vector<int64_t> grouping_1 =   { 10, 10, 11, 10, 10, 10, 10, 11, 11, 11, 11, 10, 10, 11, 11 };
+      auto *input1 = new NullableScalarVec(grouping_1);
+
+      //    0   1   2   3   4   5   6   7   8   9  10  11  12  13  14
+      // { 10, 10, 11, 10, 10, 10, 10, 11, 11, 11, 11, 10, 10, 11, 11 }
+      // { 10,  7, 11,  7,  5, 10, 10,  5, 11,  3, 11,  3, 10, 11,  7 };
+      //  10,  10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11
+      //   3,   5,  7,  7, 10, 10, 10, 10, 11,  5, 11,  3, 11, 11,  7
+      //
+
+      std::vector<double> grouping_2 = { 10,  7, 11,  7,  5, 10, 10,  5, 11,  3, 11,  3, 10, 11,  7 };
+      auto *input2 = new NullableScalarVec(grouping_2);
+
+      std::vector<int> grouping_3 =    {  1,  8,  1,  8,  1,  8,  1,  8,  1,  8,  1,  8,  1,  8,  1 };
+      auto *input3 = new NullableScalarVec(grouping_3);
+
+      std::vector<std::vector<size_t>> expected = {{11}, {4}, {1, 3}, {0, 6, 12}, {5}, {9}, {7}, {14}, {2, 8, 10}, {13}};
+
+      size_t count = grouping_1.size();
+      size_t start_group_pos[2] = {0, count};
+      size_t* a_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
+      size_t* b_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
+
+      size_t* a_pos_idxs = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
+      size_t* b_pos_idxs = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
+
+      size_t a_pos_idxs_size;
+      size_t b_pos_idxs_size;
+
+      input1->group_indexes_on_subset(nullptr, start_group_pos, 2, a_arr, a_pos_idxs, a_pos_idxs_size);
+      std::cout << "Pos Idxs: ";
+      for(auto i = 0; i < a_pos_idxs_size; i++){
+        std::cout << a_pos_idxs[i] << " ";
+      }
+      std::cout << std::endl;
+      std::cout << "Result Array: ";
+      for(auto i = 0; i < count; i++){
+        std::cout << a_arr[i] << " ";
+      }
+      std::cout << std::endl;
+      input2->group_indexes_on_subset(a_arr, a_pos_idxs, a_pos_idxs_size, b_arr, b_pos_idxs, b_pos_idxs_size);
+      std::cout << "Pos Idxs: ";
+      for(auto i = 0; i < b_pos_idxs_size; i++){
+        std::cout << b_pos_idxs[i] << " ";
+      }
+      std::cout << std::endl;
+      std::cout << "Result Array: ";
+      for(auto i = 0; i < count; i++){
+        std::cout << b_arr[i] << " ";
+      }
+      std::cout << std::endl;
+      input3->group_indexes_on_subset(b_arr, b_pos_idxs, b_pos_idxs_size, a_arr, a_pos_idxs, a_pos_idxs_size);
+      std::cout << "Pos Idxs: ";
+      for(auto i = 0; i < a_pos_idxs_size; i++){
+        std::cout << a_pos_idxs[i] << " ";
+      }
+      std::cout << std::endl;
+
+      std::cout << "Result Array: ";
+      for(auto i = 0; i < count; i++){
+        std::cout << a_arr[i] << " ";
+      }
+      std::cout << std::endl;
+
+      std::vector<std::vector<size_t>> result;
+      for(auto g = 1; g < a_pos_idxs_size; g++){
+        std::vector<size_t> output_group(&a_arr[a_pos_idxs[g - 1]], &a_arr[a_pos_idxs[g]]);
+        result.push_back(output_group);
+      }
+      cyclone::print_vec("result", result);
+
+      free(a_arr);
+      free(b_arr);
+      free(a_pos_idxs);
+      free(b_pos_idxs);
+
+      CHECK(result == expected);
     }
-    std::cout << std::endl;
-    input3->group_indexes_on_subset(b_arr, b_pos_idxs, b_pos_idxs_size, a_arr, a_pos_idxs, a_pos_idxs_size);
-    std::cout << "Pos Idxs: ";
-    for(auto i = 0; i < a_pos_idxs_size; i++){
-      std::cout << a_pos_idxs[i] << " ";
+
+    TEST_CASE("group_indexes_on_subset short-circuit works"){
+      std::vector<int64_t> grouping_1 = { 1, 2, 3, 4, 5 };
+      auto *input1 = new NullableScalarVec(grouping_1);
+
+      size_t count = grouping_1.size();
+      size_t start_arr[5] = {0, 1, 2, 3, 4};
+      size_t start_group_pos[6] = {0, 1, 2, 3, 4, 5};
+
+      size_t* a_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
+      size_t* a_pos_idxs = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
+      size_t a_pos_idxs_size;
+
+      input1->group_indexes_on_subset(start_arr, start_group_pos, 6, a_arr, a_pos_idxs, a_pos_idxs_size);
+
+      CHECK(a_pos_idxs_size == 6);
+      CHECK(a_arr[0] == start_arr[0]);
+      CHECK(a_arr[1] == start_arr[1]);
+      CHECK(a_arr[2] == start_arr[2]);
+      CHECK(a_arr[3] == start_arr[3]);
+      CHECK(a_arr[4] == start_arr[4]);
+
+      CHECK(a_pos_idxs[0] == start_group_pos[0]);
+      CHECK(a_pos_idxs[1] == start_group_pos[1]);
+      CHECK(a_pos_idxs[2] == start_group_pos[2]);
+      CHECK(a_pos_idxs[3] == start_group_pos[3]);
+      CHECK(a_pos_idxs[4] == start_group_pos[4]);
+      CHECK(a_pos_idxs[5] == start_group_pos[5]);
+
+      free(a_arr);
+      free(a_pos_idxs);
     }
-    std::cout << std::endl;
-
-    std::cout << "Result Array: ";
-    for(auto i = 0; i < count; i++){
-      std::cout << a_arr[i] << " ";
-    }
-    std::cout << std::endl;
-
-    std::vector<std::vector<size_t>> result;
-    for(auto g = 1; g < a_pos_idxs_size; g++){
-      std::vector<size_t> output_group(&a_arr[a_pos_idxs[g - 1]], &a_arr[a_pos_idxs[g]]);
-      result.push_back(output_group);
-    }
-    cyclone::print_vec("result", result);
-
-    free(a_arr);
-    free(b_arr);
-    free(a_pos_idxs);
-    free(b_pos_idxs);
-
-    CHECK(result == expected);
-  }
-
-  TEST_CASE("group_indexes_on_subset short-circuit works"){
-    std::vector<int64_t> grouping_1 = { 1, 2, 3, 4, 5 };
-    auto *input1 = new NullableScalarVec(grouping_1);
-
-    size_t count = grouping_1.size();
-    size_t start_arr[5] = {0, 1, 2, 3, 4};
-    size_t start_group_pos[6] = {0, 1, 2, 3, 4, 5};
-
-    size_t* a_arr = static_cast<size_t *>(malloc(sizeof(size_t) * count));
-    size_t* a_pos_idxs = static_cast<size_t *>(malloc(sizeof(size_t) * (count + 1)));
-    size_t a_pos_idxs_size;
-
-    input1->group_indexes_on_subset(start_arr, start_group_pos, 6, a_arr, a_pos_idxs, a_pos_idxs_size);
-
-    CHECK(a_pos_idxs_size == 6);
-    CHECK(a_arr[0] == start_arr[0]);
-    CHECK(a_arr[1] == start_arr[1]);
-    CHECK(a_arr[2] == start_arr[2]);
-    CHECK(a_arr[3] == start_arr[3]);
-    CHECK(a_arr[4] == start_arr[4]);
-
-    CHECK(a_pos_idxs[0] == start_group_pos[0]);
-    CHECK(a_pos_idxs[1] == start_group_pos[1]);
-    CHECK(a_pos_idxs[2] == start_group_pos[2]);
-    CHECK(a_pos_idxs[3] == start_group_pos[3]);
-    CHECK(a_pos_idxs[4] == start_group_pos[4]);
-    CHECK(a_pos_idxs[5] == start_group_pos[5]);
-
-    free(a_arr);
-    free(a_pos_idxs);
   }
 }

--- a/src/main/resources/io/sparkcyclone/cpp/tests/nullable_varchar_vector_spec.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/tests/nullable_varchar_vector_spec.cc
@@ -327,7 +327,7 @@ namespace cyclone::tests {
       CHECK(output->equivalent_to(expected));
     }
 
-    TEST_CASE("group_indexes_on_subset works"){
+    TEST_CASE("group_indexes_on_subset works [0]") {
       auto *input1 = new nullable_varchar_vector(std::vector<std::string> {"A", "A", "B", "A", "A", "A", "A", "B", "B", "B", "B", "A", "A", "B", "B" });
       auto *input2 = new nullable_varchar_vector(std::vector<std::string> {"A", "C", "B", "C", "D", "A", "A", "D", "B", "E", "B", "E", "A", "B", "C" });
       auto *input3 = new nullable_varchar_vector(std::vector<std::string> {"G", "H", "G", "H", "G", "H", "G", "H", "G", "H", "G", "H", "G", "H", "G" });
@@ -363,7 +363,28 @@ namespace cyclone::tests {
 
       CHECK(result == expected);
     }
-    TEST_CASE("group_indexes_on_subset short-circuit works"){
+
+    TEST_CASE("group_indexes_on_subset works [1]") {
+      auto input1 = std::vector<std::string> { "JAN", "JANU", "FEBU", "FEB", "MARCH", "MARCG", "APR", "APR", "JANU", "SEP", "OCT", "NOV", "DEC2", "DEC1", "DEC0" };
+      auto vec1 = new nullable_varchar_vector(input1);
+      vec1->set_validity(3, 0);
+      vec1->set_validity(10, 0);
+
+      auto input2 = std::vector<std::string> { "APR", "APR", "JAN", "NOV", "SEP", "DEC0", "DEC1", "DEC2", "FEBU", "JANU", "JANU", "MARCG", "MARCH", "OCT", "FEB" };
+      auto vec2 = new nullable_varchar_vector(input2);
+      vec2->set_validity(13, 0);
+      vec2->set_validity(14, 0);
+
+      auto groups = vec1->group_indexes();
+      std::vector<size_t> indices;
+      for (auto group : groups) {
+        for (auto i : group) indices.emplace_back(i);
+      }
+
+      CHECK(vec1->select(indices)->equivalent_to(vec2));
+    }
+
+    TEST_CASE("group_indexes_on_subset short-circuit works") {
       auto *input1 = new nullable_varchar_vector(std::vector<std::string> {"A", "B", "C", "D", "E"});
 
       size_t count = 5;

--- a/src/main/resources/io/sparkcyclone/cpp/tests/nullable_varchar_vector_spec.cc
+++ b/src/main/resources/io/sparkcyclone/cpp/tests/nullable_varchar_vector_spec.cc
@@ -384,6 +384,26 @@ namespace cyclone::tests {
       CHECK(vec1->select(indices)->equivalent_to(vec2));
     }
 
+    // TEST_CASE("group_indexes_on_subset works [2]") {
+    //   auto input1 = std::vector<std::string> { "JAN", "JANU", "FEBU", "FEB", "MARCH", "MARCG", "APR", "NOV", "MARCG", "SEPT", "SEPT", "APR", "JANU", "SEP", "OCT", "NOV", "DEC2", "DEC1", "DEC0" };
+    //   auto vec1 = new nullable_varchar_vector(input1);
+    //   vec1->set_validity(3, 0);
+    //   vec1->set_validity(10, 0);
+
+    //   auto input2 = std::vector<std::string> { "APR", "APR", "JAN", "NOV", "SEP", "DEC0", "DEC1", "DEC2", "FEBU", "JANU", "JANU", "MARCG", "MARCH", "OCT", "FEB" };
+    //   auto vec2 = new nullable_varchar_vector(input2);
+    //   vec2->set_validity(13, 0);
+    //   vec2->set_validity(14, 0);
+
+    //   auto groups = vec1->group_indexes();
+    //   std::vector<size_t> indices;
+    //   for (auto group : groups) {
+    //     for (auto i : group) indices.emplace_back(i);
+    //   }
+
+    //   CHECK(vec1->select(indices)->equivalent_to(vec2));
+    // }
+
     TEST_CASE("group_indexes_on_subset short-circuit works") {
       auto *input1 = new nullable_varchar_vector(std::vector<std::string> {"A", "B", "C", "D", "E"});
 

--- a/src/main/scala/io/sparkcyclone/native/transpiler/CppTranspiler.scala
+++ b/src/main/scala/io/sparkcyclone/native/transpiler/CppTranspiler.scala
@@ -196,7 +196,7 @@ object CppTranspiler {
       ).indented,
       s"}",
       debugPrint("separate_to_groups", debug),
-      s"std::vector<std::vector<size_t>> groups = cyclone::separate_to_groups(grouping, grouping_keys);",
+      s"std::vector<std::vector<size_t>> groups = cyclone::grouping::separate_to_groups(grouping, grouping_keys);",
       s"""auto group_count = grouping_keys.size();""",
       s"""*groups_out = ${groupByType.toVeType.cVectorType}::allocate();""",
       s"""groups_out[0]->resize(group_count);""",


### PR DESCRIPTION
Summary:

- Patch the included `nanobench` library be able to compile under `nc++`
- Add more comments to the existing grouping code so that it is easier to understand
- Experiment with an implementation of `multiple_radix_sort_and_group` for grouping string vectors
- Add benchmark code scaffold for grouping strings
- Implement `sort_and_group_multiple()`, which takes a set of multiple contiguous ranges, applies sort + grouping to each subset, and combines the output group delimiters for each subset into a single array
- Re-implement the `sort_and_group_multiple()` function to be much more efficient and use raw C pointers instead of C++ data structures
- Implement a new version of `nullable_varchar_vector::group_indexes_on_subset()` that groups elements without hashing, and uses `sort_and_group_multiple()`
- Fix multiple pointer bugs with this new implementation
- Update string grouping benchmarks to include the new grouping code as candidate
- Swap names for grouping functions
- Add unit tests for string grouping
- Move `separate_to_groups()` to `cyclone::grouping` namespace
- Fix critical bug in string grouping to be able to handle multiple subsets correctly
- Add more unit tests to cover the multiple subsets string grouping use case
- Add better documentation for `nullable_varchar_vector::group_indexes_on_subset()`

Benchmarks:

Here, `vector_group1` represents the original (and functionally incorrect) hash-based string grouping.  `vector_group3` represents the first version of the vectorized string grouping, where C++ data structures are used.  `vector_group2` represents the second version of the vectorized string grouping, where raw C pointers are used.  

Based on the benchmark results, the first implementation of correct vectorized string grouping was slower than the original hash-based implementation, while the second implementation, in addition to being functionally correct, ran faster than the original implementation by roughly 60%:

```
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|      172,437,000.00 |                5.80 |    0.0% |      1.90 | `vector_group 1 (with validity, all valid input)`
|      174,894,000.00 |                5.72 |    0.0% |      1.92 | `vector_group 1 (with validity, some invalid input)`
|      124,518,000.00 |                8.03 |    0.0% |      1.37 | `vector_group 2 (with validity, all valid input)`
|      124,576,000.00 |                8.03 |    0.0% |      1.37 | `vector_group 2 (with validity, some invalid input)`
|      211,624,000.00 |                4.73 |    0.6% |      2.34 | `vector_group 3 (with validity, all valid input)`
|      211,080,000.00 |                4.74 |    0.1% |      2.32 | `vector_group 3 (with validity, some invalid input)`
===============================================================================
benchmarks/cyclone_string_grouping_benchmark.cc:74:
TEST CASE:  String Group-by Implementation Benchmarks
```

Remaining Work:

Thorough unit tests have been added to ensure that vectorized string grouping is functionally correct.  The work to integrate this with Spark Cyclone's code generation will be in https://github.com/XpressAI/SparkCyclone/pull/592.